### PR TITLE
[SWIFT-160] Add support for separate consensus and fog auth creds

### DIFF
--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -27,20 +27,7 @@ public final class MobileCoinClient {
     private let callbackQueue: DispatchQueue
 
     init(accountKey: AccountKeyWithFog, config: Config) {
-        let networkConfig: NetworkConfig = {
-            var networkConfig: NetworkConfig
-            if let attestationConfig = config.attestationConfig {
-                networkConfig = NetworkConfig(
-                    consensusUrl: config.consensusUrl,
-                    fogUrl: config.fogUrl,
-                    attestation: attestationConfig)
-            } else {
-            	networkConfig = NetworkConfig(consensusUrl: config.consensusUrl, fogUrl: config.fogUrl)
-            }
-            networkConfig.consensusTrustRoots = config.consensusTrustRoots
-            networkConfig.fogTrustRoots = config.fogTrustRoots
-            return networkConfig
-        }()
+        let networkConfig = NetworkConfig(mobileCoinClientConfig: config)
 
         logger.info("""
             Initializing \(Self.self):
@@ -386,5 +373,21 @@ extension MobileCoinClient {
             }
             return .success(())
         }
+    }
+}
+
+extension NetworkConfig {
+    fileprivate init(mobileCoinClientConfig config: MobileCoinClient.Config) {
+        if let attestationConfig = config.attestationConfig {
+            self.init(
+                consensusUrl: config.consensusUrl,
+                fogUrl: config.fogUrl,
+                attestation: attestationConfig)
+        } else {
+            self.init(consensusUrl: config.consensusUrl, fogUrl: config.fogUrl)
+        }
+
+        self.consensusTrustRoots = config.consensusTrustRoots
+        self.fogTrustRoots = config.fogTrustRoots
     }
 }

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -78,10 +78,16 @@ public final class MobileCoinClient {
         accountLock.readSync { $0.cachedAccountActivity }
     }
 
-    public func setBasicAuthorization(username: String, password: String) {
+    public func setConsensusBasicAuthorization(username: String, password: String) {
         logger.info("username: \(redacting: username), password: \(redacting: password)")
         let credentials = BasicCredentials(username: username, password: password)
-        inner.accessAsync { $0.serviceProvider.setAuthorization(credentials: credentials) }
+        inner.accessAsync { $0.serviceProvider.setConsensusAuthorization(credentials: credentials) }
+    }
+
+    public func setFogBasicAuthorization(username: String, password: String) {
+        logger.info("username: \(redacting: username), password: \(redacting: password)")
+        let credentials = BasicCredentials(username: username, password: password)
+        inner.accessAsync { $0.serviceProvider.setFogAuthorization(credentials: credentials) }
     }
 
     public func updateBalance(completion: @escaping (Result<Balance, ConnectionError>) -> Void) {

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -43,7 +43,7 @@ public final class MobileCoinClient {
         }()
 
         logger.info("""
-            Initializing MobileCoinClient:
+            Initializing \(Self.self):
             \(Self.configDescription(
                 accountKey: accountKey,
                 config: config,

--- a/Sources/Network/AttestedConnectionConfig.swift
+++ b/Sources/Network/AttestedConnectionConfig.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import NIOSSL
+
+protocol AttestedConnectionConfigProtocol: ConnectionConfigProtocol {
+    var url: MobileCoinUrlProtocol { get }
+    var attestation: Attestation { get }
+    var trustRoots: [NIOSSLCertificate]? { get }
+    var authorization: BasicCredentials? { get }
+}
+
+struct AttestedConnectionConfig<Url: MobileCoinUrlProtocol>: AttestedConnectionConfigProtocol {
+    let urlTyped: Url
+    let attestation: Attestation
+    let trustRoots: [NIOSSLCertificate]?
+    let authorization: BasicCredentials?
+
+    init(
+        url: Url,
+        attestation: Attestation,
+        trustRoots: [NIOSSLCertificate]?,
+        authorization: BasicCredentials?
+    ) {
+        self.urlTyped = url
+        self.attestation = attestation
+        self.trustRoots = trustRoots
+        self.authorization = authorization
+    }
+
+    var url: MobileCoinUrlProtocol { urlTyped }
+}

--- a/Sources/Network/Connection/AttestedConnection.swift
+++ b/Sources/Network/Connection/AttestedConnection.swift
@@ -31,19 +31,13 @@ class AttestedConnection {
 
     init(
         client: AttestableGrpcClient,
-        url: MobileCoinUrlProtocol,
-        attestation: Attestation,
+        config: AttestedConnectionConfigProtocol,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
     ) {
         logger.info("")
-        let inner = Inner(
-            client: client,
-            url: url,
-            attestation: attestation,
-            rng: rng,
-            rngContext: rngContext)
+        let inner = Inner(client: client, config: config, rng: rng, rngContext: rngContext)
         self.inner = .init(inner, targetQueue: targetQueue)
     }
 
@@ -129,17 +123,16 @@ extension AttestedConnection {
 
         init(
             client: AttestableGrpcClient,
-            url: MobileCoinUrlProtocol,
-            attestation: Attestation,
+            config: AttestedConnectionConfigProtocol,
             rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
             rngContext: Any? = nil
         ) {
             logger.info("")
-            self.session = ConnectionSession(url: url)
+            self.session = ConnectionSession(config: config)
             self.client = client
             self.attestAke = AttestAke()
-            self.responderId = url.responderId
-            self.attestationVerifier = AttestationVerifier(attestation: attestation)
+            self.responderId = config.url.responderId
+            self.attestationVerifier = AttestationVerifier(attestation: config.attestation)
             self.rng = rng
             self.rngContext = rngContext
         }

--- a/Sources/Network/Connection/Connection.swift
+++ b/Sources/Network/Connection/Connection.swift
@@ -9,13 +9,13 @@ class Connection {
     private let inner: SerialDispatchLock<Inner>
 
     init(url: MobileCoinUrlProtocol, targetQueue: DispatchQueue?) {
-        let inner = Inner(session: ConnectionSession(url: url))
+        let inner = Inner(url: url)
         self.inner = .init(inner, targetQueue: targetQueue)
     }
 
     func setAuthorization(credentials: BasicCredentials) {
         inner.accessAsync {
-            $0.session.authorizationCredentials = credentials
+            $0.setAuthorization(credentials: credentials)
         }
     }
 
@@ -38,7 +38,17 @@ class Connection {
 
 extension Connection {
     private struct Inner {
-        let session: ConnectionSession
+        private let session: ConnectionSession
+
+        init(url: MobileCoinUrlProtocol) {
+            logger.info("")
+            self.session = ConnectionSession(url: url)
+        }
+
+        func setAuthorization(credentials: BasicCredentials) {
+            logger.info("")
+            session.authorizationCredentials = credentials
+        }
 
         func requestCallOptions() -> CallOptions {
             var callOptions = CallOptions()

--- a/Sources/Network/Connection/ConnectionSession.swift
+++ b/Sources/Network/Connection/ConnectionSession.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIOHPACK
 import NIOHTTP1
 
-class ConnectionSession {
+final class ConnectionSession {
     private static var ephemeralCookieStorage: HTTPCookieStorage {
         guard let cookieStorage = URLSessionConfiguration.ephemeral.httpCookieStorage else {
             // Safety: URLSessionConfiguration.ephemeral.httpCookieStorage will always return
@@ -21,9 +21,14 @@ class ConnectionSession {
     private let cookieStorage: HTTPCookieStorage
     var authorizationCredentials: BasicCredentials?
 
-    init(url: MobileCoinUrlProtocol) {
+    convenience init(config: ConnectionConfigProtocol) {
+        self.init(url: config.url, authorization: config.authorization)
+    }
+
+    init(url: MobileCoinUrlProtocol, authorization: BasicCredentials? = nil) {
         self.url = url.httpBasedUrl
         self.cookieStorage = Self.ephemeralCookieStorage
+        self.authorizationCredentials = authorization
     }
 
     func addRequestHeaders(to hpackHeaders: inout HPACKHeaders) {

--- a/Sources/Network/Connection/Connections/ConsensusConnection.swift
+++ b/Sources/Network/Connection/Connections/ConsensusConnection.swift
@@ -11,20 +11,17 @@ final class ConsensusConnection: AttestedConnection, ConsensusService {
     private let client: ConsensusClient_ConsensusClientAPIClient
 
     init(
-        url: ConsensusUrl,
-        attestation: Attestation,
-        trustRoots: [NIOSSLCertificate]?,
+        config: AttestedConnectionConfig<ConsensusUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = ConsensusClient_ConsensusClientAPIClient(channel: channel)
         super.init(
             client: Attest_AttestedApiClient(channel: channel),
-            url: url,
-            attestation: attestation,
+            config: config,
             targetQueue: targetQueue,
             rng: rng,
             rngContext: rngContext)

--- a/Sources/Network/Connection/Connections/FogBlockConnection.swift
+++ b/Sources/Network/Connection/Connections/FogBlockConnection.swift
@@ -11,14 +11,13 @@ final class FogBlockConnection: Connection, FogBlockService {
     private let client: FogLedger_FogBlockAPIClient
 
     init(
-        url: FogUrl,
-        trustRoots: [NIOSSLCertificate]?,
+        config: ConnectionConfig<FogUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = FogLedger_FogBlockAPIClient(channel: channel)
-        super.init(url: url, targetQueue: targetQueue)
+        super.init(config: config, targetQueue: targetQueue)
     }
 
     func getBlocks(

--- a/Sources/Network/Connection/Connections/FogKeyImageConnection.swift
+++ b/Sources/Network/Connection/Connections/FogKeyImageConnection.swift
@@ -11,20 +11,17 @@ final class FogKeyImageConnection: AttestedConnection, FogKeyImageService {
     private let client: FogLedger_FogKeyImageAPIClient
 
     init(
-        url: FogUrl,
-        attestation: Attestation,
-        trustRoots: [NIOSSLCertificate]?,
+        config: AttestedConnectionConfig<FogUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = FogLedger_FogKeyImageAPIClient(channel: channel)
         super.init(
             client: self.client,
-            url: url,
-            attestation: attestation,
+            config: config,
             targetQueue: targetQueue,
             rng: rng,
             rngContext: rngContext)

--- a/Sources/Network/Connection/Connections/FogMerkleProofConnection.swift
+++ b/Sources/Network/Connection/Connections/FogMerkleProofConnection.swift
@@ -11,20 +11,17 @@ final class FogMerkleProofConnection: AttestedConnection, FogMerkleProofService 
     private let client: FogLedger_FogMerkleProofAPIClient
 
     init(
-        url: FogUrl,
-        attestation: Attestation,
-        trustRoots: [NIOSSLCertificate]?,
+        config: AttestedConnectionConfig<FogUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = FogLedger_FogMerkleProofAPIClient(channel: channel)
         super.init(
             client: self.client,
-            url: url,
-            attestation: attestation,
+            config: config,
             targetQueue: targetQueue,
             rng: rng,
             rngContext: rngContext)

--- a/Sources/Network/Connection/Connections/FogReportConnection.swift
+++ b/Sources/Network/Connection/Connections/FogReportConnection.swift
@@ -6,14 +6,10 @@ import Foundation
 import GRPC
 import LibMobileCoin
 
-final class FogReportConnection: Connection, FogReportService {
+final class FogReportConnection: ArbitraryConnection, FogReportService {
     private let client: Report_ReportAPIClient
 
-    init(
-        url: FogUrl,
-        channelManager: GrpcChannelManager,
-        targetQueue: DispatchQueue?
-    ) {
+    init(url: FogUrl, channelManager: GrpcChannelManager, targetQueue: DispatchQueue?) {
         let channel = channelManager.channel(for: url)
         self.client = Report_ReportAPIClient(channel: channel)
         super.init(url: url, targetQueue: targetQueue)

--- a/Sources/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
+++ b/Sources/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
@@ -11,14 +11,13 @@ final class FogUntrustedTxOutConnection: Connection, FogUntrustedTxOutService {
     private let client: FogLedger_FogUntrustedTxOutApiClient
 
     init(
-        url: FogUrl,
-        trustRoots: [NIOSSLCertificate]?,
+        config: ConnectionConfig<FogUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = FogLedger_FogUntrustedTxOutApiClient(channel: channel)
-        super.init(url: url, targetQueue: targetQueue)
+        super.init(config: config, targetQueue: targetQueue)
     }
 
     func getTxOuts(

--- a/Sources/Network/Connection/Connections/FogViewConnection.swift
+++ b/Sources/Network/Connection/Connections/FogViewConnection.swift
@@ -11,20 +11,17 @@ final class FogViewConnection: AttestedConnection, FogViewService {
     private let client: FogView_FogViewAPIClient
 
     init(
-        url: FogUrl,
-        attestation: Attestation,
-        trustRoots: [NIOSSLCertificate]?,
+        config: AttestedConnectionConfig<FogUrl>,
         channelManager: GrpcChannelManager,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
     ) {
-        let channel = channelManager.channel(for: url, trustRoots: trustRoots)
+        let channel = channelManager.channel(for: config)
         self.client = FogView_FogViewAPIClient(channel: channel)
         super.init(
             client: self.client,
-            url: url,
-            attestation: attestation,
+            config: config,
             targetQueue: targetQueue,
             rng: rng,
             rngContext: rngContext)

--- a/Sources/Network/ConnectionConfig.swift
+++ b/Sources/Network/ConnectionConfig.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import NIOSSL
+
+protocol ConnectionConfigProtocol {
+    var url: MobileCoinUrlProtocol { get }
+    var trustRoots: [NIOSSLCertificate]? { get }
+    var authorization: BasicCredentials? { get }
+}
+
+struct ConnectionConfig<Url: MobileCoinUrlProtocol>: ConnectionConfigProtocol {
+    let urlTyped: Url
+    let trustRoots: [NIOSSLCertificate]?
+    let authorization: BasicCredentials?
+
+    init(url: Url, trustRoots: [NIOSSLCertificate]?, authorization: BasicCredentials?) {
+        self.urlTyped = url
+        self.trustRoots = trustRoots
+        self.authorization = authorization
+    }
+
+    var url: MobileCoinUrlProtocol { urlTyped }
+}

--- a/Sources/Network/GRPC/GrpcChannelManager.swift
+++ b/Sources/Network/GRPC/GrpcChannelManager.swift
@@ -11,6 +11,10 @@ final class GrpcChannelManager {
     private let eventLoopGroup = PlatformSupport.makeEventLoopGroup(loopCount: 1)
     private var addressToChannel: [GrpcChannelConfig: GRPCChannel] = [:]
 
+    func channel(for config: ConnectionConfigProtocol) -> GRPCChannel {
+        channel(for: config.url, trustRoots: config.trustRoots)
+    }
+
     func channel(for url: MobileCoinUrlProtocol, trustRoots: [NIOSSLCertificate]? = nil)
         -> GRPCChannel
     {

--- a/Sources/Network/Service/DefaultServiceProvider.swift
+++ b/Sources/Network/Service/DefaultServiceProvider.swift
@@ -75,8 +75,11 @@ final class DefaultServiceProvider: ServiceProvider {
         return reportConnection
     }
 
-    func setAuthorization(credentials: BasicCredentials) {
+    func setConsensusAuthorization(credentials: BasicCredentials) {
         consensus.setAuthorization(credentials: credentials)
+    }
+
+    func setFogAuthorization(credentials: BasicCredentials) {
         view.setAuthorization(credentials: credentials)
         merkleProof.setAuthorization(credentials: credentials)
         keyImage.setAuthorization(credentials: credentials)

--- a/Sources/Network/Service/DefaultServiceProvider.swift
+++ b/Sources/Network/Service/DefaultServiceProvider.swift
@@ -20,37 +20,27 @@ final class DefaultServiceProvider: ServiceProvider {
     init(networkConfig: NetworkConfig, targetQueue: DispatchQueue?) {
         self.targetQueue = targetQueue
         self.consensus = ConsensusConnection(
-            url: networkConfig.consensusUrl,
-            attestation: networkConfig.consensusAttestation,
-            trustRoots: networkConfig.consensusTrustRoots,
+            config: networkConfig.consensus,
             channelManager: channelManager,
             targetQueue: targetQueue)
         self.view = FogViewConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogViewAttestation,
-            trustRoots: networkConfig.fogTrustRoots,
+            config: networkConfig.fogView,
             channelManager: channelManager,
             targetQueue: targetQueue)
         self.merkleProof = FogMerkleProofConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogMerkleProofAttestation,
-            trustRoots: networkConfig.fogTrustRoots,
+            config: networkConfig.fogMerkleProof,
             channelManager: channelManager,
             targetQueue: targetQueue)
         self.keyImage = FogKeyImageConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogKeyImageAttestation,
-            trustRoots: networkConfig.fogTrustRoots,
+            config: networkConfig.fogKeyImage,
             channelManager: channelManager,
             targetQueue: targetQueue)
         self.block = FogBlockConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: networkConfig.fogTrustRoots,
+            config: networkConfig.fogBlock,
             channelManager: channelManager,
             targetQueue: targetQueue)
         self.untrustedTxOut = FogUntrustedTxOutConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: networkConfig.fogTrustRoots,
+            config: networkConfig.fogUntrustedTxOut,
             channelManager: channelManager,
             targetQueue: targetQueue)
     }

--- a/Sources/Network/Service/ServiceProvider.swift
+++ b/Sources/Network/Service/ServiceProvider.swift
@@ -15,5 +15,6 @@ protocol ServiceProvider {
 
     func fogReportService(for fogReportUrl: FogUrl) -> FogReportService
 
-    func setAuthorization(credentials: BasicCredentials)
+    func setConsensusAuthorization(credentials: BasicCredentials)
+    func setFogAuthorization(credentials: BasicCredentials)
 }

--- a/Sources/Utils/InfiniteIterator/AnyInfiniteIterator.swift
+++ b/Sources/Utils/InfiniteIterator/AnyInfiniteIterator.swift
@@ -2,8 +2,6 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
-// swiftlint:disable colon
-
 import Foundation
 
 struct AnyInfiniteIterator<Element> {
@@ -31,8 +29,8 @@ private class AnyInfiniteIteratorBoxBase<Element>: InfiniteIteratorProtocol {
     }
 }
 
-private final class InfiniteIteratorBox<Base: InfiniteIteratorProtocol>:
-    AnyInfiniteIteratorBoxBase<Base.Element>
+private final class InfiniteIteratorBox<Base>: AnyInfiniteIteratorBoxBase<Base.Element>
+    where Base: InfiniteIteratorProtocol
 {
     init(_ base: Base) { self._base = base }
 

--- a/Tests/Common/Fixtures/MobileCoinClient+Fixtures.swift
+++ b/Tests/Common/Fixtures/MobileCoinClient+Fixtures.swift
@@ -8,31 +8,12 @@ import Foundation
 @testable import MobileCoin
 import NIOSSL
 
-extension MobileCoinClient {
-    enum Fixtures {}
-}
-
-extension MobileCoinClient.Fixtures {
-    struct Init {
-        let accountKey: AccountKey
-
-        let consensusUrl = "mc://node1.fake.mobilecoin.com"
-        let fogUrl = "fog://fog.fake.mobilecoin.com"
-
-        init(accountIndex: UInt8 = 0) throws {
-            self.accountKey = try AccountKey.Fixtures.Default(accountIndex: accountIndex).accountKey
-        }
-    }
-}
-
 extension MobileCoinClient.Config {
     enum Fixtures {}
 }
 
 extension MobileCoinClient.Config.Fixtures {
-    struct Default {
-        let config: MobileCoinClient.Config
-
+    struct Init {
         let consensusUrl = "mc://node1.fake.mobilecoin.com"
         let fogUrl = "fog://fog.fake.mobilecoin.com"
 
@@ -41,15 +22,51 @@ extension MobileCoinClient.Config.Fixtures {
         let wrongTrustRootBytes: Data
         let invalidTrustRootBytes: Data
 
-        init() throws {
-            self.config = try MobileCoinClient.Config.make(
-                consensusUrl: self.consensusUrl,
-                fogUrl: self.fogUrl).get()
+        let consensusAttestation = Attestation()
+        let fogViewAttestation = Attestation()
+        let fogMerkleProofAttestation = Attestation()
+        let fogKeyImageAttestation = Attestation()
+        let fogReportAttestation = Attestation()
 
+        init() throws {
             let trustRootsFixture = try NetworkConfig.Fixtures.TrustRoots()
             self.trustRootBytes = trustRootsFixture.trustRootBytes
             self.wrongTrustRootBytes = trustRootsFixture.wrongTrustRootBytes
             self.invalidTrustRootBytes = trustRootsFixture.invalidTrustRootBytes
+        }
+    }
+}
+
+extension MobileCoinClient.Config.Fixtures {
+    struct Default {
+        let config: MobileCoinClient.Config
+
+        init() throws {
+            let initFixture = try Init()
+            self.config = try MobileCoinClient.Config.make(
+                consensusUrl: initFixture.consensusUrl,
+                consensusAttestation: initFixture.consensusAttestation,
+                fogUrl: initFixture.fogUrl,
+                fogViewAttestation: initFixture.fogViewAttestation,
+                fogKeyImageAttestation: initFixture.fogKeyImageAttestation,
+                fogMerkleProofAttestation: initFixture.fogMerkleProofAttestation,
+                fogReportAttestation: initFixture.fogReportAttestation).get()
+        }
+    }
+}
+
+extension MobileCoinClient {
+    enum Fixtures {}
+}
+
+extension MobileCoinClient.Fixtures {
+    struct Init {
+        let accountKey: AccountKey
+        let config: MobileCoinClient.Config
+
+        init(accountIndex: UInt8 = 0) throws {
+            self.accountKey = try AccountKey.Fixtures.Default(accountIndex: accountIndex).accountKey
+            self.config = try MobileCoinClient.Config.Fixtures.Default().config
         }
     }
 }

--- a/Tests/Common/Fixtures/Network/MobileCoinNetwork.swift
+++ b/Tests/Common/Fixtures/Network/MobileCoinNetwork.swift
@@ -63,14 +63,20 @@ extension MobileCoinNetwork {
     func consensusTrustRoots() throws -> [NIOSSLCertificate] { try trustRoots() }
     func fogTrustRoots() throws -> [NIOSSLCertificate] { try trustRoots() }
 
-    var username: String { Self.devAuthUsername }
-    var password: String { Self.devAuthPassword }
-    var credentials: BasicCredentials { BasicCredentials(username: username, password: password) }
+    private var consensusUsername: String { Self.devAuthUsername }
+    private var consensusPassword: String { Self.devAuthPassword }
+    var consensusCredentials: BasicCredentials
+        { BasicCredentials(username: consensusUsername, password: consensusPassword) }
 
-    var wrongPassword: String { "user1:1602033437:ffffffffffffffffffff" }
-    var invalidCredentials: BasicCredentials {
-        BasicCredentials(username: username, password: wrongPassword)
-    }
+    private var fogUsername: String { Self.devAuthUsername }
+    private var fogPassword: String { Self.devAuthPassword }
+    var fogCredentials: BasicCredentials
+        { BasicCredentials(username: fogUsername, password: fogPassword) }
+
+    private var invalidCredUsername: String { "user1" }
+    private var invalidCredPassword: String { "user1:1602033437:ffffffffffffffffffff" }
+    var invalidCredentials: BasicCredentials
+        { BasicCredentials(username: invalidCredUsername, password: invalidCredPassword) }
 
     var rootEntropies: [Data32] { isTestNet ? Self.testNetRootEntropies : Self.devRootEntropies }
 }
@@ -79,13 +85,9 @@ extension MobileCoinNetwork {
 
 #if canImport(Keys)
     static let devAuthUsername = MobileCoinKeys().mobilecoinDevAuthUsername
-#else
-    static let devAuthUsername = ""
-#endif
-
-#if canImport(Keys)
     static let devAuthPassword = MobileCoinKeys().mobilecoinDevAuthPassword
 #else
+    static let devAuthUsername = ""
     static let devAuthPassword = ""
 #endif
 

--- a/Tests/Integration/IntegrationTestFixtures.swift
+++ b/Tests/Integration/IntegrationTestFixtures.swift
@@ -34,10 +34,8 @@ extension IntegrationTestFixtures {
     static func fogTrustRoots() throws -> [NIOSSLCertificate]
     { try mobileCoinNetwork.fogTrustRoots() }
 
-    static let username = mobileCoinNetwork.username
-    static let password = mobileCoinNetwork.password
-    static let wrongPassword = mobileCoinNetwork.wrongPassword
-    static let credentials = mobileCoinNetwork.credentials
+    static let consensusCredentials = mobileCoinNetwork.consensusCredentials
+    static let fogCredentials = mobileCoinNetwork.fogCredentials
     static let invalidCredentials = mobileCoinNetwork.invalidCredentials
 
     static let fee = McConstants.MINIMUM_FEE
@@ -101,7 +99,12 @@ extension IntegrationTestFixtures {
         config: MobileCoinClient.Config
     ) throws -> MobileCoinClient {
         let client = try MobileCoinClient.make(accountKey: accountKey, config: config).get()
-        client.setBasicAuthorization(username: username, password: password)
+        client.setConsensusBasicAuthorization(
+            username: consensusCredentials.username,
+            password: consensusCredentials.password)
+        client.setFogBasicAuthorization(
+            username: fogCredentials.username,
+            password: fogCredentials.password)
         return client
     }
 
@@ -138,7 +141,8 @@ extension IntegrationTestFixtures {
         let networkConfig = try createNetworkConfig()
         let serviceProvider =
             DefaultServiceProvider(networkConfig: networkConfig, targetQueue: DispatchQueue.main)
-        serviceProvider.setAuthorization(credentials: credentials)
+        serviceProvider.setConsensusAuthorization(credentials: consensusCredentials)
+        serviceProvider.setFogAuthorization(credentials: fogCredentials)
         return serviceProvider
     }
 

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -351,7 +351,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         var config = try IntegrationTestFixtures.createMobileCoinClientConfig()
         XCTAssertSuccess(config.setConsensusTrustRoots([
             try IntegrationTestFixtures.trustRootsBytes(),
-            try MobileCoinClient.Config.Fixtures.Default().wrongTrustRootBytes,
+            try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes,
         ]))
         let client =
             try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1, config: config)
@@ -391,9 +391,10 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 
         var config = try IntegrationTestFixtures.createMobileCoinClientConfig()
         XCTAssertSuccess(config.setConsensusTrustRoots([
-            try MobileCoinClient.Config.Fixtures.Default().wrongTrustRootBytes,
+            try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes,
         ]))
-        let client = try IntegrationTestFixtures.createMobileCoinClient(config: config)
+        let client =
+            try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, config: config)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let expect = expectation(description: "Submitting transaction")

--- a/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
@@ -173,7 +173,7 @@ extension ConsensusConnectionIntTests {
             trustRoots: trustRoots,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.consensusCredentials)
         return connection
     }
 }

--- a/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
@@ -153,27 +153,19 @@ extension ConsensusConnectionIntTests {
         return try createConsensusConnection(trustRoots: trustRoots)
     }
 
-    func createConsensusConnectionWithInvalidCredentials() throws -> ConsensusConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = ConsensusConnection(
-            url: networkConfig.consensusUrl,
-            attestation: networkConfig.consensusAttestation,
-            trustRoots: try IntegrationTestFixtures.consensusTrustRoots(),
+    func createConsensusConnection(trustRoots: [NIOSSLCertificate]) throws -> ConsensusConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(trustRoots: trustRoots)
+        return ConsensusConnection(
+            config: networkConfig.consensus,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 
-    func createConsensusConnection(trustRoots: [NIOSSLCertificate]) throws -> ConsensusConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = ConsensusConnection(
-            url: networkConfig.consensusUrl,
-            attestation: networkConfig.consensusAttestation,
-            trustRoots: trustRoots,
+    func createConsensusConnectionWithInvalidCredentials() throws -> ConsensusConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        return ConsensusConnection(
+            config: networkConfig.consensus,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.consensusCredentials)
-        return connection
     }
 }

--- a/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
@@ -149,7 +149,7 @@ extension FogBlockConnectionIntTests {
             trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
         return connection
     }
 

--- a/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
@@ -144,23 +144,17 @@ class FogBlockConnectionIntTests: XCTestCase {
 extension FogBlockConnectionIntTests {
     func createFogBlockConnection() throws -> FogBlockConnection {
         let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogBlockConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogBlockConnection(
+            config: networkConfig.fogBlock,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
-        return connection
     }
 
     func createFogBlockConnectionWithInvalidCredentials() throws -> FogBlockConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogBlockConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        return FogBlockConnection(
+            config: networkConfig.fogBlock,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 }

--- a/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -115,7 +115,7 @@ extension FogKeyImageConnectionIntTests {
             trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
         return connection
     }
 

--- a/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -109,25 +109,17 @@ class FogKeyImageConnectionIntTests: XCTestCase {
 extension FogKeyImageConnectionIntTests {
     func createFogKeyImageConnection() throws -> FogKeyImageConnection {
         let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogKeyImageConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogKeyImageAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogKeyImageConnection(
+            config: networkConfig.fogKeyImage,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
-        return connection
     }
 
     func createFogKeyImageConnectionWithInvalidCredentials() throws -> FogKeyImageConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogKeyImageConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogKeyImageAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        return FogKeyImageConnection(
+            config: networkConfig.fogKeyImage,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 }

--- a/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
@@ -148,25 +148,17 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
 extension FogMerkleProofConnectionIntTests {
     func createFogMerkleProofConnection() throws -> FogMerkleProofConnection {
         let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogMerkleProofConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogMerkleProofAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogMerkleProofConnection(
+            config: networkConfig.fogMerkleProof,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
-        return connection
     }
 
     func createFogMerkleProofConnectionWithInvalidCredentials() throws -> FogMerkleProofConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogMerkleProofConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogMerkleProofAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        return FogMerkleProofConnection(
+            config: networkConfig.fogMerkleProof,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 }

--- a/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
@@ -154,7 +154,7 @@ extension FogMerkleProofConnectionIntTests {
             trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
         return connection
     }
 

--- a/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
@@ -46,25 +46,19 @@ class FogUntrustedTxOutConnectionIntTests: XCTestCase {
 extension FogUntrustedTxOutConnectionIntTests {
     func createFogUntrustedTxOutConnection() throws -> FogUntrustedTxOutConnection {
         let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogUntrustedTxOutConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogUntrustedTxOutConnection(
+            config: networkConfig.fogUntrustedTxOut,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
-        return connection
     }
 
     func createFogUntrustedTxOutConnectionWithInvalidCredentials() throws
         -> FogUntrustedTxOutConnection
     {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
-        let connection = FogUntrustedTxOutConnection(
-            url: networkConfig.fogUrl,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        return FogUntrustedTxOutConnection(
+            config: networkConfig.fogUntrustedTxOut,
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 }

--- a/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
@@ -51,7 +51,7 @@ extension FogUntrustedTxOutConnectionIntTests {
             trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
             channelManager: GrpcChannelManager(),
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
         return connection
     }
 

--- a/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
@@ -245,7 +245,7 @@ extension FogViewConnectionIntTests {
             trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
             channelManager: channelManager,
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.credentials)
+        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
         return connection
     }
 

--- a/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
@@ -239,26 +239,18 @@ extension FogViewConnectionIntTests {
     func createFogViewConnection() throws -> FogViewConnection {
         let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
         let channelManager = GrpcChannelManager()
-        let connection = FogViewConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogViewAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogViewConnection(
+            config: networkConfig.fogView,
             channelManager: channelManager,
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.fogCredentials)
-        return connection
     }
 
     func createFogViewConnectionWithInvalidCredentials() throws -> FogViewConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
         let channelManager = GrpcChannelManager()
-        let connection = FogViewConnection(
-            url: networkConfig.fogUrl,
-            attestation: networkConfig.fogViewAttestation,
-            trustRoots: try IntegrationTestFixtures.fogTrustRoots(),
+        return FogViewConnection(
+            config: networkConfig.fogView,
             channelManager: channelManager,
             targetQueue: DispatchQueue.main)
-        connection.setAuthorization(credentials: IntegrationTestFixtures.invalidCredentials)
-        return connection
     }
 }

--- a/Tests/Unit/MobileCoinClientPublicApiTests.swift
+++ b/Tests/Unit/MobileCoinClientPublicApiTests.swift
@@ -2,60 +2,79 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
-// swiftlint:disable multiline_function_chains
-
 import MobileCoin
 import XCTest
 
 class MobileCoinClientPublicApiTests: XCTestCase {
 
-    func testMake() throws {
-        let fixture = try MobileCoinClient.Fixtures.Init()
-        let config = try MobileCoinClient.Config.make(
+    func testMakeConfig() throws {
+        let fixture = try MobileCoinClient.Config.Fixtures.Init()
+        XCTAssertSuccess(MobileCoinClient.Config.make(
             consensusUrl: fixture.consensusUrl,
-            fogUrl: fixture.fogUrl).get()
-        _ = MobileCoinClient.make(accountKey: fixture.accountKey, config: config)
+            consensusAttestation: fixture.consensusAttestation,
+            fogUrl: fixture.fogUrl,
+            fogViewAttestation: fixture.fogViewAttestation,
+            fogKeyImageAttestation: fixture.fogKeyImageAttestation,
+            fogMerkleProofAttestation: fixture.fogMerkleProofAttestation,
+            fogReportAttestation: fixture.fogReportAttestation))
     }
 
     func testWrongConsensusUrlSchemeFails() throws {
-        let fixture = try MobileCoinClient.Fixtures.Init()
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: "https://node1.fake.mobilecoin.com",
-            fogUrl: fixture.fogUrl).get())
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: "mob://node1.fake.mobilecoin.com",
-            fogUrl: fixture.fogUrl).get())
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: "fog://node1.fake.mobilecoin.com",
-            fogUrl: fixture.fogUrl).get())
+        let fixture = try MobileCoinClient.Config.Fixtures.Init()
+        let wrongConsensusSchemeUrls = [
+            "https://node1.fake.mobilecoin.com",
+            "mob://node1.fake.mobilecoin.com",
+            "fog://node1.fake.mobilecoin.com",
+        ]
+        for wrongConsensusSchemeUrl in wrongConsensusSchemeUrls {
+            XCTAssertFailure(MobileCoinClient.Config.make(
+                consensusUrl: wrongConsensusSchemeUrl,
+                consensusAttestation: fixture.consensusAttestation,
+                fogUrl: fixture.fogUrl,
+                fogViewAttestation: fixture.fogViewAttestation,
+                fogKeyImageAttestation: fixture.fogKeyImageAttestation,
+                fogMerkleProofAttestation: fixture.fogMerkleProofAttestation,
+                fogReportAttestation: fixture.fogReportAttestation))
+        }
     }
 
     func testWrongFogUrlSchemeFails() throws {
-        let fixture = try MobileCoinClient.Fixtures.Init()
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: fixture.consensusUrl,
-            fogUrl: "https://fog.fake.mobilecoin.com").get())
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: fixture.consensusUrl,
-            fogUrl: "mc://fog.fake.mobilecoin.com").get())
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: fixture.consensusUrl,
-            fogUrl: "mob://fog.fake.mobilecoin.com").get())
-        XCTAssertThrowsError(try MobileCoinClient.Config.make(
-            consensusUrl: fixture.consensusUrl,
-            fogUrl: "fog-view://fog.fake.mobilecoin.com").get())
+        let fixture = try MobileCoinClient.Config.Fixtures.Init()
+        let wrongFogSchemeUrls = [
+            "https://fog.fake.mobilecoin.com",
+            "mc://fog.fake.mobilecoin.com",
+            "mob://fog.fake.mobilecoin.com",
+            "fog-view://fog.fake.mobilecoin.com",
+        ]
+        for wrongFogSchemeUrl in wrongFogSchemeUrls {
+            XCTAssertFailure(MobileCoinClient.Config.make(
+                consensusUrl: fixture.consensusUrl,
+                consensusAttestation: fixture.consensusAttestation,
+                fogUrl: wrongFogSchemeUrl,
+                fogViewAttestation: fixture.fogViewAttestation,
+                fogKeyImageAttestation: fixture.fogKeyImageAttestation,
+                fogMerkleProofAttestation: fixture.fogMerkleProofAttestation,
+                fogReportAttestation: fixture.fogReportAttestation))
+        }
     }
 
     func testInvalidConsensusTrustRootFails() throws {
+        let initFixture = try MobileCoinClient.Config.Fixtures.Init()
         let fixture = try MobileCoinClient.Config.Fixtures.Default()
         var config = fixture.config
-        XCTAssertFailure(config.setConsensusTrustRoots([fixture.invalidTrustRootBytes]))
+        XCTAssertFailure(config.setConsensusTrustRoots([initFixture.invalidTrustRootBytes]))
     }
 
     func testInvalidFogTrustRootFails() throws {
+        let initFixture = try MobileCoinClient.Config.Fixtures.Init()
         let fixture = try MobileCoinClient.Config.Fixtures.Default()
         var config = fixture.config
-        XCTAssertFailure(config.setFogTrustRoots([fixture.invalidTrustRootBytes]))
+        XCTAssertFailure(config.setFogTrustRoots([initFixture.invalidTrustRootBytes]))
+    }
+
+    func testMake() throws {
+        let fixture = try MobileCoinClient.Fixtures.Init()
+        _ = MobileCoinClient.make(accountKey: fixture.accountKey, config: fixture.config)
     }
 
 }


### PR DESCRIPTION
This PR:
* Splits out `setBasicAuthorization` into `setConsensusBasicAuthorization` and `setFogBasicAuthorization`.
* Adds `setConsensusBasicAuthorization` and `setFogBasicAuthorization` convenience setters on `MobileCoinClient.Config`, to compliment the ones already on `MobileCoinClient` (This allows better encapsulation of data since authorization credentials are considered part of the configuration.) The setters on `MobileCoinClient` are kept so that the auth credentials may be changed while the `MobileCoinClient` is in active use.
* Removes `MobileCoinClient.Config.make(consensusUrl:fogUrl:)`, so that the `MobileCoinClient.Config.make` that should be used is the one with `Attestation` parameters. The attestation parameters may be specified using `Attestation()` if no MrEnclave or MrSigner verification is desired. However, by making the parameters explicit, it helps make it more clear that some attestation is being performed, even if it's just basic ias report validation.