### PR TITLE
[SWIFT-161] Track last received user event when querying Fog View

### DIFF
--- a/Sources/Account/Account.swift
+++ b/Sources/Account/Account.swift
@@ -10,7 +10,6 @@ final class Account {
     let fogView = FogView()
 
     var allTxOutTrackers: [TxOutTracker] = []
-    var unscannedMissedBlocksRanges: [Range<UInt64>] = []
 
     init(accountKey: AccountKeyWithFog) {
         logger.info("")
@@ -22,6 +21,8 @@ final class Account {
     var publicAddress: PublicAddress {
         accountKey.publicAddress
     }
+
+    var unscannedMissedBlocksRanges: [Range<UInt64>] { fogView.unscannedMissedBlocksRanges }
 
     private var allTxOutsFoundBlockCount: UInt64 {
         var allTxOutsFoundBlockCount = fogView.allRngTxOutsFoundBlockCount
@@ -127,6 +128,11 @@ final class Account {
     func addTxOuts(_ txOuts: [KnownTxOut]) {
         logger.info("txOuts: \(redacting: txOuts)")
         allTxOutTrackers.append(contentsOf: txOuts.map { TxOutTracker($0) })
+    }
+
+    func addViewKeyScanResults(scannedBlockRanges: [Range<UInt64>], foundTxOuts: [KnownTxOut]) {
+        addTxOuts(foundTxOuts)
+        fogView.markBlocksAsScanned(blockRanges: scannedBlockRanges)
     }
 
     func cachedReceivedStatus(of receipt: Receipt)

--- a/Sources/Fog/View/FogRngSet.swift
+++ b/Sources/Fog/View/FogRngSet.swift
@@ -79,21 +79,15 @@ final class FogRngSet {
         return Dictionary(uniqueKeysWithValues: Array(eligibleRngTrackers.prefix(maxRngs)))
     }
 
-    func processQueryResponse(
-        _ queryResponse: FogView_QueryResponse,
-        searchAttempt: FogSearchAttempt,
-        accountKey: AccountKey
-    ) -> Result<[FogView_TxOutSearchResult], ConnectionError> {
+    func processRngs(queryResponse: FogView_QueryResponse, accountKey: AccountKey)
+        -> Result<(), ConnectionError>
+    {
         processRngRecords(
             queryResponse.rngs,
             highestProcessedBlockCount: queryResponse.highestProcessedBlockCount,
             accountKey: accountKey
-        ).flatMap {
+        ).map {
             processDecommissionedRngs(queryResponse.decommissionedIngestInvocations)
-            return processTxOutSearchResults(
-                queryResponse.txOutSearchResults,
-                highestProcessedBlockCount: queryResponse.highestProcessedBlockCount,
-                searchAttempt: searchAttempt)
         }
     }
 
@@ -133,6 +127,16 @@ final class FogRngSet {
                 rngTracker.decommissioned = true
             }
         }
+    }
+
+    func processTxOutSearchResults(
+        queryResponse: FogView_QueryResponse,
+        searchAttempt: FogSearchAttempt
+    ) -> Result<[FogView_TxOutSearchResult], ConnectionError> {
+        processTxOutSearchResults(
+            queryResponse.txOutSearchResults,
+            highestProcessedBlockCount: queryResponse.highestProcessedBlockCount,
+            searchAttempt: searchAttempt)
     }
 
     private func processTxOutSearchResults(

--- a/Sources/Fog/View/FogRngSet.swift
+++ b/Sources/Fog/View/FogRngSet.swift
@@ -25,10 +25,9 @@ final class FogRngSet {
         numOutputs: PositiveInt,
         minOutputsPerSelectedRng: Int
     ) -> FogSearchAttempt {
-        logger.info(
-            "requestedBlockCount: \(redacting: String(describing: requestedBlockCount)), " +
-                "numOutputs: \(numOutputs.value), " +
-                "minOutputsPerSelectedRng: \(minOutputsPerSelectedRng)")
+        logger.info("requestedBlockCount: \(redacting: String(describing: requestedBlockCount)), " +
+            "numOutputs: \(numOutputs.value), minOutputsPerSelectedRng: " +
+            "\(minOutputsPerSelectedRng)")
         // Max rngs we can select while maintaining the requested minimum outputs per selected rng.
         let maxRngs = 0 < minOutputsPerSelectedRng && minOutputsPerSelectedRng <= numOutputs.value
             ? numOutputs.value / minOutputsPerSelectedRng : numOutputs.value
@@ -60,8 +59,7 @@ final class FogRngSet {
         -> [Int64: RngTracker]
     {
         logger.info(
-            "requestedBlockCount: \(String(describing: requestedBlockCount)), " +
-                "maxRngs: \(maxRngs)")
+            "requestedBlockCount: \(String(describing: requestedBlockCount)), maxRngs: \(maxRngs)")
         // Filter for rngs that are still active.
         var eligibleRngTrackers = ingestInvocationIdToRngTrackers.filter { $0.value.active }
 
@@ -82,31 +80,30 @@ final class FogRngSet {
     }
 
     func processQueryResponse(
+        _ queryResponse: FogView_QueryResponse,
         searchAttempt: FogSearchAttempt,
-        queryResponse: FogView_QueryResponse,
         accountKey: AccountKey
     ) -> Result<[FogView_TxOutSearchResult], ConnectionError> {
         processRngRecords(
-            accountKey: accountKey,
-            rngRecords: queryResponse.rngs,
-            highestProcessedBlockCount: queryResponse.highestProcessedBlockCount
+            queryResponse.rngs,
+            highestProcessedBlockCount: queryResponse.highestProcessedBlockCount,
+            accountKey: accountKey
         ).flatMap {
-            processDecommissionedRngs(
-                decommissionedRngs: queryResponse.decommissionedIngestInvocations)
-            return processTxOutResults(
-                searchAttempt: searchAttempt,
-                txOutResults: queryResponse.txOutSearchResults,
-                highestProcessedBlockCount: queryResponse.highestProcessedBlockCount)
+            processDecommissionedRngs(queryResponse.decommissionedIngestInvocations)
+            return processTxOutSearchResults(
+                queryResponse.txOutSearchResults,
+                highestProcessedBlockCount: queryResponse.highestProcessedBlockCount,
+                searchAttempt: searchAttempt)
         }
     }
 
     private func processRngRecords(
-        accountKey: AccountKey,
-        rngRecords: [FogView_RngRecord],
-        highestProcessedBlockCount: UInt64
+        _ rngRecords: [FogView_RngRecord],
+        highestProcessedBlockCount: UInt64,
+        accountKey: AccountKey
     ) -> Result<(), ConnectionError> {
-        logger.info("rngRecords: \(rngRecords), " +
-                "highestProcessedBlockCount: \(highestProcessedBlockCount)")
+        logger.info(
+            "rngRecords: \(rngRecords), highestProcessedBlockCount: \(highestProcessedBlockCount)")
         for rngRecord in rngRecords
             where ingestInvocationIdToRngTrackers[rngRecord.ingestInvocationID] == nil
         {
@@ -126,7 +123,7 @@ final class FogRngSet {
     }
 
     private func processDecommissionedRngs(
-        decommissionedRngs: [FogView_DecommissionedIngestInvocation]
+        _ decommissionedRngs: [FogView_DecommissionedIngestInvocation]
     ) {
         logger.info("decommissionedRngs: \(decommissionedRngs)")
         for decommissionedRng in decommissionedRngs {
@@ -138,15 +135,15 @@ final class FogRngSet {
         }
     }
 
-    private func processTxOutResults(
-        searchAttempt: FogSearchAttempt,
-        txOutResults: [FogView_TxOutSearchResult],
-        highestProcessedBlockCount: UInt64
+    private func processTxOutSearchResults(
+        _ txOutSearchResults: [FogView_TxOutSearchResult],
+        highestProcessedBlockCount: UInt64,
+        searchAttempt: FogSearchAttempt
     ) -> Result<[FogView_TxOutSearchResult], ConnectionError> {
-        logger.info("txOutResults: \(redacting: txOutResults), " +
-                        "highestProcessedBlockCount: \(highestProcessedBlockCount)")
+        logger.info("txOutSearchResults: \(redacting: txOutSearchResults), " +
+            "highestProcessedBlockCount: \(highestProcessedBlockCount)")
         let searchKeyToTxOutResult = Dictionary(
-            txOutResults.map { ($0.searchKey, $0) },
+            txOutSearchResults.map { ($0.searchKey, $0) },
             uniquingKeysWith: { key1, _ in key1 })
 
         return searchAttempt.ingestInvocationIdToRngSearchAttempt
@@ -155,9 +152,9 @@ final class FogRngSet {
                 guard let rngTracker = ingestInvocationIdToRngTrackers[ingestInvocationId] else {
                     // This condition is considered a programming error and mean `searchAttempt` was
                     // created using a different `FogRngSet` instance. We silently fail here, since
-                    // we know we're in a good state anyway.
-                    logger.assertionFailure("Error: RngTracker not found for rngKey in " +
-                                 "search attempt. ingestInvocationId: \(ingestInvocationId)")
+                    // we know we're still in a valid, internally-consistent state.
+                    logger.assertionFailure("RngTracker not found for rngKey in search attempt. " +
+                        "ingestInvocationId: \(ingestInvocationId)")
                     return .success([])
                 }
 
@@ -231,7 +228,7 @@ private final class RngTracker {
         highestProcessedBlockCount: UInt64
     ) -> Result<[FogView_TxOutSearchResult], ConnectionError> {
         logger.info("rngSearchKeyToTxOutResult: \(redacting: rngSearchKeyToTxOutResult), " +
-                        "highestProcessedBlockCount: \(highestProcessedBlockCount)")
+            "highestProcessedBlockCount: \(highestProcessedBlockCount)")
         var foundTxOutResults: [FogView_TxOutSearchResult] = []
 
         searchResultLoop: while true {
@@ -242,8 +239,8 @@ private final class RngTracker {
                 // this search attempt was made. Either way, if the next output we need wasn't one
                 // of the ones searched for or wasn't in the search results, then there's nothing
                 // else we can do with this rng.
-                logger.info("found all outputs OR processed txos " +
-                                "since this search attempt was made.")
+                logger.info(
+                    "found all outputs OR processed txos since this search attempt was made.")
                 break
             }
 
@@ -272,9 +269,8 @@ private final class RngTracker {
                 return .failure(.serverRateLimited("Fog View return error code: RateLimited."))
             case .badSearchKey, .internalError, .intentionallyUnused, .UNRECOGNIZED:
                 logger.warning("Fog view result error")
-                return .failure(.invalidServerResponse(
-                    "Fog View result error: \(txOutResult.resultCodeEnum), response: " +
-                    "\(txOutResult)"))
+                return .failure(.invalidServerResponse("Fog View result error: " +
+                    "\(txOutResult.resultCodeEnum), response: \(txOutResult)"))
             }
         }
 

--- a/Sources/Fog/View/FogView+TxOutFetcher.swift
+++ b/Sources/Fog/View/FogView+TxOutFetcher.swift
@@ -81,6 +81,8 @@ extension FogView {
                 "numOutputs: \(numOutputs)")
             var requestAad = FogView_QueryRequestAAD()
             let searchAttempt: FogSearchAttempt = fogView.readSync {
+                requestAad.startFromUserEventID = $0.nextStartFromUserEventId
+
                 // Note: converting directly from blockIndex to blockCount here is valid.
                 requestAad.startFromBlockIndex = $0.allRngRecordsKnownBlockCount
 

--- a/Sources/Fog/View/FogView.swift
+++ b/Sources/Fog/View/FogView.swift
@@ -35,18 +35,18 @@ final class FogView {
     }
 
     func processQueryResponse(
+        _ queryResponse: FogView_QueryResponse,
         searchAttempt: FogSearchAttempt,
-        response: FogView_QueryResponse,
         accountKey: AccountKey
     ) -> Result<[KnownTxOut], ConnectionError> {
         logger.info("")
         return rngSet.processQueryResponse(
+            queryResponse,
             searchAttempt: searchAttempt,
-            queryResponse: response,
             accountKey: accountKey
         ).flatMap { searchResults in
             searchResults.map { searchResult in
-                Self.decryptSearchResult(searchResult: searchResult, accountKey: accountKey)
+                Self.decryptSearchResult(searchResult, accountKey: accountKey)
             }.collectResult().map { decryptedTxOuts in
                 // Filter out TxOuts that don't belong to this account.
                 decryptedTxOuts.compactMap { txOut in
@@ -62,7 +62,7 @@ final class FogView {
     }
 
     private static func decryptSearchResult(
-        searchResult: FogView_TxOutSearchResult,
+        _ searchResult: FogView_TxOutSearchResult,
         accountKey: AccountKey
     ) -> Result<LedgerTxOut, ConnectionError> {
         logger.info("")

--- a/Sources/LibMobileCoin/ProtoExtensions.swift
+++ b/Sources/LibMobileCoin/ProtoExtensions.swift
@@ -65,13 +65,6 @@ extension FogCommon_BlockRange {
 
 // MARK: - Fog View
 
-extension FogView_QueryResponse {
-    var missedBlockRangeValues: [Range<UInt64>] {
-        get { missedBlockRanges.map { $0.startBlock..<$0.endBlock } }
-        set { missedBlockRanges = newValue.map { FogCommon_BlockRange($0) } }
-    }
-}
-
 extension FogView_RngRecord {
     init(nonce fogRngKey: FogRngKey, startBlock: UInt64) {
         self.init()


### PR DESCRIPTION
This PR adds tracking for Fog View user events by keeping track of `QueryResponse.next_start_from_user_event_id` and passing that value to subsequent queries via `QueryRequestAAD.start_from_user_event_id`.

This helps cut down on the amount of data that's returned in response to Fog View queries. Fog View considers new rngs, decommissioned rngs, and missed block ranges as user events, which will be the 3 types of data that will be optimized as a result of this. Among other things, this puts less pressure on the `FogView` object to track which missed blocks have already been processed.