### PR TITLE
Fix off-by-1 bug when preparing a transaction

### DIFF
--- a/Sources/Transaction/TransactionPreparer.swift
+++ b/Sources/Transaction/TransactionPreparer.swift
@@ -47,7 +47,7 @@ struct TransactionPreparer {
                 isGreaterThanValue: fee)
         else {
             logger.warning("failure - sumOfValues inputs: \(redacting: inputs) " +
-                            "isGreaterThanValue fee: \(redacting: fee)")
+                            "is less than or equal to fee: \(redacting: fee)")
             serialQueue.async {
                 completion(.failure(.insufficientBalance()))
             }
@@ -97,9 +97,9 @@ struct TransactionPreparer {
         }
         guard UInt64.safeCompare(
                 sumOfValues: inputs.map { $0.value },
-                isGreaterThanSumOfValues: [amount.value, fee])
+                isGreaterThanOrEqualToSumOfValues: [amount.value, fee])
         else {
-            logger.warning("sum of inputs is greater than amount + fee")
+            logger.warning("sum of inputs is less than amount + fee")
             serialQueue.async {
                 completion(.failure(.insufficientBalance()))
             }


### PR DESCRIPTION
This PR fixes a bug in `TransactionPreparer` where an `.insufficientBalance` error was thrown if the total value of unspent TxOuts was exactly equal to the amount being send + the fee.