### PR TITLE
Reset version up 1.0.0-rc1

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -26,7 +26,7 @@ target 'Example' do
   # pod 'MobileCoin', git: 'https://github.com/mobilecoinofficial/MobileCoin-Swift.git'
   # pod 'MobileCoin/Core', git: 'https://github.com/mobilecoinofficial/MobileCoin-Swift.git', testspecs: ['Tests', 'IntegrationTests']
 
-  pod 'LibMobileCoin', '~> 1.0.1-pre1', binary: true
+  pod 'LibMobileCoin', '~> 1.0-pre', binary: true
   # pod 'LibMobileCoin', path: '../Vendor/libmobilecoin-ios-artifacts'
   # pod 'LibMobileCoin', podspec: '../Vendor/libmobilecoin-ios-artifacts/LibMobileCoin.podspec'
   # pod 'LibMobileCoin', git: 'https://github.com/mobilecoinofficial/libmobilecoin-ios-artifacts.git'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
     - MobileCoin/Core (= 1.0.1-pre1)
   - MobileCoin/Core (1.0.1-pre1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (~> 1.0.1-pre1)
+    - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -35,7 +35,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/IntegrationTests (1.0.1-pre1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (~> 1.0.1-pre1)
+    - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -44,7 +44,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/PerformanceTests (1.0.1-pre1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (~> 1.0.1-pre1)
+    - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -53,7 +53,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/Tests (1.0.1-pre1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (~> 1.0.1-pre1)
+    - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -158,7 +158,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 77fa1f5491846ed115a7fff26ce8abfb813e1e01
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 01a323128ca15c504f40ca38e70e4746271812da
+  MobileCoin: 62d65d930612473a94610f0577f7fcf5c3dfa83a
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   SwiftNIO: 81d33ce8c500b7e41b6cdde5f2f12330b9750219
   SwiftNIOConcurrencyHelpers: 23fc68bac541a465162d7225d2c743edd2f1012c

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -22,9 +22,9 @@ PODS:
     - gRPC-Swift (~> 1.0.0)
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.0.1-pre1):
-    - MobileCoin/Core (= 1.0.1-pre1)
-  - MobileCoin/Core (1.0.1-pre1):
+  - MobileCoin (1.0.0-rc1):
+    - MobileCoin/Core (= 1.0.0-rc1)
+  - MobileCoin/Core (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16)
     - SwiftNIOHTTP1 (~> 2.18)
     - SwiftProtobuf (~> 1.5)
-  - MobileCoin/Core/IntegrationTests (1.0.1-pre1):
+  - MobileCoin/Core/IntegrationTests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
@@ -42,7 +42,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16)
     - SwiftNIOHTTP1 (~> 2.18)
     - SwiftProtobuf (~> 1.5)
-  - MobileCoin/Core/PerformanceTests (1.0.1-pre1):
+  - MobileCoin/Core/PerformanceTests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
@@ -51,7 +51,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16)
     - SwiftNIOHTTP1 (~> 2.18)
     - SwiftProtobuf (~> 1.5)
-  - MobileCoin/Core/Tests (1.0.1-pre1):
+  - MobileCoin/Core/Tests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin (= 1.0.1-pre4)
     - Logging (~> 1.4)
@@ -158,7 +158,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 77fa1f5491846ed115a7fff26ce8abfb813e1e01
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 62d65d930612473a94610f0577f7fcf5c3dfa83a
+  MobileCoin: 9460e3385af1272fd1e29efd7f172537f1452355
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   SwiftNIO: 81d33ce8c500b7e41b6cdde5f2f12330b9750219
   SwiftNIOConcurrencyHelpers: 23fc68bac541a465162d7225d2c743edd2f1012c

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -104,7 +104,7 @@ PODS:
 DEPENDENCIES:
   - gRPC-Swift (~> 1.0.0)
   - Keys (from `Pods/CocoaPodsKeys`)
-  - LibMobileCoin (~> 1.0.1-pre1)
+  - LibMobileCoin (~> 1.0-pre)
   - MobileCoin (from `..`)
   - MobileCoin/Core (from `..`)
   - MobileCoin/Core/IntegrationTests (from `..`)
@@ -172,6 +172,6 @@ SPEC CHECKSUMS:
   SwiftNIOTransportServices: 896c9a4ac98698d32aa2feea7657ade219ae80bb
   SwiftProtobuf: 3320217e9d8fb75f36b40282e78c482640fd75dd
 
-PODFILE CHECKSUM: 5523ada23726f2dec58cf7eeac9c6c25054f7d1d
+PODFILE CHECKSUM: ceecfbd38c8dcccb921037f2b464d49e9e9fbb03
 
 COCOAPODS: 1.9.3

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.0.1-pre1"
+  s.version      = "1.0.0-rc1"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
       "Sources/**/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin", "~> 1.0.1-pre1"
+    subspec.dependency "LibMobileCoin", "= 1.0.1-pre4"
 
     subspec.dependency "gRPC-Swift", "~> 1.0.0"
     subspec.dependency "Logging", "~> 1.4"


### PR DESCRIPTION
This PR changes the version of the MobileCoin pod from `1.0.1-pre1` to `1.0.0-rc1`. It was originally set to `1.0.1-pre1` to match the version of Fog and LibMobileCoin, however, this is unnecessary. LibMobileCoin will continue to match the corresponding version of Fog that it is built from and the MobileCoin pod will use its own versioning independently (since it has its own API and must follow its own semver).

Note: Dropping the version down is okay in this case on account of there only being 1 published version, `1.0.1-pre1`, and that version needs to be yanked on account of a security bug. As such, the opportunity is being seized to reset the version to be a prerelease of `1.0.0`.