### PR TITLE
Update LibMobileCoin to v1.0.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -26,12 +26,12 @@ target 'Example' do
   # pod 'MobileCoin', git: 'https://github.com/mobilecoinofficial/MobileCoin-Swift.git'
   # pod 'MobileCoin/Core', git: 'https://github.com/mobilecoinofficial/MobileCoin-Swift.git', testspecs: ['Tests', 'IntegrationTests']
 
-  pod 'LibMobileCoin', '~> 1.0-pre', binary: true
+  pod 'LibMobileCoin', binary: true
   # pod 'LibMobileCoin', path: '../Vendor/libmobilecoin-ios-artifacts'
   # pod 'LibMobileCoin', podspec: '../Vendor/libmobilecoin-ios-artifacts/LibMobileCoin.podspec'
   # pod 'LibMobileCoin', git: 'https://github.com/mobilecoinofficial/libmobilecoin-ios-artifacts.git'
 
-  pod 'gRPC-Swift', '~> 1.0.0', binary: true
+  pod 'gRPC-Swift', binary: true
   pod 'SwiftProtobuf', binary: true
   pod 'SwiftLint', binary: true
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
     - SwiftNIOTransportServices (< 2.0.0, >= 1.6.0)
     - SwiftProtobuf (< 2.0.0, >= 1.9.0)
   - Keys (1.0.1)
-  - LibMobileCoin (1.0.1-pre4):
+  - LibMobileCoin (1.0.0):
     - gRPC-Swift (~> 1.0.0)
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
@@ -26,7 +26,7 @@ PODS:
     - MobileCoin/Core (= 1.0.0-rc1)
   - MobileCoin/Core (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (= 1.0.1-pre4)
+    - LibMobileCoin (~> 1.0)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -35,7 +35,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/IntegrationTests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (= 1.0.1-pre4)
+    - LibMobileCoin (~> 1.0)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -44,7 +44,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/PerformanceTests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (= 1.0.1-pre4)
+    - LibMobileCoin (~> 1.0)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -53,7 +53,7 @@ PODS:
     - SwiftProtobuf (~> 1.5)
   - MobileCoin/Core/Tests (1.0.0-rc1):
     - gRPC-Swift (~> 1.0.0)
-    - LibMobileCoin (= 1.0.1-pre4)
+    - LibMobileCoin (~> 1.0)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.22)
@@ -102,9 +102,9 @@ PODS:
   - SwiftProtobuf (1.15.0)
 
 DEPENDENCIES:
-  - gRPC-Swift (~> 1.0.0)
+  - gRPC-Swift
   - Keys (from `Pods/CocoaPodsKeys`)
-  - LibMobileCoin (~> 1.0-pre)
+  - LibMobileCoin
   - MobileCoin (from `..`)
   - MobileCoin/Core (from `..`)
   - MobileCoin/Core/IntegrationTests (from `..`)
@@ -156,9 +156,9 @@ SPEC CHECKSUMS:
   CNIOWindows: f2baa102255e986467578337ffa2f777cb6bdf7f
   gRPC-Swift: 77154009a019e97f8c4bd8f2bb75fe9726801157
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  LibMobileCoin: 77fa1f5491846ed115a7fff26ce8abfb813e1e01
+  LibMobileCoin: c6399204cc78ef6d0f5fb3e01c2d4da489918edd
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 9460e3385af1272fd1e29efd7f172537f1452355
+  MobileCoin: c6713e46f43d247167e560ea9e927e8fdf9492fe
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   SwiftNIO: 81d33ce8c500b7e41b6cdde5f2f12330b9750219
   SwiftNIOConcurrencyHelpers: 23fc68bac541a465162d7225d2c743edd2f1012c
@@ -172,6 +172,6 @@ SPEC CHECKSUMS:
   SwiftNIOTransportServices: 896c9a4ac98698d32aa2feea7657ade219ae80bb
   SwiftProtobuf: 3320217e9d8fb75f36b40282e78c482640fd75dd
 
-PODFILE CHECKSUM: ceecfbd38c8dcccb921037f2b464d49e9e9fbb03
+PODFILE CHECKSUM: 004d4412cc1559f32bc126f553599fcfcaac859f
 
 COCOAPODS: 1.9.3

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
       "Sources/**/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin", "= 1.0.1-pre4"
+    subspec.dependency "LibMobileCoin", "~> 1.0"
 
     subspec.dependency "gRPC-Swift", "~> 1.0.0"
     subspec.dependency "Logging", "~> 1.4"

--- a/Sources/Encodings/TransferPayload.swift
+++ b/Sources/Encodings/TransferPayload.swift
@@ -26,7 +26,7 @@ extension TransferPayload: Hashable {}
 
 extension TransferPayload {
     init?(_ transferPayload: Printable_TransferPayload) {
-        guard let rootEntropy = Data32(transferPayload.entropy),
+        guard let rootEntropy = Data32(transferPayload.rootEntropy),
               let txOutPublicKey = RistrettoPublic(transferPayload.txOutPublicKey.data)
         else {
             return nil
@@ -40,7 +40,7 @@ extension TransferPayload {
 extension Printable_TransferPayload {
     init(_ transferPayload: TransferPayload) {
         self.init()
-        self.entropy = transferPayload.rootEntropy
+        self.rootEntropy = transferPayload.rootEntropy
         self.txOutPublicKey = External_CompressedRistretto(transferPayload.txOutPublicKey)
         if let memo = transferPayload.memo {
             self.memo = memo


### PR DESCRIPTION
This PR updates the LibMobileCoin pod and libmobilecoin-ios-artifacts submodule to v1.0.0.