### PR TITLE
[SWIFT-170] Cache minimum transaction fee

### DIFF
--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -55,8 +55,10 @@ public final class MobileCoinClient {
         let inner = Inner(serviceProvider: serviceProvider, fogResolverManager: fogResolverManager)
         self.inner = .init(inner, targetQueue: serialQueue)
 
-        self.feeFetcher =
-            BlockchainFeeFetcher(blockchainService: serviceProvider.blockchainService)
+        self.feeFetcher = BlockchainFeeFetcher(
+            blockchainService: serviceProvider.blockchainService,
+            minimumFeeCacheTTL: config.minimumFeeCacheTTL,
+            targetQueue: serialQueue)
     }
 
     public var balance: Balance {
@@ -346,6 +348,9 @@ extension MobileCoinClient {
         }
 
         fileprivate var networkConfig: NetworkConfig
+
+        // default minimum fee cache TTL is 30 minutes
+        public var minimumFeeCacheTTL: TimeInterval = 30 * 60
 
         public var cacheStorageAdapter: StorageAdapter?
 

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -212,12 +212,14 @@ public final class MobileCoinClient {
         completion: @escaping (Result<(), TransactionSubmissionError>) -> Void
     ) {
         inner.accessAsync {
-            TransactionSubmitter(consensusService: $0.serviceProvider.consensusService)
-                .submitTransaction(transaction) { result in
-                    self.callbackQueue.async {
-                        completion(result)
-                    }
+            TransactionSubmitter(
+                consensusService: $0.serviceProvider.consensusService,
+                feeFetcher: self.feeFetcher
+            ).submitTransaction(transaction) { result in
+                self.callbackQueue.async {
+                    completion(result)
                 }
+            }
         }
     }
 

--- a/Sources/Network/Connection/Connections/BlockchainConnection.swift
+++ b/Sources/Network/Connection/Connections/BlockchainConnection.swift
@@ -8,7 +8,6 @@ import LibMobileCoin
 import SwiftProtobuf
 
 final class BlockchainConnection: Connection, BlockchainService {
-
     private let client: ConsensusCommon_BlockchainAPIClient
 
     init(

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -7,9 +7,11 @@ import LibMobileCoin
 
 struct TransactionSubmitter {
     private let consensusService: ConsensusService
+    private let feeFetcher: BlockchainFeeFetcher
 
-    init(consensusService: ConsensusService) {
+    init(consensusService: ConsensusService, feeFetcher: BlockchainFeeFetcher) {
         self.consensusService = consensusService
+        self.feeFetcher = feeFetcher
     }
 
     func submitTransaction(
@@ -21,7 +23,19 @@ struct TransactionSubmitter {
             "\(redacting: transaction.serializedData.base64EncodedString())",
             logFunction: false)
         consensusService.proposeTx(External_Tx(transaction)) {
-            completion($0.mapError { .connectionError($0) }.flatMap { self.processResponse($0) })
+            switch $0 {
+            case .success(let response):
+                let responseResult = self.processResponse(response)
+                if case .txFeeError = response.result {
+                    self.feeFetcher.resetCache {
+                        completion(responseResult)
+                    }
+                } else {
+                    completion(responseResult)
+                }
+            case .failure(let error):
+                completion(.failure(.connectionError(error)))
+            }
         }
     }
 

--- a/Tests/Unit/Transaction/Fee/BlockchainFeeFetcherTests.swift
+++ b/Tests/Unit/Transaction/Fee/BlockchainFeeFetcherTests.swift
@@ -10,7 +10,10 @@ class BlockchainFeeFetcherTests: XCTestCase {
 
     func testFetchMinimumFeeReturnsDefaultWithLegacyService() throws {
         let blockchainService = TestBlockchainService.makeWithSuccess()
-        let fetcher = BlockchainFeeFetcher(blockchainService: blockchainService)
+        let fetcher = BlockchainFeeFetcher(
+            blockchainService: blockchainService,
+            minimumFeeCacheTTL: 60,
+            targetQueue: DispatchQueue.main)
 
         let expect = expectation(description: "fetching minimum fee")
         fetcher.fetchMinimumFee {
@@ -22,7 +25,10 @@ class BlockchainFeeFetcherTests: XCTestCase {
 
     func testFetchMinimumFeeWorksWithNewService() throws {
         let blockchainService = TestBlockchainService(successWithMinimumFee: 3_000_000_000)
-        let fetcher = BlockchainFeeFetcher(blockchainService: blockchainService)
+        let fetcher = BlockchainFeeFetcher(
+            blockchainService: blockchainService,
+            minimumFeeCacheTTL: 60,
+            targetQueue: DispatchQueue.main)
 
         let expect = expectation(description: "fetching minimum fee")
         fetcher.fetchMinimumFee {


### PR DESCRIPTION
This PR adds in-memory caching of the minimum transaction fee returned from `GetLastBlockInfo` as part of the transaction estimation/preparation process.

The default cache invalidation timeout value is 30 minutes, which can be configured in `MobileCoinClient.Config`. In addition to the cache invalidation timeout, the cache will also be invalidated if the `submitTransaction` operation results in a `txFeeError`. This ensures that the `minimumFee` will be re-fetched if consensus were to increase the minimum fee in the future.