### PR TITLE
Retry Logic for `.connectionError`s

### DIFF
--- a/Sources/Network/Connection/ConnectionSession.swift
+++ b/Sources/Network/Connection/ConnectionSession.swift
@@ -39,6 +39,10 @@ final class ConnectionSession {
     func processResponse(headers: HPACKHeaders) {
         processCookieHeader(headers: headers)
     }
+    
+    func removeCookies(for input: URL) {
+        cookieStorage.cookies(for: input)?.forEach({cookieStorage.deleteCookie($0)})
+    }
 }
 
 extension ConnectionSession {


### PR DESCRIPTION
## Description

I re-used the code path from `.attestationFailure` to add auth-then-retry logic for `.connectionError`s inside `AttestedConnection`.

I also remove cookies for the request URL because thats how the load balancer decides which box to send the connection too. 

## Notes

- Do you have ideas for how I could approach a unit test for "erroring" an attested connection to simulate a retry ? 



