### PR TITLE
Additional fixes required for `v1.2.0-pre0` release

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -182,7 +182,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: e2f2e79ec02c5fef095fe9f2b391805d32342d03
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: f847066f88e1944f7184afd8aa788aba420b9948
+  MobileCoin: a9af68c39a6894288efa34061c6e35833f6015ed
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
   SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -11,7 +11,11 @@ Pod::Spec.new do |s|
 
   s.license      = { :type => "GPLv3" }
 
-  s.source       = { :git => "https://github.com/mobilecoinofficial/MobileCoin-Swift.git", :tag => "v#{s.version}" }
+  s.source       = { 
+    :git => "https://github.com/mobilecoinofficial/MobileCoin-Swift.git",
+    :tag => "v#{s.version}",
+    :submodules => true
+  }
 
 
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Sources/Network/GRPC/GrpcChannelManager.swift
+++ b/Sources/Network/GRPC/GrpcChannelManager.swift
@@ -33,7 +33,7 @@ extension ClientConnection {
     {
         let builder: Builder
         if config.useTls {
-            let secureBuilder = ClientConnection.secure(group: group)
+            let secureBuilder = ClientConnection.usingTLSBackedByNIOSSL(on: group)
             if let trustRoots = config.trustRoots {
                 secureBuilder.withTLS(trustRoots: .certificates(trustRoots))
             }

--- a/Tests/Integration/IntegrationTestFixtures.swift
+++ b/Tests/Integration/IntegrationTestFixtures.swift
@@ -9,7 +9,7 @@ import NIOSSL
 import XCTest
 
 enum IntegrationTestFixtures {
-    static let network: NetworkPreset = .mobiledev
+    static let network: NetworkPreset = .alpha
 }
 
 extension IntegrationTestFixtures {

--- a/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
@@ -32,7 +32,7 @@ extension FogReportConnectionIntTests {
         let url = try FogUrl.make(string: IntegrationTestFixtures.network.fogReportUrl).get()
         return FogReportConnection(
             url: url,
-            transportProtocolOption: .http,
+            transportProtocolOption: try IntegrationTestFixtures.network.networkConfig().transportProtocol.option,
             channelManager: GrpcChannelManager(),
             httpRequester: TestHttpRequester(),
             targetQueue: DispatchQueue.main)


### PR DESCRIPTION
- Fetch submodule => true in podspec
- Change Integration Test network environment
- Fix deprecated GRPC function 
- Remove hard-coded `.http`