### PR TITLE
Remove Xcode 11 from CircleCI, App-Store requires 12 or up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
           name: build-and-test-xcode-<< matrix.xcode-version >>
           matrix:
             parameters:
-              xcode-version: ["11.7.0", *default-xcode-version]
+              xcode-version: [*default-xcode-version]
       #- generate-docs:
           #filters:
             #branches: { only: master }


### PR DESCRIPTION
App Store requires Xcode 12 or up since April 2021 - https://developer.apple.com/news/?id=ib31uj1j