### PR TITLE
Add seperate HTTP & GRPC paths to integration tests. Adjust init and …

### DIFF
--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -307,7 +307,8 @@ extension MobileCoinClient {
             fogViewAttestation: Attestation,
             fogKeyImageAttestation: Attestation,
             fogMerkleProofAttestation: Attestation,
-            fogReportAttestation: Attestation
+            fogReportAttestation: Attestation,
+            transportProtocol: TransportProtocol = .grpc
         ) -> Result<Config, InvalidInputError> {
             ConsensusUrl.make(string: consensusUrl).flatMap { consensusUrl in
                 FogUrl.make(string: fogUrl).map { fogUrl in
@@ -320,7 +321,8 @@ extension MobileCoinClient {
                     let networkConfig = NetworkConfig(
                         consensusUrl: consensusUrl,
                         fogUrl: fogUrl,
-                        attestation: attestationConfig)
+                        attestation: attestationConfig,
+                        transportProtocol: transportProtocol)
                     return Config(networkConfig: networkConfig)
                 }
             }

--- a/Sources/Network/NetworkConfig.swift
+++ b/Sources/Network/NetworkConfig.swift
@@ -6,12 +6,12 @@ import Foundation
 import NIOSSL
 
 struct NetworkConfig {
-    static func make(consensusUrl: String, fogUrl: String, attestation: AttestationConfig)
+    static func make(consensusUrl: String, fogUrl: String, attestation: AttestationConfig, transportProtocol: TransportProtocol = .grpc)
         -> Result<NetworkConfig, InvalidInputError>
     {
         ConsensusUrl.make(string: consensusUrl).flatMap { consensusUrl in
             FogUrl.make(string: fogUrl).map { fogUrl in
-                NetworkConfig(consensusUrl: consensusUrl, fogUrl: fogUrl, attestation: attestation)
+                NetworkConfig(consensusUrl: consensusUrl, fogUrl: fogUrl, attestation: attestation, transportProtocol: transportProtocol)
             }
         }
     }
@@ -31,7 +31,7 @@ struct NetworkConfig {
 
     var httpRequester: HttpRequester?
     
-    init(consensusUrl: ConsensusUrl, fogUrl: FogUrl, attestation: AttestationConfig) {
+    init(consensusUrl: ConsensusUrl, fogUrl: FogUrl, attestation: AttestationConfig, transportProtocol: TransportProtocol = .grpc) {
         self.consensusUrl = consensusUrl
         self.fogUrl = fogUrl
         self.attestation = attestation

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -366,12 +366,13 @@ final class TestHttpRequester: HttpRequester {
 
 extension NetworkPreset {
 
-    func networkConfig() throws -> NetworkConfig {
+    func networkConfig(transportProtocol: TransportProtocol = TransportProtocol.grpc) throws -> NetworkConfig {
         let attestationConfig = try self.attestationConfig()
         var networkConfig = try NetworkConfig.make(
             consensusUrl: consensusUrl,
             fogUrl: fogUrl,
-            attestation: attestationConfig).get()
+            attestation: attestationConfig,
+            transportProtocol: transportProtocol).get()
         networkConfig.httpRequester = TestHttpRequester()
         networkConfig.consensusTrustRoots = try consensusTrustRoots()
         networkConfig.fogTrustRoots = try fogTrustRoots()

--- a/Tests/Integration/Fog/Report/FogReportManagerIntTests.swift
+++ b/Tests/Integration/Fog/Report/FogReportManagerIntTests.swift
@@ -6,8 +6,16 @@
 import XCTest
 
 class FogReportManagerIntTests: XCTestCase {
-    func testFogReport() throws {
-        let fogReportManager = try IntegrationTestFixtures.createFogReportManager()
+    func testFogReportGRPC() throws {
+        try fogReport(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testFogReportHTTP() throws {
+        try fogReport(transportProtocol: TransportProtocol.http)
+    }
+    
+    func fogReport(transportProtocol: TransportProtocol) throws {
+        let fogReportManager = try IntegrationTestFixtures.createFogReportManager(transportProtocol: transportProtocol)
         let reportUrl = try IntegrationTestFixtures.fogReportUrlTyped()
 
         let expect = expectation(description: "Retrieve fog reports")

--- a/Tests/Integration/Fog/Report/FogResolverManagerIntTests.swift
+++ b/Tests/Integration/Fog/Report/FogResolverManagerIntTests.swift
@@ -6,8 +6,16 @@
 import XCTest
 
 class FogResolverManagerIntTests: XCTestCase {
-    func testFogReport() throws {
-        let fogResolverManager = try IntegrationTestFixtures.createFogResolverManager()
+    func testFogReportGRPC() throws {
+        try fogReport(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testFogReportHTTP() throws {
+        try fogReport(transportProtocol: TransportProtocol.http)
+    }
+    
+    func fogReport(transportProtocol: TransportProtocol) throws {
+        let fogResolverManager = try IntegrationTestFixtures.createFogResolverManager(transportProtocol: transportProtocol)
         let publicAddress = try IntegrationTestFixtures.createPublicAddress()
 
         let expect = expectation(description: "Retrieve fog reports")
@@ -19,3 +27,4 @@ class FogResolverManagerIntTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 }
+

--- a/Tests/Integration/MobileCoinClientIntTests.swift
+++ b/Tests/Integration/MobileCoinClientIntTests.swift
@@ -9,11 +9,19 @@ import XCTest
 
 class MobileCoinClientIntTests: XCTestCase {
 
-    func testTransactionDoubleSubmissionFails() throws {
+    func testTransactionDoubleSubmissionFailsGRPC() throws {
+        try transactionDoubleSubmissionFails(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testTransactionDoubleSubmissionFailsHTTP() throws {
+        try transactionDoubleSubmissionFails(transportProtocol: TransportProtocol.http)
+    }
+    
+    func transactionDoubleSubmissionFails(transportProtocol: TransportProtocol) throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Submitting transaction twice")
-        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect)
+        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect, transportProtocol: transportProtocol)
         { client in
             client.prepareTransaction(
                 to: recipient,
@@ -44,8 +52,16 @@ class MobileCoinClientIntTests: XCTestCase {
 
     /// Tests that the transaction status check fails if the inputs were spent by another
     /// transaction
-    func testTransactionStatusFailsWhenInputIsAlreadySpent() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0)
+    func testTransactionStatusFailsWhenInputIsAlreadySpentGRPC() throws {
+        try transactionStatusFailsWhenInputIsAlreadySpent(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testTransactionStatusFailsWhenInputIsAlreadySpentHTTP() throws {
+        try transactionStatusFailsWhenInputIsAlreadySpent(transportProtocol: TransportProtocol.http)
+    }
+    
+    func transactionStatusFailsWhenInputIsAlreadySpent(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Checking transaction status")
@@ -125,8 +141,16 @@ class MobileCoinClientIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testTransactionStatusDoesNotSucceedWithoutSubmission() throws {
-        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0)
+    func testTransactionStatusDoesNotSucceedWithoutSubmissionGRPC() throws {
+        try transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testTransactionStatusDoesNotSucceedWithoutSubmissionHTTP() throws {
+        try transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol.http)
+    }
+    
+    func transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol) throws {
+        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Checking transaction status")
@@ -181,11 +205,20 @@ class MobileCoinClientIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testReceiptStatusDoesNotSucceedWithoutSubmission() throws {
-        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0)
+    func testReceiptStatusDoesNotSucceedWithoutSubmissionGRPC() throws {
+        try receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testReceiptStatusDoesNotSucceedWithoutSubmissionHTTP() throws {
+        try receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol.http)
+    }
+    
+    func receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol) throws {
+        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
-            accountKey: receiverAccountKey)
+            accountKey: receiverAccountKey,
+            transportProtocol: transportProtocol)
 
         let expect = expectation(description: "Checking receipt status fails")
         func updateBalances(callback: @escaping () -> Void) {
@@ -255,8 +288,16 @@ class MobileCoinClientIntTests: XCTestCase {
         waitForExpectations(timeout: 60)
     }
 
-    func testConcurrentBalanceChecks() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testConcurrentBalanceChecksGRPC() throws {
+        try concurrentBalanceChecks(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testConcurrentBalanceChecksHTTP() throws {
+        try concurrentBalanceChecks(transportProtocol: TransportProtocol.http)
+    }
+    
+    func concurrentBalanceChecks(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Checking account balance")
         client.updateBalance {
@@ -290,8 +331,16 @@ class MobileCoinClientIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testConcurrentBalanceChecksWhileUpdating() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testConcurrentBalanceChecksWhileUpdatingGRPC() throws {
+        try concurrentBalanceChecksWhileUpdating(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testConcurrentBalanceChecksWhileUpdatingHTTP() throws {
+        try concurrentBalanceChecksWhileUpdating(transportProtocol: TransportProtocol.http)
+    }
+    
+    func concurrentBalanceChecksWhileUpdating(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Checking account balance")
         let group = DispatchGroup()
@@ -329,8 +378,16 @@ class MobileCoinClientIntTests: XCTestCase {
         waitForExpectations(timeout: 120)
     }
 
-    func testConcurrentBalanceUpdates() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testConcurrentBalanceUpdatesGRPC() throws {
+        try concurrentBalanceUpdates(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testConcurrentBalanceUpdatesHTTP() throws {
+        try concurrentBalanceUpdates(transportProtocol: TransportProtocol.http)
+    }
+    
+    func concurrentBalanceUpdates(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Checking account balance")
         let group = DispatchGroup()

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -9,8 +9,16 @@ import XCTest
 
 class MobileCoinClientPublicApiIntTests: XCTestCase {
 
-    func testBalance() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testBalanceGRPC() throws {
+        try balance(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testBalanceHTTP() throws {
+        try balance(transportProtocol: TransportProtocol.http)
+    }
+    
+    func balance(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Updating account balance")
         client.updateBalance {
@@ -26,8 +34,16 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testAccountActivity() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testAccountActivityGRPC() throws {
+        try accountActivity(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testAccountActivityHTTP() throws {
+        try accountActivity(transportProtocol: TransportProtocol.http)
+    }
+    
+    func accountActivity(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Updating account balance")
         client.updateBalance {
@@ -46,9 +62,17 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testUpdateBalance() throws {
+    func testUpdateBalanceGRPC() throws {
+        try updateBalance(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testUpdateBalanceHTTP() throws {
+        try updateBalance(transportProtocol: TransportProtocol.http)
+    }
+    
+    func updateBalance(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Updating account balance")
-        try IntegrationTestFixtures.createMobileCoinClient().updateBalance {
+        try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol).updateBalance {
             guard let balance = $0.successOrFulfill(expectation: expect) else { return }
 
             if let amountPicoMob = try? XCTUnwrap(balance.amountPicoMob()) {
@@ -60,11 +84,19 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testPrepareTransaction() throws {
+    func testPrepareTransactionGRPC() throws {
+        try prepareTransaction(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testPrepareTransactionHTTP() throws {
+        try prepareTransaction(transportProtocol: TransportProtocol.http)
+    }
+    
+    func prepareTransaction(transportProtocol: TransportProtocol) throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Preparing transaction")
-        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect)
+        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect, transportProtocol: transportProtocol)
         { client in
             client.prepareTransaction(
                 to: recipient,
@@ -80,11 +112,19 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testSubmitTransaction() throws {
+    func testSubmitTransactionGRPC() throws {
+        try submitTransaction(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testSubmitTransactionHTTP() throws {
+        try submitTransaction(transportProtocol: TransportProtocol.http)
+    }
+    
+    func submitTransaction(transportProtocol: TransportProtocol) throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let expect = expectation(description: "Submitting transaction")
-        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect)
+        try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect, transportProtocol: transportProtocol)
         { client in
             client.prepareTransaction(
                 to: recipient,
@@ -105,9 +145,17 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testSelfPaymentBalanceChange() throws {
+    func testSelfPaymentBalanceChangeGRPC() throws {
+        try selfPaymentBalanceChange(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testSelfPaymentBalanceChangeHTTP() throws {
+        try selfPaymentBalanceChange(transportProtocol: TransportProtocol.http)
+    }
+    
+    func selfPaymentBalanceChange(transportProtocol: TransportProtocol) throws {
         let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 2)
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
         let expect = expectation(description: "Self payment")
         func submitTransaction(callback: @escaping (Balance) -> Void) {
@@ -169,9 +217,17 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testSelfPaymentBalanceChangeFeeLevel() throws {
+    func testSelfPaymentBalanceChangeFeeLevelGRPC() throws {
+        try selfPaymentBalanceChangeFeeLevel(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testSelfPaymentBalanceChangeFeeLevelHTTP() throws {
+        try selfPaymentBalanceChangeFeeLevel(transportProtocol: TransportProtocol.http)
+    }
+    
+    func selfPaymentBalanceChangeFeeLevel(transportProtocol: TransportProtocol) throws {
         let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 1)
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
         let expect = expectation(description: "Self payment")
         func submitTransaction(callback: @escaping (Balance) -> Void) {
@@ -231,8 +287,16 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testTransactionStatus() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1)
+    func testTransactionStatusGRPC() throws {
+        try transactionStatus(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testTransactionStatusHTTP() throws {
+        try transactionStatus(transportProtocol: TransportProtocol.http)
+    }
+    
+    func transactionStatus(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let expect = expectation(description: "Checking transaction status")
@@ -303,11 +367,20 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testReceiptStatus() throws {
-        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0)
+    func testReceiptStatusGRPC() throws {
+        try receiptStatus(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testReceiptStatusHTTP() throws {
+        try receiptStatus(transportProtocol: TransportProtocol.http)
+    }
+    
+    func receiptStatus(transportProtocol: TransportProtocol) throws {
+        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
-            accountKey: receiverAccountKey)
+            accountKey: receiverAccountKey,
+            transportProtocol: transportProtocol)
 
         let expect = expectation(description: "Checking receipt status")
 
@@ -376,11 +449,19 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testConsensusTrustRootWorks() throws {
-        var config = try IntegrationTestFixtures.createMobileCoinClientConfig()
+    func testConsensusTrustRootWorksGRPC() throws {
+        try consensusTrustRootWorks(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testConsensusTrustRootWorksHTTP() throws {
+        try consensusTrustRootWorks(transportProtocol: TransportProtocol.http)
+    }
+    
+    func consensusTrustRootWorks(transportProtocol: TransportProtocol) throws {
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(transportProtocol:transportProtocol)
         XCTAssertSuccess(
             config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()))
-        let client = try IntegrationTestFixtures.createMobileCoinClient(config: config)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(config: config, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let expect = expectation(description: "Submitting transaction")
@@ -411,12 +492,20 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testExtraConsensusTrustRootWorks() throws {
-        var config = try IntegrationTestFixtures.createMobileCoinClientConfig()
+    func testExtraConsensusTrustRootWorksGRPC() throws {
+        try extraConsensusTrustRootWorks(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testExtraConsensusTrustRootWorksHTTP() throws {
+        try extraConsensusTrustRootWorks(transportProtocol: TransportProtocol.http)
+    }
+    
+    func extraConsensusTrustRootWorks(transportProtocol: TransportProtocol) throws {
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(transportProtocol:transportProtocol)
         XCTAssertSuccess(config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()
             + [try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes]))
         let client =
-            try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1, config: config)
+            try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1, config: config, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Submitting transaction")
@@ -447,16 +536,24 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testWrongConsensusTrustRootReturnsError() throws {
+    func testWrongConsensusTrustRootReturnsErrorGRPC() throws {
+        try wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testWrongConsensusTrustRootReturnsErrorHTTP() throws {
+        try wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol.http)
+    }
+    
+    func wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol) throws {
         // Skipped because gRPC currently keeps retrying connection errors indefinitely.
         try XCTSkipIf(true)
 
-        var config = try IntegrationTestFixtures.createMobileCoinClientConfig()
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(transportProtocol:transportProtocol)
         XCTAssertSuccess(config.setConsensusTrustRoots([
             try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes,
         ]))
         let client =
-            try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, config: config)
+            try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, config: config, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let expect = expectation(description: "Submitting transaction")

--- a/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
@@ -9,13 +9,21 @@ import LibMobileCoin
 import XCTest
 
 class FogBlockConnectionIntTests: XCTestCase {
-    func testGetBlocks() throws {
+    func testGetBlocksGRPC() throws {
+        try getBlocks(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetBlocksHTTP() throws {
+        try getBlocks(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getBlocks(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog GetBlocks request")
 
         var request = FogLedger_BlockRequest()
         let range: Range<UInt64> = 1..<2
         request.rangeValues = [range]
-        try createFogBlockConnection().getBlocks(request: request) {
+        try createFogBlockConnection(transportProtocol:transportProtocol).getBlocks(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             print("numBlocks: \(response.numBlocks)")
@@ -35,14 +43,22 @@ class FogBlockConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetBlockZero() throws {
+    func testGetBlockZeroGRPC() throws {
+        try getBlockZero(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetBlockZeroHTTP() throws {
+        try getBlockZero(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getBlockZero(transportProtocol: TransportProtocol) throws {
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")
 
         var request = FogLedger_BlockRequest()
         request.rangeValues = [0..<1]
-        try createFogBlockConnection().getBlocks(request: request) {
+        try createFogBlockConnection(transportProtocol:transportProtocol).getBlocks(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.blocks.count, request.ranges.count)
@@ -61,10 +77,18 @@ class FogBlockConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 60)
     }
 
-    func testGetBlocksReturnsNoBlocksWithoutRange() throws {
+    func testGetBlocksReturnsNoBlocksWithoutRangeGRPC() throws {
+        try getBlocksReturnsNoBlocksWithoutRange(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetBlocksReturnsNoBlocksWithoutRangeHTTP() throws {
+        try getBlocksReturnsNoBlocksWithoutRange(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getBlocksReturnsNoBlocksWithoutRange(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog GetBlocks request")
 
-        try createFogBlockConnection().getBlocks(request: FogLedger_BlockRequest()) {
+        try createFogBlockConnection(transportProtocol:transportProtocol).getBlocks(request: FogLedger_BlockRequest()) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.blocks.count, 0)
@@ -76,12 +100,20 @@ class FogBlockConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetBlocksReturnsNoBlocksForEmptyRange() throws {
+    func testGetBlocksReturnsNoBlocksForEmptyRangeGRPC() throws {
+        try getBlocksReturnsNoBlocksForEmptyRange(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetBlocksReturnsNoBlocksForEmptyRangeHTTP() throws {
+        try getBlocksReturnsNoBlocksForEmptyRange(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getBlocksReturnsNoBlocksForEmptyRange(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog GetBlocks request")
 
         var request = FogLedger_BlockRequest()
         request.rangeValues = [0..<0]
-        try createFogBlockConnection().getBlocks(request: request) {
+        try createFogBlockConnection(transportProtocol:transportProtocol).getBlocks(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.blocks.count, 0)
@@ -93,7 +125,15 @@ class FogBlockConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testDoSGetBlocks() throws {
+    func testDoSGetBlocksGRPC() throws {
+        try doSGetBlocks(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testDoSGetBlocksHTTP() throws {
+        try doSGetBlocks(transportProtocol: TransportProtocol.http)
+    }
+    
+    func doSGetBlocks(transportProtocol: TransportProtocol) throws {
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")
@@ -103,7 +143,7 @@ class FogBlockConnectionIntTests: XCTestCase {
             request.rangeValues = [0..<UInt64.max]
 
             group.enter()
-            try createFogBlockConnection().getBlocks(request: request) {
+            try createFogBlockConnection(transportProtocol:transportProtocol).getBlocks(request: request) {
                 guard let response = $0.successOrLeaveGroup(group) else { return }
 
                 XCTAssertEqual(response.blocks.count, 0)
@@ -119,14 +159,22 @@ class FogBlockConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testInvalidCredentialsReturnsAuthorizationFailure() throws {
+    func testInvalidCredentialsReturnsAuthorizationFailureGRPC() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testInvalidCredentialsReturnsAuthorizationFailureHTTP() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.http)
+    }
+    
+    func invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol) throws {
         try XCTSkipUnless(IntegrationTestFixtures.network.fogRequiresCredentials)
 
         let expect = expectation(description: "Fog GetBlocks request")
 
         var request = FogLedger_BlockRequest()
         request.rangeValues = [1..<2]
-        try createFogBlockConnectionWithInvalidCredentials().getBlocks(request: request) {
+        try createFogBlockConnectionWithInvalidCredentials(transportProtocol:transportProtocol).getBlocks(request: request) {
             guard let error = $0.failureOrFulfill(expectation: expect) else { return }
 
             switch error {
@@ -142,13 +190,13 @@ class FogBlockConnectionIntTests: XCTestCase {
 }
 
 extension FogBlockConnectionIntTests {
-    func createFogBlockConnection() throws -> FogBlockConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+    func createFogBlockConnection(transportProtocol: TransportProtocol) throws -> FogBlockConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(transportProtocol: transportProtocol)
         return createFogBlockConnection(networkConfig: networkConfig)
     }
 
-    func createFogBlockConnectionWithInvalidCredentials() throws -> FogBlockConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+    func createFogBlockConnectionWithInvalidCredentials(transportProtocol: TransportProtocol) throws -> FogBlockConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials(transportProtocol: transportProtocol)
         return createFogBlockConnection(networkConfig: networkConfig)
     }
 

--- a/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -7,14 +7,22 @@ import LibMobileCoin
 import XCTest
 
 class FogKeyImageConnectionIntTests: XCTestCase {
-    func testCheckKeyImagesReturnsNotSpentForFakeKeyImage() throws {
+    func testCheckKeyImagesReturnsNotSpentForFakeKeyImageGRPC() throws {
+        try checkKeyImagesReturnsNotSpentForFakeKeyImage(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testCheckKeyImagesReturnsNotSpentForFakeKeyImageHTTP() throws {
+        try checkKeyImagesReturnsNotSpentForFakeKeyImage(transportProtocol: TransportProtocol.http)
+    }
+    
+    func checkKeyImagesReturnsNotSpentForFakeKeyImage(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog CheckKeyImages request")
 
         var request = FogLedger_CheckKeyImagesRequest()
         var query = FogLedger_KeyImageQuery()
         query.keyImage = External_KeyImage(Data(repeating: 0, count: 32))
         request.queries = [query]
-        try createFogKeyImageConnection().checkKeyImages(request: request) {
+        try createFogKeyImageConnection(transportProtocol:transportProtocol).checkKeyImages(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             print("numBlocks: \(response.numBlocks)")
@@ -39,14 +47,22 @@ class FogKeyImageConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testCheckKeyImagesResponseIsPaddedForTooShortKeyImage() throws {
+    func testCheckKeyImagesResponseIsPaddedForTooShortKeyImageGRPC() throws {
+        try checkKeyImagesResponseIsPaddedForTooShortKeyImage(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testCheckKeyImagesResponseIsPaddedForTooShortKeyImageHTTP() throws {
+        try checkKeyImagesResponseIsPaddedForTooShortKeyImage(transportProtocol: TransportProtocol.http)
+    }
+    
+    func checkKeyImagesResponseIsPaddedForTooShortKeyImage(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog CheckKeyImages request")
 
         var request = FogLedger_CheckKeyImagesRequest()
         var query = FogLedger_KeyImageQuery()
         query.keyImage = External_KeyImage(Data(repeating: 0, count: 0))
         request.queries = [query]
-        try createFogKeyImageConnection().checkKeyImages(request: request) {
+        try createFogKeyImageConnection(transportProtocol:transportProtocol).checkKeyImages(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.results.count, request.queries.count)
@@ -66,14 +82,22 @@ class FogKeyImageConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testCheckKeyImagesResponseFailsForTooLongKeyImage() throws {
+    func testCheckKeyImagesResponseFailsForTooLongKeyImageGRPC() throws {
+        try checkKeyImagesResponseFailsForTooLongKeyImage(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testCheckKeyImagesResponseFailsForTooLongKeyImageHTTP() throws {
+        try checkKeyImagesResponseFailsForTooLongKeyImage(transportProtocol: TransportProtocol.http)
+    }
+    
+    func checkKeyImagesResponseFailsForTooLongKeyImage(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog CheckKeyImages request")
 
         var request = FogLedger_CheckKeyImagesRequest()
         var query = FogLedger_KeyImageQuery()
         query.keyImage = External_KeyImage(Data(repeating: 0, count: 33))
         request.queries = [query]
-        try createFogKeyImageConnection().checkKeyImages(request: request) {
+        try createFogKeyImageConnection(transportProtocol:transportProtocol).checkKeyImages(request: request) {
             guard let error = $0.failureOrFulfill(expectation: expect) else { return }
             print("error: \(error)")
 
@@ -82,7 +106,15 @@ class FogKeyImageConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testInvalidCredentialsReturnsAuthorizationFailure() throws {
+    func testInvalidCredentialsReturnsAuthorizationFailureGRPC() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testInvalidCredentialsReturnsAuthorizationFailureHTTP() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.http)
+    }
+    
+    func invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol) throws {
         try XCTSkipUnless(IntegrationTestFixtures.network.fogRequiresCredentials)
 
         let expect = expectation(description: "Fog CheckKeyImages request")
@@ -91,7 +123,7 @@ class FogKeyImageConnectionIntTests: XCTestCase {
         var query = FogLedger_KeyImageQuery()
         query.keyImage = External_KeyImage(Data(repeating: 0, count: 32))
         request.queries = [query]
-        try createFogKeyImageConnectionWithInvalidCredentials().checkKeyImages(request: request) {
+        try createFogKeyImageConnectionWithInvalidCredentials(transportProtocol:transportProtocol).checkKeyImages(request: request) {
             guard let error = $0.failureOrFulfill(expectation: expect) else { return }
 
             switch error {
@@ -107,13 +139,13 @@ class FogKeyImageConnectionIntTests: XCTestCase {
 }
 
 extension FogKeyImageConnectionIntTests {
-    func createFogKeyImageConnection() throws -> FogKeyImageConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+    func createFogKeyImageConnection(transportProtocol:TransportProtocol) throws -> FogKeyImageConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(transportProtocol:transportProtocol)
         return createFogKeyImageConnection(networkConfig: networkConfig)
     }
 
-    func createFogKeyImageConnectionWithInvalidCredentials() throws -> FogKeyImageConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+    func createFogKeyImageConnectionWithInvalidCredentials(transportProtocol: TransportProtocol) throws -> FogKeyImageConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials(transportProtocol: transportProtocol)
         return createFogKeyImageConnection(networkConfig: networkConfig)
     }
 

--- a/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
@@ -7,13 +7,21 @@ import LibMobileCoin
 import XCTest
 
 class FogMerkleProofConnectionIntTests: XCTestCase {
-    func testGetOutputsRequest() throws {
+    func testGetOutputsRequestGRPC() throws {
+        try getOutputsRequest(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetOutputsRequestHTTP() throws {
+        try getOutputsRequest(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getOutputsRequest(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
 
         var request = FogLedger_GetOutputsRequest()
         request.indices = [0]
         request.merkleRootBlock = 10
-        try createFogMerkleProofConnection().getOutputs(request: request) {
+        try createFogMerkleProofConnection(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             print("numBlocks: \(response.numBlocks)")
@@ -34,13 +42,21 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetOutputsReturnsNoResultsWhenSearchingForZeroIndices() throws {
+    func testGetOutputsReturnsNoResultsWhenSearchingForZeroIndicesGRPC() throws {
+        try getOutputsReturnsNoResultsWhenSearchingForZeroIndices(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetOutputsReturnsNoResultsWhenSearchingForZeroIndicesHTTP() throws {
+        try getOutputsReturnsNoResultsWhenSearchingForZeroIndices(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getOutputsReturnsNoResultsWhenSearchingForZeroIndices(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
 
         var request = FogLedger_GetOutputsRequest()
         request.indices = []
         request.merkleRootBlock = 10
-        try createFogMerkleProofConnection().getOutputs(request: request) {
+        try createFogMerkleProofConnection(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.results.count, request.indices.count)
@@ -52,13 +68,21 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetOutputsRequestAcceptsUIntMinMerkleRootBlock() throws {
+    func testGetOutputsRequestAcceptsUIntMinMerkleRootBlockGRPC() throws {
+        try getOutputsRequestAcceptsUIntMinMerkleRootBlock(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetOutputsRequestAcceptsUIntMinMerkleRootBlockHTTP() throws {
+        try getOutputsRequestAcceptsUIntMinMerkleRootBlock(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getOutputsRequestAcceptsUIntMinMerkleRootBlock(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
 
         var request = FogLedger_GetOutputsRequest()
         request.indices = [0]
         request.merkleRootBlock = 0
-        try createFogMerkleProofConnection().getOutputs(request: request) {
+        try createFogMerkleProofConnection(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.results.count, request.indices.count)
@@ -76,13 +100,21 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetOutputsRequestAcceptsUIntMaxMerkleRootBlock() throws {
+    func testGetOutputsRequestAcceptsUIntMaxMerkleRootBlockGRPC() throws {
+        try getOutputsRequestAcceptsUIntMaxMerkleRootBlock(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetOutputsRequestAcceptsUIntMaxMerkleRootBlockHTTP() throws {
+        try getOutputsRequestAcceptsUIntMaxMerkleRootBlock(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getOutputsRequestAcceptsUIntMaxMerkleRootBlock(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
 
         var request = FogLedger_GetOutputsRequest()
         request.indices = [0]
         request.merkleRootBlock = .max
-        try createFogMerkleProofConnection().getOutputs(request: request) {
+        try createFogMerkleProofConnection(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.results.count, request.indices.count)
@@ -100,13 +132,21 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testGetOutputsRequestReturnsNotFoundForUIntMax() throws {
+    func testGetOutputsRequestReturnsNotFoundForUIntMaxGRPC() throws {
+        try getOutputsRequestReturnsNotFoundForUIntMax(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetOutputsRequestReturnsNotFoundForUIntMaxHTTP() throws {
+        try getOutputsRequestReturnsNotFoundForUIntMax(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getOutputsRequestReturnsNotFoundForUIntMax(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
 
         var request = FogLedger_GetOutputsRequest()
         request.indices = [.max]
         request.merkleRootBlock = .max
-        try createFogMerkleProofConnection().getOutputs(request: request) {
+        try createFogMerkleProofConnection(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertEqual(response.results.count, request.indices.count)
@@ -122,7 +162,15 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testInvalidCredentialsReturnsAuthorizationFailure() throws {
+    func testInvalidCredentialsReturnsAuthorizationFailureGRPC() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testInvalidCredentialsReturnsAuthorizationFailureHTTP() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.http)
+    }
+    
+    func invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol) throws {
         try XCTSkipUnless(IntegrationTestFixtures.network.fogRequiresCredentials)
 
         let expect = expectation(description: "Making Fog MerkleProof GetOutputs request")
@@ -130,7 +178,7 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
         var request = FogLedger_GetOutputsRequest()
         request.indices = [0]
         request.merkleRootBlock = 10
-        try createFogMerkleProofConnectionWithInvalidCredentials().getOutputs(request: request) {
+        try createFogMerkleProofConnectionWithInvalidCredentials(transportProtocol:transportProtocol).getOutputs(request: request) {
             guard let error = $0.failureOrFulfill(expectation: expect) else { return }
 
             switch error {
@@ -146,13 +194,13 @@ class FogMerkleProofConnectionIntTests: XCTestCase {
 }
 
 extension FogMerkleProofConnectionIntTests {
-    func createFogMerkleProofConnection() throws -> FogMerkleProofConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+    func createFogMerkleProofConnection(transportProtocol: TransportProtocol) throws -> FogMerkleProofConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(transportProtocol: transportProtocol)
         return createFogMerkleProofConnection(networkConfig: networkConfig)
     }
 
-    func createFogMerkleProofConnectionWithInvalidCredentials() throws -> FogMerkleProofConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+    func createFogMerkleProofConnectionWithInvalidCredentials(transportProtocol: TransportProtocol) throws -> FogMerkleProofConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials(transportProtocol: transportProtocol)
         return createFogMerkleProofConnection(networkConfig: networkConfig)
     }
 

--- a/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
@@ -8,10 +8,18 @@ import XCTest
 
 class FogReportConnectionIntTests: XCTestCase {
 
-    func testGetReports() throws {
+    func testGetReportsGRPC() throws {
+        try getReports(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetReportsHTTP() throws {
+        try getReports(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getReports(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog GetReports request")
 
-        try createFogReportConnection().getReports(request: Report_ReportRequest()) {
+        try createFogReportConnection(transportProtocol:transportProtocol).getReports(request: Report_ReportRequest()) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
 
             XCTAssertGreaterThan(response.reports.count, 0)
@@ -28,11 +36,11 @@ class FogReportConnectionIntTests: XCTestCase {
 }
 
 extension FogReportConnectionIntTests {
-    func createFogReportConnection() throws -> FogReportConnection {
+    func createFogReportConnection(transportProtocol: TransportProtocol) throws -> FogReportConnection {
         let url = try FogUrl.make(string: IntegrationTestFixtures.network.fogReportUrl).get()
         return FogReportConnection(
             url: url,
-            transportProtocolOption: try IntegrationTestFixtures.network.networkConfig().transportProtocol.option,
+            transportProtocolOption: transportProtocol.option,
             channelManager: GrpcChannelManager(),
             httpRequester: TestHttpRequester(),
             targetQueue: DispatchQueue.main)

--- a/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
@@ -7,9 +7,17 @@ import LibMobileCoin
 import XCTest
 
 class FogUntrustedTxOutConnectionIntTests: XCTestCase {
-    func testGetTxOutsReturnsNoResultsWithoutPubkeys() throws {
+    func testGetTxOutsReturnsNoResultsWithoutPubkeysGRPC() throws {
+        try getTxOutsReturnsNoResultsWithoutPubkeys(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testGetTxOutsReturnsNoResultsWithoutPubkeysHTTP() throws {
+        try getTxOutsReturnsNoResultsWithoutPubkeys(transportProtocol: TransportProtocol.http)
+    }
+    
+    func getTxOutsReturnsNoResultsWithoutPubkeys(transportProtocol: TransportProtocol) throws {
         let expect = expectation(description: "Fog GetTxOuts request")
-        try createFogUntrustedTxOutConnection().getTxOuts(request: FogLedger_TxOutRequest()) {
+        try createFogUntrustedTxOutConnection(transportProtocol:transportProtocol).getTxOuts(request: FogLedger_TxOutRequest()) {
             guard let response = $0.successOrFulfill(expectation: expect) else { return }
             print("numBlocks: \(response.numBlocks)")
             print("globalTxoCount: \(response.globalTxoCount)")
@@ -23,11 +31,19 @@ class FogUntrustedTxOutConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testInvalidCredentialsReturnsAuthorizationFailure() throws {
+    func testInvalidCredentialsReturnsAuthorizationFailureGRPC() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testInvalidCredentialsReturnsAuthorizationFailureHTTP() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.http)
+    }
+    
+    func invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol) throws {
         try XCTSkipUnless(IntegrationTestFixtures.network.fogRequiresCredentials)
 
         let expect = expectation(description: "Fog GetTxOuts request")
-        let connection = try createFogUntrustedTxOutConnectionWithInvalidCredentials()
+        let connection = try createFogUntrustedTxOutConnectionWithInvalidCredentials(transportProtocol:transportProtocol)
         connection.getTxOuts(request: FogLedger_TxOutRequest()) {
             guard let error = $0.failureOrFulfill(expectation: expect) else { return }
 
@@ -44,15 +60,15 @@ class FogUntrustedTxOutConnectionIntTests: XCTestCase {
 }
 
 extension FogUntrustedTxOutConnectionIntTests {
-    func createFogUntrustedTxOutConnection() throws -> FogUntrustedTxOutConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+    func createFogUntrustedTxOutConnection(transportProtocol: TransportProtocol) throws -> FogUntrustedTxOutConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(transportProtocol: transportProtocol)
         return createFogUntrustedTxOutConnection(networkConfig: networkConfig)
     }
 
-    func createFogUntrustedTxOutConnectionWithInvalidCredentials() throws
+    func createFogUntrustedTxOutConnectionWithInvalidCredentials(transportProtocol: TransportProtocol) throws
         -> FogUntrustedTxOutConnection
     {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials(transportProtocol: transportProtocol)
         return createFogUntrustedTxOutConnection(networkConfig: networkConfig)
     }
 

--- a/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
@@ -9,8 +9,16 @@ import LibMobileCoin
 import XCTest
 
 class FogViewConnectionIntTests: XCTestCase {
-    func testEnclaveRequest() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestGRPC() throws {
+        try enclaveRequest(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestHTTP() throws {
+        try enclaveRequest(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequest(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
         fogViewConnection.query(
@@ -34,9 +42,17 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsTxOuts() throws {
+    func testEnclaveRequestReturnsTxOutsGRPC() throws {
+        try enclaveRequestReturnsTxOuts(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsTxOutsHTTP() throws {
+        try enclaveRequestReturnsTxOuts(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsTxOuts(transportProtocol: TransportProtocol) throws {
         let accountKey = try IntegrationTestFixtures.createAccountKey()
-        let fogViewConnection = try createFogViewConnection()
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -85,8 +101,16 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsNotFoundForFakeData() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestReturnsNotFoundForFakeDataGRPC() throws {
+        try enclaveRequestReturnsNotFoundForFakeData(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsNotFoundForFakeDataHTTP() throws {
+        try enclaveRequestReturnsNotFoundForFakeData(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsNotFoundForFakeData(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -110,8 +134,16 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsBadSearchKeyForEmptySearchKey() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestReturnsBadSearchKeyForEmptySearchKeyGRPC() throws {
+        try enclaveRequestReturnsBadSearchKeyForEmptySearchKey(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsBadSearchKeyForEmptySearchKeyHTTP() throws {
+        try enclaveRequestReturnsBadSearchKeyForEmptySearchKey(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsBadSearchKeyForEmptySearchKey(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -135,8 +167,16 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsBadSearchKeyForInvalidSearchKey() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestReturnsBadSearchKeyForInvalidSearchKeyGRPC() throws {
+        try enclaveRequestReturnsBadSearchKeyForInvalidSearchKey(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsBadSearchKeyForInvalidSearchKeyHTTP() throws {
+        try enclaveRequestReturnsBadSearchKeyForInvalidSearchKey(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsBadSearchKeyForInvalidSearchKey(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -161,8 +201,16 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsBadSearchKeyForTooShortSearchKey() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestReturnsBadSearchKeyForTooShortSearchKeyGRPC() throws {
+        try enclaveRequestReturnsBadSearchKeyForTooShortSearchKey(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsBadSearchKeyForTooShortSearchKeyHTTP() throws {
+        try enclaveRequestReturnsBadSearchKeyForTooShortSearchKey(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsBadSearchKeyForTooShortSearchKey(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -187,8 +235,16 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testEnclaveRequestReturnsBadSearchKeyForTooLongSearchKey() throws {
-        let fogViewConnection = try createFogViewConnection()
+    func testEnclaveRequestReturnsBadSearchKeyForTooLongSearchKeyGRPC() throws {
+        try enclaveRequestReturnsBadSearchKeyForTooLongSearchKey(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testEnclaveRequestReturnsBadSearchKeyForTooLongSearchKeyHTTP() throws {
+        try enclaveRequestReturnsBadSearchKeyForTooLongSearchKey(transportProtocol: TransportProtocol.http)
+    }
+    
+    func enclaveRequestReturnsBadSearchKeyForTooLongSearchKey(transportProtocol: TransportProtocol) throws {
+        let fogViewConnection = try createFogViewConnection(transportProtocol:transportProtocol)
 
         let expect = expectation(description: "Making Fog View enclave request")
 
@@ -213,11 +269,19 @@ class FogViewConnectionIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testInvalidCredentialsReturnsAuthorizationFailure() throws {
+    func testInvalidCredentialsReturnsAuthorizationFailureGRPC() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testInvalidCredentialsReturnsAuthorizationFailureHTTP() throws {
+        try invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol.http)
+    }
+    
+    func invalidCredentialsReturnsAuthorizationFailure(transportProtocol: TransportProtocol) throws {
         try XCTSkipUnless(IntegrationTestFixtures.network.fogRequiresCredentials)
 
         let expect = expectation(description: "Making Fog View enclave request")
-        try createFogViewConnectionWithInvalidCredentials().query(
+        try createFogViewConnectionWithInvalidCredentials(transportProtocol:transportProtocol).query(
             requestAad: FogView_QueryRequestAAD(),
             request: FogView_QueryRequest()
         ) {
@@ -236,13 +300,13 @@ class FogViewConnectionIntTests: XCTestCase {
 }
 
 extension FogViewConnectionIntTests {
-    func createFogViewConnection() throws -> FogViewConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfig()
+    func createFogViewConnection(transportProtocol: TransportProtocol) throws -> FogViewConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfig(transportProtocol: transportProtocol)
         return createFogViewConnection(networkConfig: networkConfig)
     }
 
-    func createFogViewConnectionWithInvalidCredentials() throws -> FogViewConnection {
-        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials()
+    func createFogViewConnectionWithInvalidCredentials(transportProtocol: TransportProtocol) throws -> FogViewConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidCredentials(transportProtocol: transportProtocol)
         return createFogViewConnection(networkConfig: networkConfig)
     }
 

--- a/Tests/Integration/Transaction/ReceiptPublicApiIntTests.swift
+++ b/Tests/Integration/Transaction/ReceiptPublicApiIntTests.swift
@@ -7,8 +7,16 @@ import XCTest
 
 class ReceiptPublicApiIntTests: XCTestCase {
 
-    func testSerializedData() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testSerializedDataGRPC() throws {
+        try serializedData(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testSerializedDataHTTP() throws {
+        try serializedData(transportProtocol: TransportProtocol.http)
+    }
+    
+    func serializedData(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Testing Receipt serialization")
@@ -31,9 +39,17 @@ class ReceiptPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testValidateAndUnmaskValueAccepts() throws {
+    func testValidateAndUnmaskValueAcceptsGRPC() throws {
+        try validateAndUnmaskValueAccepts(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testValidateAndUnmaskValueAcceptsHTTP() throws {
+        try validateAndUnmaskValueAccepts(transportProtocol: TransportProtocol.http)
+    }
+    
+    func validateAndUnmaskValueAccepts(transportProtocol: TransportProtocol) throws {
         let accountKey = try IntegrationTestFixtures.createAccountKey()
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
         let expect = expectation(description: "testing confirmation number")
         client.updateBalance {
@@ -56,11 +72,19 @@ class ReceiptPublicApiIntTests: XCTestCase {
         waitForExpectations(timeout: 20)
     }
 
-    func testValidateAndUnmaskValueRejects() throws {
+    func testValidateAndUnmaskValueRejectsGRPC() throws {
+        try validateAndUnmaskValueRejects(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testValidateAndUnmaskValueRejectsHTTP() throws {
+        try validateAndUnmaskValueRejects(transportProtocol: TransportProtocol.http)
+    }
+    
+    func validateAndUnmaskValueRejects(transportProtocol: TransportProtocol) throws {
         let accountKey = try IntegrationTestFixtures.createAccountKey()
         let accountKey2 = try IntegrationTestFixtures.createAccountKey(accountIndex: 2)
         let accountKey3 = try IntegrationTestFixtures.createAccountKey(accountIndex: 3)
-        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
         let expect = expectation(description: "testing confirmation number")
         client.updateBalance {

--- a/Tests/Integration/Transaction/TransactionPublicApiIntTests.swift
+++ b/Tests/Integration/Transaction/TransactionPublicApiIntTests.swift
@@ -7,8 +7,16 @@ import XCTest
 
 class TransactionPublicApiIntTests: XCTestCase {
 
-    func testSerializedData() throws {
-        let client = try IntegrationTestFixtures.createMobileCoinClient()
+    func testSerializedDataGRPC() throws {
+        try serializedData(transportProtocol: TransportProtocol.grpc)
+    }
+    
+    func testSerializedDataHTTP() throws {
+        try serializedData(transportProtocol: TransportProtocol.http)
+    }
+    
+    func serializedData(transportProtocol: TransportProtocol) throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
         let expect = expectation(description: "Testing Transaction serialization")


### PR DESCRIPTION
Soundtrack of this PR: [Roy Ayers - Searching](https://www.youtube.com/watch?v=R8FSBbRNhEk)

### Motivation

After adding network robustness (HTTP) support, the integration tests still only one `TransportProtocol` option which would be its default value as set in the `NetworkConfig.swift`

### In this PR

Add separate test functions for each protocol option. Keep existing test functions but parameterize them to accept a `TransportProtocol` and then add new test functions for each type - GRPC & HTTP.

### Future Work
- Possibly split the integration tests into separate targets/groups for GRPC & HTTP ? This might be required for splitting GRPC into its own build-target as has been requested by Signal.