### PR TITLE
Process `TxOut`s on a user's default change subaddress 

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,42 +19,42 @@ PODS:
     - SwiftNIOTransportServices (< 2.0.0, >= 1.11.1)
     - SwiftProtobuf (< 2.0.0, >= 1.9.0)
   - Keys (1.0.1)
-  - LibMobileCoin (1.2.0-pre3):
+  - LibMobileCoin (1.2.0-pre4):
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.0-pre2):
-    - MobileCoin/Core (= 1.2.0-pre2)
-  - MobileCoin/Core (1.2.0-pre2):
+  - MobileCoin (1.2.0-pre4):
+    - MobileCoin/Core (= 1.2.0-pre4)
+  - MobileCoin/Core (1.2.0-pre4):
     - gRPC-Swift
-    - LibMobileCoin (~> 1.2.0-pre3)
+    - LibMobileCoin (~> 1.2.0-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftProtobuf
-  - MobileCoin/Core/IntegrationTests (1.2.0-pre2):
+  - MobileCoin/Core/IntegrationTests (1.2.0-pre4):
     - gRPC-Swift
-    - LibMobileCoin (~> 1.2.0-pre3)
+    - LibMobileCoin (~> 1.2.0-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftProtobuf
-  - MobileCoin/Core/PerformanceTests (1.2.0-pre2):
+  - MobileCoin/Core/PerformanceTests (1.2.0-pre4):
     - gRPC-Swift
-    - LibMobileCoin (~> 1.2.0-pre3)
+    - LibMobileCoin (~> 1.2.0-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftProtobuf
-  - MobileCoin/Core/Tests (1.2.0-pre2):
+  - MobileCoin/Core/Tests (1.2.0-pre4):
     - gRPC-Swift
-    - LibMobileCoin (~> 1.2.0-pre3)
+    - LibMobileCoin (~> 1.2.0-pre4)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
@@ -180,9 +180,9 @@ SPEC CHECKSUMS:
   CNIOWindows: f5aa9dfb401b440a7b4c9cd911e53e981a787193
   gRPC-Swift: 8942047451bf81413077e6b94bf4213e47b181cc
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  LibMobileCoin: f3c44fb94b8647bd5cac3aedf0b1ca24f6cc7201
+  LibMobileCoin: eb34bc04933790ef25d065b38c2192edc6c175c1
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 339e51b8739b7ea2f0519cc7bdde8c4e05c2b374
+  MobileCoin: fc6afdb7e753ad93cdd2c6ee026451ae6e3a4957
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
   SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.0-pre2"
+  s.version      = "1.2.0-pre4"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
       "Sources/**/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin", "~> 1.2.0-pre3"
+    subspec.dependency "LibMobileCoin", "~> 1.2.0-pre4"
 
     subspec.dependency "gRPC-Swift"
     subspec.dependency "Logging", "~> 1.4"

--- a/Sources/Account/AccountKey.swift
+++ b/Sources/Account/AccountKey.swift
@@ -33,6 +33,7 @@ public struct AccountKey {
     let spendPrivateKey: RistrettoPrivate
     let fogInfo: FogInfo?
     let subaddressIndex: UInt64
+    let changeSubaddressIndex: UInt64 = McConstants.DEFAULT_CHANGE_SUBADDRESS_INDEX
 
     public let publicAddress: PublicAddress
 
@@ -72,20 +73,60 @@ public struct AccountKey {
     var fogReportId: String? { fogInfo?.reportId }
     var fogAuthoritySpki: Data? { fogInfo?.authoritySpki }
 
-    var subaddressViewPrivateKey: RistrettoPrivate {
+    private typealias SubaddressPrivateKey = (subaddressViewPrivateKey: RistrettoPrivate, subaddressSpendPrivateKey: RistrettoPrivate)
+    
+    private var subaddressPrivateKey : SubaddressPrivateKey {
         AccountKeyUtils.subaddressPrivateKeys(
             viewPrivateKey: viewPrivateKey,
             spendPrivateKey: spendPrivateKey,
             subaddressIndex: subaddressIndex
-        ).subaddressViewPrivateKey
+        )
+    }
+    
+    private var changeSubaddressPrivateKey : SubaddressPrivateKey {
+        AccountKeyUtils.subaddressPrivateKeys(
+            viewPrivateKey: viewPrivateKey,
+            spendPrivateKey: spendPrivateKey,
+            subaddressIndex: McConstants.DEFAULT_CHANGE_SUBADDRESS_INDEX
+        )
+    }
+    
+    var subaddressViewPrivateKey: RistrettoPrivate {
+        subaddressPrivateKey.subaddressViewPrivateKey
     }
 
     var subaddressSpendPrivateKey: RistrettoPrivate {
-        AccountKeyUtils.subaddressPrivateKeys(
-            viewPrivateKey: viewPrivateKey,
-            spendPrivateKey: spendPrivateKey,
-            subaddressIndex: subaddressIndex
-        ).subaddressSpendPrivateKey
+        subaddressPrivateKey.subaddressSpendPrivateKey
+    }
+    
+    var changeSubaddressViewPrivateKey: RistrettoPrivate {
+        changeSubaddressPrivateKey.subaddressViewPrivateKey
+    }
+
+    var changeSubaddressSpendPrivateKey: RistrettoPrivate {
+        changeSubaddressPrivateKey.subaddressSpendPrivateKey
+    }
+    
+    func subaddressSpendPrivateKey(index: UInt64) -> RistrettoPrivate? {
+        switch index {
+        case subaddressIndex:
+            return subaddressSpendPrivateKey
+        case changeSubaddressIndex:
+            return changeSubaddressSpendPrivateKey
+        default:
+            return nil
+        }
+    }
+    
+    func subaddressViewPrivateKey(index: UInt64) -> RistrettoPrivate? {
+        switch index {
+        case subaddressIndex:
+            return subaddressViewPrivateKey
+        case changeSubaddressIndex:
+            return changeSubaddressViewPrivateKey
+        default:
+            return nil
+        }
     }
 }
 

--- a/Sources/Account/OwnedTxOut.swift
+++ b/Sources/Account/OwnedTxOut.swift
@@ -19,6 +19,8 @@ public struct OwnedTxOut {
 
     public let spentBlock: BlockMetadata?
 
+    public let subaddressIndex: UInt64
+
     init(
         _ knownTxOut: KnownTxOut,
         receivedBlock: BlockMetadata,
@@ -29,6 +31,7 @@ public struct OwnedTxOut {
         self.keyImageTyped = knownTxOut.keyImage
         self.receivedBlock = receivedBlock
         self.spentBlock = spentBlock
+        self.subaddressIndex = knownTxOut.subaddressIndex
     }
 }
 

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -8,23 +8,24 @@ struct KnownTxOut: TxOutProtocol {
     private let ledgerTxOut: LedgerTxOut
     let value: UInt64
     let keyImage: KeyImage
+    let subaddressIndex: UInt64
 
     init?(_ ledgerTxOut: LedgerTxOut, accountKey: AccountKey) {
-        
         guard let value = ledgerTxOut.value(accountKey: accountKey),
-              let keyImage = ledgerTxOut.keyImage(accountKey: accountKey),
+              let (subaddressIndex, keyImage) = ledgerTxOut.keyImage(accountKey: accountKey),
               let commitment = TxOutUtils.reconstructCommitment(
                                                    maskedValue: ledgerTxOut.maskedValue,
                                                    publicKey: ledgerTxOut.publicKey,
-                                                   viewPrivateKey:accountKey.viewPrivateKey)
+                                                   viewPrivateKey: accountKey.viewPrivateKey)
         else {
             return nil
         }
-        
+
         self.commitment = commitment
         self.ledgerTxOut = ledgerTxOut
         self.value = value
         self.keyImage = keyImage
+        self.subaddressIndex = subaddressIndex
     }
 
     var commitment: Data32
@@ -37,4 +38,3 @@ struct KnownTxOut: TxOutProtocol {
 
 extension KnownTxOut: Equatable {}
 extension KnownTxOut: Hashable {}
-

--- a/Sources/LibMobileCoin/McConstants.swift
+++ b/Sources/LibMobileCoin/McConstants.swift
@@ -73,6 +73,8 @@ extension McConstants {
     /// An account's "default address" is its zero^th subaddress.
     static let DEFAULT_SUBADDRESS_INDEX: UInt64 = 0
 
+    /// An account's "default change address" is its first subaddress.
+    static let DEFAULT_CHANGE_SUBADDRESS_INDEX: UInt64 = 1
 }
 
 // MARK: - Keys

--- a/Sources/Transaction/Inputs/PreparedTxInput.swift
+++ b/Sources/Transaction/Inputs/PreparedTxInput.swift
@@ -26,6 +26,10 @@ struct PreparedTxInput {
     let knownTxOut: KnownTxOut
     let ring: [(TxOut, TxOutMembershipProof)]
     let realInputIndex: Int
+    
+    var subaddressIndex : UInt64 {
+        knownTxOut.subaddressIndex
+    }
 
     private init(knownTxOut: KnownTxOut, ring: [(TxOut, TxOutMembershipProof)], realInputIndex: Int)
     {

--- a/Sources/Transaction/TransactionBuilder.swift
+++ b/Sources/Transaction/TransactionBuilder.swift
@@ -275,10 +275,13 @@ final class TransactionBuilder {
     private func addInput(preparedTxInput: PreparedTxInput, accountKey: AccountKey)
         -> Result<(), TransactionBuilderError>
     {
-        addInput(
-            preparedTxInput: preparedTxInput,
-            viewPrivateKey: accountKey.viewPrivateKey,
-            subaddressSpendPrivateKey: accountKey.subaddressSpendPrivateKey)
+        guard let subaddressSpendPrivateKey = accountKey.subaddressSpendPrivateKey(index: preparedTxInput.subaddressIndex) else {
+            return .failure(TransactionBuilderError.invalidInput("Tx subaddress index out of bounds"))
+        }
+        return addInput(
+                preparedTxInput: preparedTxInput,
+                viewPrivateKey: accountKey.viewPrivateKey,
+                subaddressSpendPrivateKey: subaddressSpendPrivateKey)
     }
 
     private func addInput(

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -124,13 +124,22 @@ extension NetworkPreset {
     }
 
     private static let mainNetConsensusMrEnclaveHex =
-        "e66db38b8a43a33f6c1610d335a361963bb2b31e056af0dc0a895ac6c857cab9"
+        "653228afd2b02a6c28f1dc3b108b1dfa457d170b32ae8ec2978f941bd1655c83"
     private static let mainNetFogViewMrEnclaveHex =
-        "ddd59da874fdf3239d5edb1ef251df07a8728c9ef63057dd0b50ade5a9ddb041"
+        "dd84abda7f05116e21fcd1ee6361b0ec29445fff0472131eaf37bf06255b567a"
     private static let mainNetFogLedgerMrEnclaveHex =
-        "511eab36de691ded50eb08b173304194da8b9d86bfdd7102001fe6bb279c3666"
+        "89db0d1684fcc98258295c39f4ab68f7de5917ef30f0004d9a86f29930cebbbd"
     private static let mainNetFogReportMrEnclaveHex =
-        "709ab90621e3a8d9eb26ed9e2830e091beceebd55fb01c5d7c31d27e83b9b0d1"
+        "f3f7e9a674c55fb2af543513527b6a7872de305bac171783f6716a0bf6919499"
+    
+//    private static let mainNetConsensusMrEnclaveHex =
+//        "e66db38b8a43a33f6c1610d335a361963bb2b31e056af0dc0a895ac6c857cab9"
+//    private static let mainNetFogViewMrEnclaveHex =
+//        "ddd59da874fdf3239d5edb1ef251df07a8728c9ef63057dd0b50ade5a9ddb041"
+//    private static let mainNetFogLedgerMrEnclaveHex =
+//        "511eab36de691ded50eb08b173304194da8b9d86bfdd7102001fe6bb279c3666"
+//    private static let mainNetFogReportMrEnclaveHex =
+//        "709ab90621e3a8d9eb26ed9e2830e091beceebd55fb01c5d7c31d27e83b9b0d1"
 
     private static let testNetConsensusMrEnclaveHex =
         "9659ea738275b3999bf1700398b60281be03af5cb399738a89b49ea2496595af"

--- a/Tests/Unit/Ledger/TxOutTests.swift
+++ b/Tests/Unit/Ledger/TxOutTests.swift
@@ -23,7 +23,7 @@ class TxOutTests: XCTestCase {
         let fixture = try TxOut.Fixtures.Default()
         let txOut = fixture.txOut
         let recipientAccountKey = fixture.recipientAccountKey
-        XCTAssertEqual(txOut.keyImage(accountKey: recipientAccountKey), fixture.keyImage)
+        XCTAssertEqual(txOut.keyImage(accountKey: recipientAccountKey)?.keyImage, fixture.keyImage)
     }
 
     func testValue() throws {


### PR DESCRIPTION
Soundtrack of this PR: [Saine - Cruisin](https://www.youtube.com/watch?v=_s--A6z_kuY)

### Motivation

MobileCoin wallets have "default spend" and "default change" subaddresses. Spend is `0`, change is `1`. Fog only post-processes TxOut's **owned** by the "default spend address" (zero). It's possible (and becoming best practice) to send a `TxOut` to a users "default change subaddress" with an encrypted fog hint for the "default spend address". Right now the SDK assumes all TxOut's are sent to the "default spend address". TxOut's sent to the "default change address" but "owned" by the "default spend address" will be ignored in balance calculations and cannot be spent. 

### In this PR

Add code changes needed to check TxOut keyImages against the "default spend address" **and** the "default change subaddress" 

- Balance calculations will include TxOut's sent to the "default change address" but "owned" by the "default spend address" 
- TxOut's sent to the "default change address" but "owned" by the "default spend address" are now spendable

Transaction "change" will still be sent to the "default spend subaddress" - `0`

Asana Ticket - https://app.asana.com/0/1201257107231667/1201320194571576/f

### Future Work
- Suggest a staggered rollout so old clients do not suffer in-correct balances
- Send change to the "default change subaddress"

SDK Changes for above -> working branch for this change here -> https://github.com/the-real-adammork/MobileCoin-Swift/tree/task/support-change-subaddress-on-inputs

LibMobileCoin changes for above -> https://github.com/the-real-adammork/libmobilecoin-ios-artifacts/tree/task/subaddress-support

`mobilecoin` change for above -> https://github.com/the-real-adammork/mobilecoin/tree/task/subaddress-support