### PR TITLE
Add `bip39` to `TransferPayload` & `Printable`

### DIFF
--- a/Sources/Encodings/TransferPayload.swift
+++ b/Sources/Encodings/TransferPayload.swift
@@ -17,7 +17,7 @@ public struct TransferPayload {
         self.txOutPublicKey = txOutPublicKey
         self.memo = memo?.isEmpty == false ? memo : nil
     }
-    
+
     init(bip39: Data32, txOutPublicKey: RistrettoPublic, memo: String? = nil) {
         self.bip39_32 = bip39
         self.rootEntropy32 = nil
@@ -25,22 +25,12 @@ public struct TransferPayload {
         self.memo = memo?.isEmpty == false ? memo : nil
     }
 
-    public var rootEntropy: Data {
-        guard let rootEntropy = rootEntropy32 else {
-            let errorMessage = "rootEntropy not available in TransferPayload"
-            logger.error(errorMessage, logFunction: false)
-            return Data()
-        }
-        return rootEntropy.data
+    public var rootEntropy: Data? {
+        rootEntropy32?.data
     }
-    
-    public var bip39: Data {
-        guard let bip39 = bip39_32 else {
-            let errorMessage = "bip39 not available in TransferPayload"
-            logger.error(errorMessage, logFunction: false)
-            return Data()
-        }
-        return bip39.data
+
+    public var bip39: Data? {
+        bip39_32?.data
     }
 }
 
@@ -52,7 +42,7 @@ extension TransferPayload {
         guard let txOutPublicKey = RistrettoPublic(transferPayload.txOutPublicKey.data) else {
             return nil
         }
-        
+
         let rootEntropy = Data32(transferPayload.rootEntropy)
         let bip39 = Data32(transferPayload.bip39Entropy)
         switch (bip39, rootEntropy) {
@@ -65,7 +55,7 @@ extension TransferPayload {
         default:
             return nil
         }
-        
+
         self.txOutPublicKey = txOutPublicKey
         self.memo = !transferPayload.memo.isEmpty ? transferPayload.memo : nil
     }
@@ -74,8 +64,8 @@ extension TransferPayload {
 extension Printable_TransferPayload {
     init(_ transferPayload: TransferPayload) {
         self.init()
-        self.rootEntropy = transferPayload.rootEntropy
-        self.bip39Entropy = transferPayload.bip39
+        self.rootEntropy = transferPayload.rootEntropy ?? self.rootEntropy
+        self.bip39Entropy = transferPayload.bip39 ?? self.bip39Entropy
         self.txOutPublicKey = External_CompressedRistretto(transferPayload.txOutPublicKey)
         if let memo = transferPayload.memo {
             self.memo = memo

--- a/Sources/Encodings/TransferPayload.swift
+++ b/Sources/Encodings/TransferPayload.swift
@@ -27,7 +27,8 @@ public struct TransferPayload {
 
     public var rootEntropy: Data {
         guard let rootEntropy = rootEntropy32 else {
-            logger.error("rootEntropy not availabe in TransferPayload")
+            let errorMessage = "rootEntropy not available in TransferPayload"
+            logger.error(errorMessage, logFunction: false)
             return Data()
         }
         return rootEntropy.data
@@ -35,7 +36,8 @@ public struct TransferPayload {
     
     public var bip39: Data {
         guard let bip39 = bip39_32 else {
-            logger.error("bip39 not availabe in TransferPayload")
+            let errorMessage = "bip39 not available in TransferPayload"
+            logger.error(errorMessage, logFunction: false)
             return Data()
         }
         return bip39.data

--- a/Sources/Encodings/TransferPayload.swift
+++ b/Sources/Encodings/TransferPayload.swift
@@ -56,10 +56,10 @@ extension TransferPayload {
         switch (bip39, rootEntropy) {
         case let (.some(bip39_32), _) where bip39_32 != Data32():
             self.bip39_32 = bip39_32
-            self.rootEntropy32 = Data32()
+            self.rootEntropy32 = nil
         case let (_, .some(rootEntropy_32)) where rootEntropy_32 != Data32():
             self.rootEntropy32 = rootEntropy_32
-            self.bip39_32 = Data32()
+            self.bip39_32 = nil
         default:
             return nil
         }

--- a/Sources/Encodings/TransferPayload.swift
+++ b/Sources/Encodings/TransferPayload.swift
@@ -6,18 +6,39 @@ import Foundation
 import LibMobileCoin
 
 public struct TransferPayload {
-    let rootEntropy32: Data32
+    let rootEntropy32: Data32?
+    let bip39_32: Data32?
     let txOutPublicKey: RistrettoPublic
     public let memo: String?
 
     init(rootEntropy: Data32, txOutPublicKey: RistrettoPublic, memo: String? = nil) {
         self.rootEntropy32 = rootEntropy
+        self.bip39_32 = nil
+        self.txOutPublicKey = txOutPublicKey
+        self.memo = memo?.isEmpty == false ? memo : nil
+    }
+    
+    init(bip39: Data32, txOutPublicKey: RistrettoPublic, memo: String? = nil) {
+        self.bip39_32 = bip39
+        self.rootEntropy32 = nil
         self.txOutPublicKey = txOutPublicKey
         self.memo = memo?.isEmpty == false ? memo : nil
     }
 
     public var rootEntropy: Data {
-        rootEntropy32.data
+        guard let rootEntropy = rootEntropy32 else {
+            logger.error("rootEntropy not availabe in TransferPayload")
+            return Data()
+        }
+        return rootEntropy.data
+    }
+    
+    public var bip39: Data {
+        guard let bip39 = bip39_32 else {
+            logger.error("bip39 not availabe in TransferPayload")
+            return Data()
+        }
+        return bip39.data
     }
 }
 
@@ -26,12 +47,23 @@ extension TransferPayload: Hashable {}
 
 extension TransferPayload {
     init?(_ transferPayload: Printable_TransferPayload) {
-        guard let rootEntropy = Data32(transferPayload.rootEntropy),
-              let txOutPublicKey = RistrettoPublic(transferPayload.txOutPublicKey.data)
-        else {
+        guard let txOutPublicKey = RistrettoPublic(transferPayload.txOutPublicKey.data) else {
             return nil
         }
-        self.rootEntropy32 = rootEntropy
+        
+        let rootEntropy = Data32(transferPayload.rootEntropy)
+        let bip39 = Data32(transferPayload.bip39Entropy)
+        switch (bip39, rootEntropy) {
+        case let (.some(bip39_32), _) where bip39_32 != Data32():
+            self.bip39_32 = bip39_32
+            self.rootEntropy32 = Data32()
+        case let (_, .some(rootEntropy_32)) where rootEntropy_32 != Data32():
+            self.rootEntropy32 = rootEntropy_32
+            self.bip39_32 = Data32()
+        default:
+            return nil
+        }
+        
         self.txOutPublicKey = txOutPublicKey
         self.memo = !transferPayload.memo.isEmpty ? transferPayload.memo : nil
     }
@@ -41,6 +73,7 @@ extension Printable_TransferPayload {
     init(_ transferPayload: TransferPayload) {
         self.init()
         self.rootEntropy = transferPayload.rootEntropy
+        self.bip39Entropy = transferPayload.bip39
         self.txOutPublicKey = External_CompressedRistretto(transferPayload.txOutPublicKey)
         if let memo = transferPayload.memo {
             self.memo = memo


### PR DESCRIPTION
Soundtrack of this PR: [Palms Trax - Sumo Acid Crew](https://www.youtube.com/watch?v=o7fgUDJ8KHY)

### Motivation

`rootEntropy` is deprecated in the `TransferPayload` protobuf.

### In this PR
- Add `bip39` to fallible initializer, enforce that either `rootEntropy` or `bip39` be a non-empty `Data()`
- Add `bip39` to `Printable_TransferPayload` protobuf initializer

### Future Work
- Unit tests ?
