### PR TITLE
Add unit test for fogReport ShortURL's

### DIFF
--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -121,6 +121,17 @@ extension NetworkPreset {
             return "fog://fog.\(self).mobilecoin.com"
         }
     }
+    var fogShortUrl: String {
+        switch self {
+        case .mainNet:
+            return "fog://fog-rpt-prd.namda.net"
+        case .testNet:
+            return "fog://fog-rpt-stg.namda.net"
+            
+        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+            return ""
+        }
+    }
 
     private static let mainNetConsensusMrEnclaveHex =
         "653228afd2b02a6c28f1dc3b108b1dfa457d170b32ae8ec2978f941bd1655c83"
@@ -390,6 +401,7 @@ extension NetworkPreset {
     }
 
     var fogReportUrl: String { fogUrl }
+    var fogReportShortUrl: String { fogShortUrl }
     var fogReportId: String { "" }
 
     func fogAuthoritySpki() throws -> Data {
@@ -533,6 +545,15 @@ extension NetworkPreset {
         }
     }
 
+    var fogShortURLSupported: Bool {
+        switch self {
+        case .mainNet, .testNet:
+            return true
+        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+            return false
+        }
+    }
+    
     var invalidCredentials: BasicCredentials {
         BasicCredentials(username: Self.invalidCredUsername, password: Self.invalidCredPassword)
     }

--- a/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogReportConnectionIntTests.swift
@@ -30,10 +30,46 @@ class FogReportConnectionIntTests: XCTestCase {
         }
         waitForExpectations(timeout: 20)
     }
+    
+    func testGetReportsShortURL() throws {
+        try XCTSkipUnless(IntegrationTestFixtures.network.fogShortURLSupported, "Fog ShortURL not supported on this NetworkPreset")
+        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
+            try getReportsShortURL(transportProtocol: transportProtocol)
+        }
+    }
+    
+    func getReportsShortURL(transportProtocol: TransportProtocol) throws {
+        let expect = expectation(description: "Fog GetReports request")
+
+        try createShortURLFogReportConnection(transportProtocol:transportProtocol).getReports(request: Report_ReportRequest()) {
+            guard let response = $0.successOrFulfill(expectation: expect) else { return }
+
+            XCTAssertGreaterThan(response.reports.count, 0)
+            for report in response.reports {
+                print("pubkey_expiry: \(report.pubkeyExpiry)")
+                XCTAssertGreaterThan(report.pubkeyExpiry, 0)
+            }
+
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 20)
+    }
 
 }
 
 extension FogReportConnectionIntTests {
+    func createShortURLFogReportConnection(transportProtocol: TransportProtocol) throws -> FogReportConnection {
+        let url = try FogUrl.make(string: IntegrationTestFixtures.network.fogReportShortUrl).get()
+        let httpFactory = HttpProtocolConnectionFactory(httpRequester: TestHttpRequester())
+        let grpcFactory = GrpcProtocolConnectionFactory()
+        return FogReportConnection(
+            httpFactory: httpFactory,
+            grpcFactory: grpcFactory,
+            url: url,
+            transportProtocolOption: transportProtocol.option,
+            targetQueue: DispatchQueue.main)
+    }
+
     func createFogReportConnection(transportProtocol: TransportProtocol) throws -> FogReportConnection {
         let url = try FogUrl.make(string: IntegrationTestFixtures.network.fogReportUrl).get()
         let httpFactory = HttpProtocolConnectionFactory(httpRequester: TestHttpRequester())


### PR DESCRIPTION
Soundtrack of this PR: [NY*AK - Afghan Jam (feat. Mark Hand)](https://soundcloud.com/scotty5000/afghan-jam-feat-mark-hand)

### Motivation

Short URLs were introduced for compatibility reasons. We need to add these to our unit tests.

### In this PR
- Add new `fogReportShortURL` to our `NetworkPreset` file.
- Add `.testNet` and `.mainnet` short urls.
