### PR TITLE
Lint `.podspec` locally during "build-and-test" CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ jobs:
       - print-tool-versions
       - run: make build
       - run: make test
+      - run: make lint-locally-podspec
       #- run: make docs
       #- run: make lint-docs
       - store_artifacts: { path: output }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,15 @@ commands:
             git config user.email "mobilecoin-ci@mobilecoin.com"
             git config user.name "mobilecoin-ci"
 
+  set-git-credentials:
+    description: Set git credentials
+    steps:
+      - run:
+          name: Set git credentials
+          command: |
+            git config user.email "mobilecoin-ci@mobilecoin.com"
+            git config user.name "mobilecoin-ci"
+
   push-docs:
     steps:
       - add_ssh_keys:
@@ -264,6 +273,57 @@ jobs:
       - install-gh-pages
       - push-docs
 
+  prepare-pod-release:
+    parameters:
+      xcode-version:
+        type: string
+        default: *default-xcode-version
+    macos:
+      xcode: << parameters.xcode-version >>
+    environment:
+      <<: *default-environment
+    steps:
+      - checkout
+      - init-artifacts-submodule
+      - set-ruby-version
+      - install-example-gems
+      - install-example-http-gems
+      - install-example-pods:
+          xcode-version: << parameters.xcode-version >>
+      - install-example-http-pods:
+          xcode-version: << parameters.xcode-version >>
+      - install-gems
+      - run:
+          name: Pod Spec Lint
+          command: make lint-podspec
+
+  publish-pod-release:
+    parameters:
+      xcode-version:
+        type: string
+        default: *default-xcode-version
+    macos:
+      xcode: << parameters.xcode-version >>
+    environment:
+      <<: *default-environment
+    steps:
+      - checkout
+      - init-artifacts-submodule
+      - set-ruby-version
+      - install-example-gems
+      - install-example-http-gems
+      - install-example-pods:
+          xcode-version: << parameters.xcode-version >>
+      - install-example-http-pods:
+          xcode-version: << parameters.xcode-version >>
+      - install-gems
+      - set-git-credentials
+      - run:
+          name: Publish Pod to Trunk
+          command: make publish
+
+
+
 workflows:
   version: 2
   build:
@@ -273,6 +333,12 @@ workflows:
           matrix:
             parameters:
               xcode-version: [*default-xcode-version]
+      - prepare-pod-release:
+          filters:
+            branches: { only: master }
+      - publish-pod-release:
+          filters:
+            branches: { only: master }
       #- generate-docs:
           #filters:
             #branches: { only: master }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ commands:
       - run:
           name: Set git credentials
           command: |
-            git config user.email "mobilecoin-ci@mobilecoin.com"
+            git config user.email "infrastructure@mobilecoin.com"
             git config user.name "mobilecoin-ci"
 
   push-docs:
@@ -337,6 +337,7 @@ workflows:
           filters:
             branches: { only: master }
       - publish-pod-release:
+          requires: [ prepare-pod-release ]
           filters:
             branches: { only: master }
       #- generate-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ commands:
       - run:
           name: Set git credentials
           command: |
-            git config user.email "infrastructure@mobilecoin.com"
+            git config user.email "mobilecoin-ci@mobilecoin.com"
             git config user.name "mobilecoin-ci"
 
   push-docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-pre7] - 2022-01-07
+
+### Added
+
+- fog report short URL verification
+- CI/CD 
+
 ## [1.2.0-pre6] - 2022-01-06
 
 ### Added

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.0-pre6)
-  - MobileCoin/Core (1.2.0-pre6):
+  - MobileCoin (1.2.0-pre7)
+  - MobileCoin/Core (1.2.0-pre7):
     - gRPC-Swift
     - LibMobileCoin/Core (~> 1.2.0-pre5)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre6):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre7):
     - gRPC-Swift
     - LibMobileCoin/Core (~> 1.2.0-pre5)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.0-pre6)
-  - MobileCoin/PerformanceTests (1.2.0-pre6)
-  - MobileCoin/Tests (1.2.0-pre6)
+  - MobileCoin/IntegrationTests (1.2.0-pre7)
+  - MobileCoin/PerformanceTests (1.2.0-pre7)
+  - MobileCoin/Tests (1.2.0-pre7)
   - SwiftLint (0.45.0)
   - SwiftNIO (2.32.3):
     - SwiftNIOCore (= 2.32.3)
@@ -168,7 +168,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5767ae83c2127d176f608e509f4145603b52655f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: f277f7ff9498172dc205551fe68ff825999caad3
+  MobileCoin: 493cc2dbd26dbef620d128e4c852c58c6fd4091a
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
   SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.0-pre5):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.0-pre6)
-  - MobileCoin/CoreHTTP (1.2.0-pre6):
+  - MobileCoin (1.2.0-pre7)
+  - MobileCoin/CoreHTTP (1.2.0-pre7):
     - LibMobileCoin/CoreHTTP (~> 1.2.0-pre5)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre6):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre7):
     - LibMobileCoin/CoreHTTP (~> 1.2.0-pre5)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.0-pre6)
-  - MobileCoin/PerformanceTests (1.2.0-pre6)
-  - MobileCoin/Tests (1.2.0-pre6)
+  - MobileCoin/IntegrationTests (1.2.0-pre7)
+  - MobileCoin/PerformanceTests (1.2.0-pre7)
+  - MobileCoin/Tests (1.2.0-pre7)
   - SwiftLint (0.45.0)
   - SwiftProtobuf (1.18.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5767ae83c2127d176f608e509f4145603b52655f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: f277f7ff9498172dc205551fe68ff825999caad3
+  MobileCoin: 493cc2dbd26dbef620d128e4c852c58c6fd4091a
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ tag-release:
 # MobileCoin pod
 
 .PHONY: lint-podspec
+lint-locally-podspec:
+	bundle exec pod lib lint MobileCoin.podspec --skip-tests
+
+.PHONY: lint-podspec
 lint-podspec:
 	bundle exec pod spec lint MobileCoin.podspec --skip-tests
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tag-release:
 
 # MobileCoin pod
 
-.PHONY: lint-podspec
+.PHONY: lint-locally-podspec
 lint-locally-podspec:
 	bundle exec pod lib lint MobileCoin.podspec --skip-tests
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.0-pre6"
+  s.version      = "1.2.0-pre7"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"


### PR DESCRIPTION
Soundtrack of this PR: [Whodini - One Love](https://www.youtube.com/watch?v=qMnTawcUZLQ)

### Motivation

Update CircleCI workflow to push to cocoapods trunk after commits to master where the podspec version does not already have an existing tag.

### In this PR
- CircleCI changes

