### PR TITLE
Add unit tests for TransferPayload and PaymentRequest Printable encodings

### DIFF
--- a/Tests/Common/Errors/TestInitializationError.swift
+++ b/Tests/Common/Errors/TestInitializationError.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+
+struct TestInitializationError: Error {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var localizedDescription: String {
+        message
+    }
+}

--- a/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
+++ b/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
@@ -22,8 +22,3 @@ extension PaymentRequest.Fixtures {
         }
     }
 }
-
-extension TransferPayload.Fixtures.Default {
-    fileprivate static let base64Entropy = "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ="
-    fileprivate static let base64Ristretto = "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE="
-}

--- a/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
+++ b/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) 2022 MobileCoin. All rights reserved.
+//
+
+import LibMobileCoin
+@testable import MobileCoin
+
+extension PaymentRequest {
+    enum Fixtures {}
+}
+
+extension PaymentRequest.Fixtures {
+    struct Default {
+        let publicAddress: PublicAddress
+        let externalPublicAddress: External_PublicAddress
+        let paymentValue: UInt64 = 123
+        let memo = "test memo"
+        
+        init() throws {
+            self.publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+            self.externalPublicAddress = External_PublicAddress(publicAddress)
+        }
+    }
+}
+
+extension TransferPayload.Fixtures.Default {
+    fileprivate static let base64Entropy = "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ="
+    fileprivate static let base64Ristretto = "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE="
+}

--- a/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
+++ b/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
@@ -15,7 +15,7 @@ extension PaymentRequest.Fixtures {
         let externalPublicAddress: External_PublicAddress
         let paymentValue: UInt64 = 123
         let memo = "test memo"
-        
+
         init() throws {
             self.publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
             self.externalPublicAddress = External_PublicAddress(publicAddress)

--- a/Tests/Common/Fixtures/Encodings/TransferPayload.swift
+++ b/Tests/Common/Fixtures/Encodings/TransferPayload.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright (c) 2022 MobileCoin. All rights reserved.
+//
+
+import LibMobileCoin
+@testable import MobileCoin
+
+extension TransferPayload {
+    enum Fixtures {}
+}
+
+extension TransferPayload.Fixtures {
+    struct Default {
+        let entropyData: Data
+        let entropyData32: Data32
+        let ristretto: RistrettoPublic
+        let ristrettoCompressed: External_CompressedRistretto
+        let memo = "test memo"
+        
+        init() throws {
+            guard let entropyData = Data(base64Encoded: Self.base64Entropy) else {
+                throw TestInitializationError("TransferPayload.Fixture: entropyData is nil, likely an invalid base64Entropy value")
+            }
+            self.entropyData = entropyData
+            
+            guard let entropyData32 = Data32(entropyData) else {
+                throw TestInitializationError("TransferPayload.Fixture: entropyData32 is nil, likely an invalid base64Entropy value")
+            }
+            self.entropyData32 = entropyData32
+            
+            guard let ristretto = RistrettoPublic(base64Encoded: Self.base64Ristretto) else {
+                throw TestInitializationError("TransferPayload.Fixture: ristretto is nil, likely an invalid base64Ristretto value")
+            }
+            self.ristretto = ristretto
+
+            self.ristrettoCompressed = External_CompressedRistretto(ristretto)
+        }
+    }
+}
+
+extension TransferPayload.Fixtures.Default {
+    fileprivate static let base64Entropy = "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ="
+    fileprivate static let base64Ristretto = "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE="
+}

--- a/Tests/Common/Fixtures/Encodings/TransferPayload.swift
+++ b/Tests/Common/Fixtures/Encodings/TransferPayload.swift
@@ -16,20 +16,23 @@ extension TransferPayload.Fixtures {
         let ristretto: RistrettoPublic
         let ristrettoCompressed: External_CompressedRistretto
         let memo = "test memo"
-        
+
         init() throws {
             guard let entropyData = Data(base64Encoded: Self.base64Entropy) else {
-                throw TestInitializationError("TransferPayload.Fixture: entropyData is nil, likely an invalid base64Entropy value")
+                throw TestInitializationError("TransferPayload.Fixture: entropyData is nil,"
+                                              + " likely an invalid base64Entropy value")
             }
             self.entropyData = entropyData
-            
+
             guard let entropyData32 = Data32(entropyData) else {
-                throw TestInitializationError("TransferPayload.Fixture: entropyData32 is nil, likely an invalid base64Entropy value")
+                throw TestInitializationError("TransferPayload.Fixture: entropyData32 is nil,"
+                                              + " likely an invalid base64Entropy value")
             }
             self.entropyData32 = entropyData32
-            
+
             guard let ristretto = RistrettoPublic(base64Encoded: Self.base64Ristretto) else {
-                throw TestInitializationError("TransferPayload.Fixture: ristretto is nil, likely an invalid base64Ristretto value")
+                throw TestInitializationError("TransferPayload.Fixture: ristretto is nil,"
+                                              + " likely an invalid base64Ristretto value")
             }
             self.ristretto = ristretto
 

--- a/Tests/Unit/Encodings/PaymentRequestTests.swift
+++ b/Tests/Unit/Encodings/PaymentRequestTests.swift
@@ -160,4 +160,16 @@ class PaymentRequestTests: XCTestCase {
         }
     }
 
+    func testDecodingFromPrintableWithInvalidPublicAddress() throws {
+        // create Printable_PaymentRequest
+        var printablePaymentRequest = Printable_PaymentRequest()
+        printablePaymentRequest.publicAddress = External_PublicAddress()
+
+        // create PaymentRequest from Printable_PaymentRequest
+        let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+        // Validate
+        XCTAssertNil(paymentRequest)
+    }
+
 }

--- a/Tests/Unit/Encodings/PaymentRequestTests.swift
+++ b/Tests/Unit/Encodings/PaymentRequestTests.swift
@@ -8,160 +8,158 @@ import XCTest
 
 class PaymentRequestTests: XCTestCase {
 
-    static let publicAddress = (try? PublicAddress.Fixtures.Init())!.accountKey.publicAddress
-    static let externalPublicAddress = External_PublicAddress(publicAddress)
     static let value: UInt64 = 123
     static let memo = "test memo"
 
     func testEncodingToPrintableNoValueNoMemom() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create PaymentRequest
-            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress)
-            XCTAssertNotNil(paymentRequest)
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create Printable_PaymentRequest from PaymentRequest
-            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+        // create PaymentRequest
+        let paymentRequest = PaymentRequest(publicAddress: publicAddress)
+        XCTAssertNotNil(paymentRequest)
 
-            // Validate
-            XCTAssertNotNil(printablePaymentRequest)
-            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
-            XCTAssertEqual(printablePaymentRequest.value, 0)
-            XCTAssertEqual(printablePaymentRequest.memo.count, 0)
-        })
+        // create Printable_PaymentRequest from PaymentRequest
+        let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+        // Validate
+        XCTAssertNotNil(printablePaymentRequest)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.value, 0)
+        XCTAssertEqual(printablePaymentRequest.memo.count, 0)
     }
 
     func testDecodingFromPrintableNoValueNoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_PaymentRequest
-            var printablePaymentRequest = Printable_PaymentRequest()
-            printablePaymentRequest.publicAddress = Self.externalPublicAddress
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create PaymentRequest from Printable_PaymentRequest
-            let paymentRequest = PaymentRequest(printablePaymentRequest)
+        // create Printable_PaymentRequest
+        var printablePaymentRequest = Printable_PaymentRequest()
+        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
 
-            // Validate
-            XCTAssertNotNil(paymentRequest)
-            if let paymentRequest = paymentRequest {
-                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
-                XCTAssertNil(paymentRequest.value)
-                XCTAssertNil(paymentRequest.memo)
-            }
-        })
+        // create PaymentRequest from Printable_PaymentRequest
+        let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+        // Validate
+        XCTAssertNotNil(paymentRequest)
+        if let paymentRequest = paymentRequest {
+            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertNil(paymentRequest.value)
+            XCTAssertNil(paymentRequest.memo)
+        }
     }
 
     func testEncodingToPrintableNoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create PaymentRequest
-            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress,
-                                                value: Self.value)
-            XCTAssertNotNil(paymentRequest)
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create Printable_PaymentRequest from PaymentRequest
-            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+        // create PaymentRequest
+        let paymentRequest = PaymentRequest(publicAddress: publicAddress,
+                                            value: Self.value)
+        XCTAssertNotNil(paymentRequest)
 
-            // Validate
-            XCTAssertNotNil(printablePaymentRequest)
-            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
-            XCTAssertEqual(printablePaymentRequest.value, Self.value)
-            XCTAssertEqual(printablePaymentRequest.memo.count, 0)
-        })
+        // create Printable_PaymentRequest from PaymentRequest
+        let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+        // Validate
+        XCTAssertNotNil(printablePaymentRequest)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.value, Self.value)
+        XCTAssertEqual(printablePaymentRequest.memo.count, 0)
     }
 
     func testDecodingFromPrintableNoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_PaymentRequest
-            var printablePaymentRequest = Printable_PaymentRequest()
-            printablePaymentRequest.publicAddress = Self.externalPublicAddress
-            printablePaymentRequest.value = Self.value
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create PaymentRequest from Printable_PaymentRequest
-            let paymentRequest = PaymentRequest(printablePaymentRequest)
+        // create Printable_PaymentRequest
+        var printablePaymentRequest = Printable_PaymentRequest()
+        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
+        printablePaymentRequest.value = Self.value
 
-            // Validate
-            XCTAssertNotNil(paymentRequest)
-            if let paymentRequest = paymentRequest {
-                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
-                XCTAssertEqual(paymentRequest.value, Self.value)
-                XCTAssertNil(paymentRequest.memo)
-            }
-        })
+        // create PaymentRequest from Printable_PaymentRequest
+        let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+        // Validate
+        XCTAssertNotNil(paymentRequest)
+        if let paymentRequest = paymentRequest {
+            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertEqual(paymentRequest.value, Self.value)
+            XCTAssertNil(paymentRequest.memo)
+        }
     }
 
     func testEncodingToPrintableNoValue() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create PaymentRequest
-            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress, memo: Self.memo)
-            XCTAssertNotNil(paymentRequest)
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create Printable_PaymentRequest from PaymentRequest
-            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+        // create PaymentRequest
+        let paymentRequest = PaymentRequest(publicAddress: publicAddress, memo: Self.memo)
+        XCTAssertNotNil(paymentRequest)
 
-            // Validate
-            XCTAssertNotNil(printablePaymentRequest)
-            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
-            XCTAssertEqual(printablePaymentRequest.value, 0)
-            XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
-        })
+        // create Printable_PaymentRequest from PaymentRequest
+        let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+        // Validate
+        XCTAssertNotNil(printablePaymentRequest)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.value, 0)
+        XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
     }
 
     func testDecodingFromPrintableNoValue() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_PaymentRequest
-            var printablePaymentRequest = Printable_PaymentRequest()
-            printablePaymentRequest.publicAddress = Self.externalPublicAddress
-            printablePaymentRequest.memo = Self.memo
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create PaymentRequest from Printable_PaymentRequest
-            let paymentRequest = PaymentRequest(printablePaymentRequest)
+        // create Printable_PaymentRequest
+        var printablePaymentRequest = Printable_PaymentRequest()
+        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
+        printablePaymentRequest.memo = Self.memo
 
-            // Validate
-            XCTAssertNotNil(paymentRequest)
-            if let paymentRequest = paymentRequest {
-                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
-                XCTAssertNil(paymentRequest.value)
-                XCTAssertEqual(paymentRequest.memo, Self.memo)
-            }
-        })
+        // create PaymentRequest from Printable_PaymentRequest
+        let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+        // Validate
+        XCTAssertNotNil(paymentRequest)
+        if let paymentRequest = paymentRequest {
+            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertNil(paymentRequest.value)
+            XCTAssertEqual(paymentRequest.memo, Self.memo)
+        }
     }
 
     func testEncodingToPrintable() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create PaymentRequest
-            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress,
-                                                value: Self.value,
-                                                memo: Self.memo)
-            XCTAssertNotNil(paymentRequest)
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create Printable_PaymentRequest from PaymentRequest
-            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+        // create PaymentRequest
+        let paymentRequest = PaymentRequest(publicAddress: publicAddress,
+                                            value: Self.value,
+                                            memo: Self.memo)
+        XCTAssertNotNil(paymentRequest)
 
-            // Validate
-            XCTAssertNotNil(printablePaymentRequest)
-            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
-            XCTAssertEqual(printablePaymentRequest.value, Self.value)
-            XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
-        })
+        // create Printable_PaymentRequest from PaymentRequest
+        let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+        // Validate
+        XCTAssertNotNil(printablePaymentRequest)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.value, Self.value)
+        XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
     }
 
     func testDecodingFromPrintable() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_PaymentRequest
-            var printablePaymentRequest = Printable_PaymentRequest()
-            printablePaymentRequest.publicAddress = Self.externalPublicAddress
-            printablePaymentRequest.value = Self.value
-            printablePaymentRequest.memo = Self.memo
+        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
 
-            // create PaymentRequest from Printable_PaymentRequest
-            let paymentRequest = PaymentRequest(printablePaymentRequest)
+        // create Printable_PaymentRequest
+        var printablePaymentRequest = Printable_PaymentRequest()
+        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
+        printablePaymentRequest.value = Self.value
+        printablePaymentRequest.memo = Self.memo
 
-            // Validate
-            XCTAssertNotNil(paymentRequest)
-            if let paymentRequest = paymentRequest {
-                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
-                XCTAssertEqual(paymentRequest.value, Self.value)
-                XCTAssertEqual(paymentRequest.memo, Self.memo)
-            }
-        })
+        // create PaymentRequest from Printable_PaymentRequest
+        let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+        // Validate
+        XCTAssertNotNil(paymentRequest)
+        if let paymentRequest = paymentRequest {
+            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertEqual(paymentRequest.value, Self.value)
+            XCTAssertEqual(paymentRequest.memo, Self.memo)
+        }
     }
 
 }

--- a/Tests/Unit/Encodings/PaymentRequestTests.swift
+++ b/Tests/Unit/Encodings/PaymentRequestTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//  Copyright (c) 2022 MobileCoin. All rights reserved.
 //
 
 import LibMobileCoin
@@ -8,14 +8,11 @@ import XCTest
 
 class PaymentRequestTests: XCTestCase {
 
-    static let value: UInt64 = 123
-    static let memo = "test memo"
-
     func testEncodingToPrintableNoValueNoMemom() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create PaymentRequest
-        let paymentRequest = PaymentRequest(publicAddress: publicAddress)
+        let paymentRequest = PaymentRequest(publicAddress: defaultFixture.publicAddress)
         XCTAssertNotNil(paymentRequest)
 
         // create Printable_PaymentRequest from PaymentRequest
@@ -23,17 +20,17 @@ class PaymentRequestTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printablePaymentRequest)
-        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.publicAddress, defaultFixture.externalPublicAddress)
         XCTAssertEqual(printablePaymentRequest.value, 0)
         XCTAssertEqual(printablePaymentRequest.memo.count, 0)
     }
 
     func testDecodingFromPrintableNoValueNoMemo() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create Printable_PaymentRequest
         var printablePaymentRequest = Printable_PaymentRequest()
-        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
+        printablePaymentRequest.publicAddress = External_PublicAddress(defaultFixture.publicAddress)
 
         // create PaymentRequest from Printable_PaymentRequest
         let paymentRequest = PaymentRequest(printablePaymentRequest)
@@ -41,18 +38,18 @@ class PaymentRequestTests: XCTestCase {
         // Validate
         XCTAssertNotNil(paymentRequest)
         if let paymentRequest = paymentRequest {
-            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertEqual(paymentRequest.publicAddress, defaultFixture.publicAddress)
             XCTAssertNil(paymentRequest.value)
             XCTAssertNil(paymentRequest.memo)
         }
     }
 
     func testEncodingToPrintableNoMemo() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create PaymentRequest
-        let paymentRequest = PaymentRequest(publicAddress: publicAddress,
-                                            value: Self.value)
+        let paymentRequest = PaymentRequest(publicAddress: defaultFixture.publicAddress,
+                                            value: defaultFixture.paymentValue)
         XCTAssertNotNil(paymentRequest)
 
         // create Printable_PaymentRequest from PaymentRequest
@@ -60,18 +57,18 @@ class PaymentRequestTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printablePaymentRequest)
-        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
-        XCTAssertEqual(printablePaymentRequest.value, Self.value)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, defaultFixture.externalPublicAddress)
+        XCTAssertEqual(printablePaymentRequest.value, defaultFixture.paymentValue)
         XCTAssertEqual(printablePaymentRequest.memo.count, 0)
     }
 
     func testDecodingFromPrintableNoMemo() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create Printable_PaymentRequest
         var printablePaymentRequest = Printable_PaymentRequest()
-        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
-        printablePaymentRequest.value = Self.value
+        printablePaymentRequest.publicAddress = defaultFixture.externalPublicAddress
+        printablePaymentRequest.value = defaultFixture.paymentValue
 
         // create PaymentRequest from Printable_PaymentRequest
         let paymentRequest = PaymentRequest(printablePaymentRequest)
@@ -79,17 +76,18 @@ class PaymentRequestTests: XCTestCase {
         // Validate
         XCTAssertNotNil(paymentRequest)
         if let paymentRequest = paymentRequest {
-            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
-            XCTAssertEqual(paymentRequest.value, Self.value)
+            XCTAssertEqual(paymentRequest.publicAddress, defaultFixture.publicAddress)
+            XCTAssertEqual(paymentRequest.value, defaultFixture.paymentValue)
             XCTAssertNil(paymentRequest.memo)
         }
     }
 
     func testEncodingToPrintableNoValue() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create PaymentRequest
-        let paymentRequest = PaymentRequest(publicAddress: publicAddress, memo: Self.memo)
+        let paymentRequest = PaymentRequest(publicAddress: defaultFixture.publicAddress,
+                                            memo: defaultFixture.memo)
         XCTAssertNotNil(paymentRequest)
 
         // create Printable_PaymentRequest from PaymentRequest
@@ -97,18 +95,18 @@ class PaymentRequestTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printablePaymentRequest)
-        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
+        XCTAssertEqual(printablePaymentRequest.publicAddress, defaultFixture.externalPublicAddress)
         XCTAssertEqual(printablePaymentRequest.value, 0)
-        XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
+        XCTAssertEqual(printablePaymentRequest.memo, defaultFixture.memo)
     }
 
     func testDecodingFromPrintableNoValue() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create Printable_PaymentRequest
         var printablePaymentRequest = Printable_PaymentRequest()
-        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
-        printablePaymentRequest.memo = Self.memo
+        printablePaymentRequest.publicAddress = defaultFixture.externalPublicAddress
+        printablePaymentRequest.memo = defaultFixture.memo
 
         // create PaymentRequest from Printable_PaymentRequest
         let paymentRequest = PaymentRequest(printablePaymentRequest)
@@ -116,19 +114,19 @@ class PaymentRequestTests: XCTestCase {
         // Validate
         XCTAssertNotNil(paymentRequest)
         if let paymentRequest = paymentRequest {
-            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
+            XCTAssertEqual(paymentRequest.publicAddress, defaultFixture.publicAddress)
             XCTAssertNil(paymentRequest.value)
-            XCTAssertEqual(paymentRequest.memo, Self.memo)
+            XCTAssertEqual(paymentRequest.memo, defaultFixture.memo)
         }
     }
 
     func testEncodingToPrintable() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create PaymentRequest
-        let paymentRequest = PaymentRequest(publicAddress: publicAddress,
-                                            value: Self.value,
-                                            memo: Self.memo)
+        let paymentRequest = PaymentRequest(publicAddress: defaultFixture.publicAddress,
+                                            value: defaultFixture.paymentValue,
+                                            memo: defaultFixture.memo)
         XCTAssertNotNil(paymentRequest)
 
         // create Printable_PaymentRequest from PaymentRequest
@@ -136,19 +134,19 @@ class PaymentRequestTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printablePaymentRequest)
-        XCTAssertEqual(printablePaymentRequest.publicAddress, External_PublicAddress(publicAddress))
-        XCTAssertEqual(printablePaymentRequest.value, Self.value)
-        XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
+        XCTAssertEqual(printablePaymentRequest.publicAddress, defaultFixture.externalPublicAddress)
+        XCTAssertEqual(printablePaymentRequest.value, defaultFixture.paymentValue)
+        XCTAssertEqual(printablePaymentRequest.memo, defaultFixture.memo)
     }
 
     func testDecodingFromPrintable() throws {
-        let publicAddress = try PublicAddress.Fixtures.Init().accountKey.publicAddress
+        let defaultFixture = try PaymentRequest.Fixtures.Default()
 
         // create Printable_PaymentRequest
         var printablePaymentRequest = Printable_PaymentRequest()
-        printablePaymentRequest.publicAddress = External_PublicAddress(publicAddress)
-        printablePaymentRequest.value = Self.value
-        printablePaymentRequest.memo = Self.memo
+        printablePaymentRequest.publicAddress = defaultFixture.externalPublicAddress
+        printablePaymentRequest.value = defaultFixture.paymentValue
+        printablePaymentRequest.memo = defaultFixture.memo
 
         // create PaymentRequest from Printable_PaymentRequest
         let paymentRequest = PaymentRequest(printablePaymentRequest)
@@ -156,9 +154,9 @@ class PaymentRequestTests: XCTestCase {
         // Validate
         XCTAssertNotNil(paymentRequest)
         if let paymentRequest = paymentRequest {
-            XCTAssertEqual(paymentRequest.publicAddress, publicAddress)
-            XCTAssertEqual(paymentRequest.value, Self.value)
-            XCTAssertEqual(paymentRequest.memo, Self.memo)
+            XCTAssertEqual(paymentRequest.publicAddress, defaultFixture.publicAddress)
+            XCTAssertEqual(paymentRequest.value, defaultFixture.paymentValue)
+            XCTAssertEqual(paymentRequest.memo, defaultFixture.memo)
         }
     }
 

--- a/Tests/Unit/Encodings/PaymentRequestTests.swift
+++ b/Tests/Unit/Encodings/PaymentRequestTests.swift
@@ -1,0 +1,167 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import LibMobileCoin
+@testable import MobileCoin
+import XCTest
+
+class PaymentRequestTests: XCTestCase {
+
+    static let publicAddress = (try? PublicAddress.Fixtures.Init())!.accountKey.publicAddress
+    static let externalPublicAddress = External_PublicAddress(publicAddress)
+    static let value: UInt64 = 123
+    static let memo = "test memo"
+
+    func testEncodingToPrintableNoValueNoMemom() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create PaymentRequest
+            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress)
+            XCTAssertNotNil(paymentRequest)
+
+            // create Printable_PaymentRequest from PaymentRequest
+            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+            // Validate
+            XCTAssertNotNil(printablePaymentRequest)
+            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
+            XCTAssertEqual(printablePaymentRequest.value, 0)
+            XCTAssertEqual(printablePaymentRequest.memo.count, 0)
+        })
+    }
+
+    func testDecodingFromPrintableNoValueNoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_PaymentRequest
+            var printablePaymentRequest = Printable_PaymentRequest()
+            printablePaymentRequest.publicAddress = Self.externalPublicAddress
+
+            // create PaymentRequest from Printable_PaymentRequest
+            let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+            // Validate
+            XCTAssertNotNil(paymentRequest)
+            if let paymentRequest = paymentRequest {
+                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
+                XCTAssertNil(paymentRequest.value)
+                XCTAssertNil(paymentRequest.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintableNoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create PaymentRequest
+            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress,
+                                                value: Self.value)
+            XCTAssertNotNil(paymentRequest)
+
+            // create Printable_PaymentRequest from PaymentRequest
+            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+            // Validate
+            XCTAssertNotNil(printablePaymentRequest)
+            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
+            XCTAssertEqual(printablePaymentRequest.value, Self.value)
+            XCTAssertEqual(printablePaymentRequest.memo.count, 0)
+        })
+    }
+
+    func testDecodingFromPrintableNoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_PaymentRequest
+            var printablePaymentRequest = Printable_PaymentRequest()
+            printablePaymentRequest.publicAddress = Self.externalPublicAddress
+            printablePaymentRequest.value = Self.value
+
+            // create PaymentRequest from Printable_PaymentRequest
+            let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+            // Validate
+            XCTAssertNotNil(paymentRequest)
+            if let paymentRequest = paymentRequest {
+                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
+                XCTAssertEqual(paymentRequest.value, Self.value)
+                XCTAssertNil(paymentRequest.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintableNoValue() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create PaymentRequest
+            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress, memo: Self.memo)
+            XCTAssertNotNil(paymentRequest)
+
+            // create Printable_PaymentRequest from PaymentRequest
+            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+            // Validate
+            XCTAssertNotNil(printablePaymentRequest)
+            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
+            XCTAssertEqual(printablePaymentRequest.value, 0)
+            XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
+        })
+    }
+
+    func testDecodingFromPrintableNoValue() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_PaymentRequest
+            var printablePaymentRequest = Printable_PaymentRequest()
+            printablePaymentRequest.publicAddress = Self.externalPublicAddress
+            printablePaymentRequest.memo = Self.memo
+
+            // create PaymentRequest from Printable_PaymentRequest
+            let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+            // Validate
+            XCTAssertNotNil(paymentRequest)
+            if let paymentRequest = paymentRequest {
+                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
+                XCTAssertNil(paymentRequest.value)
+                XCTAssertEqual(paymentRequest.memo, Self.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintable() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create PaymentRequest
+            let paymentRequest = PaymentRequest(publicAddress: Self.publicAddress,
+                                                value: Self.value,
+                                                memo: Self.memo)
+            XCTAssertNotNil(paymentRequest)
+
+            // create Printable_PaymentRequest from PaymentRequest
+            let printablePaymentRequest = Printable_PaymentRequest(paymentRequest)
+
+            // Validate
+            XCTAssertNotNil(printablePaymentRequest)
+            XCTAssertEqual(printablePaymentRequest.publicAddress, Self.externalPublicAddress)
+            XCTAssertEqual(printablePaymentRequest.value, Self.value)
+            XCTAssertEqual(printablePaymentRequest.memo, Self.memo)
+        })
+    }
+
+    func testDecodingFromPrintable() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_PaymentRequest
+            var printablePaymentRequest = Printable_PaymentRequest()
+            printablePaymentRequest.publicAddress = Self.externalPublicAddress
+            printablePaymentRequest.value = Self.value
+            printablePaymentRequest.memo = Self.memo
+
+            // create PaymentRequest from Printable_PaymentRequest
+            let paymentRequest = PaymentRequest(printablePaymentRequest)
+
+            // Validate
+            XCTAssertNotNil(paymentRequest)
+            if let paymentRequest = paymentRequest {
+                XCTAssertEqual(paymentRequest.publicAddress, Self.publicAddress)
+                XCTAssertEqual(paymentRequest.value, Self.value)
+                XCTAssertEqual(paymentRequest.memo, Self.memo)
+            }
+        })
+    }
+
+}

--- a/Tests/Unit/Encodings/TransferPayloadTests.swift
+++ b/Tests/Unit/Encodings/TransferPayloadTests.swift
@@ -179,4 +179,84 @@ class TransferPayloadTests: XCTestCase {
             XCTAssertEqual(transferPayload.memo, defaultFixture.memo)
         }
     }
+
+    func testDecodingFailsWithValidRootEntropyInvalidNonEmptyBip39() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
+        // create invalid Printable_TransferPayload with both bip39 and rootEntropy
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = defaultFixture.entropyData
+        printableTransferPayload.bip39Entropy = Data(count: 10)
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
+
+        // attempt to create TransferPayload from Printable_TransferPayload - should fail
+        let transferPayload = TransferPayload(printableTransferPayload)
+
+        XCTAssertNil(transferPayload)
+    }
+
+    func testDecodingFailsWithValidBip39InvalidNonEmptyRootEntropy() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
+        // create invalid Printable_TransferPayload with both bip39 and rootEntropy
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = Data(count: 10)
+        printableTransferPayload.bip39Entropy = defaultFixture.entropyData
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
+
+        // attempt to create TransferPayload from Printable_TransferPayload - should fail
+        let transferPayload = TransferPayload(printableTransferPayload)
+
+        XCTAssertNil(transferPayload)
+    }
+
+    func testDecodingFailsWithBothBip39AndRootEntropySet() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
+        // create invalid Printable_TransferPayload with both bip39 and rootEntropy
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = defaultFixture.entropyData
+        printableTransferPayload.bip39Entropy = defaultFixture.entropyData
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
+
+        // attempt to create TransferPayload from Printable_TransferPayload - should fail
+        let transferPayload = TransferPayload(printableTransferPayload)
+
+        XCTAssertNil(transferPayload)
+    }
+
+    func testDecodingFailsWithBip39AndRootEntropySetToEmptyData() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
+        // create invalid Printable_TransferPayload with both bip39 and rootEntropy
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = Data()
+        printableTransferPayload.bip39Entropy = Data()
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
+
+        // attempt to create TransferPayload from Printable_TransferPayload - should fail
+        let transferPayload = TransferPayload(printableTransferPayload)
+
+        XCTAssertNil(transferPayload)
+    }
+
+    func testDecodingFailsWhenNoTxOutPublicKey() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
+        // create invalid Printable_TransferPayload with both bip39 and rootEntropy
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = defaultFixture.entropyData
+        printableTransferPayload.bip39Entropy = Data()
+        printableTransferPayload.txOutPublicKey = External_CompressedRistretto()
+        printableTransferPayload.memo = defaultFixture.memo
+
+        // attempt to create TransferPayload from Printable_TransferPayload - should fail
+        let transferPayload = TransferPayload(printableTransferPayload)
+
+        XCTAssertNil(transferPayload)
+    }
 }

--- a/Tests/Unit/Encodings/TransferPayloadTests.swift
+++ b/Tests/Unit/Encodings/TransferPayloadTests.swift
@@ -1,0 +1,191 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import LibMobileCoin
+@testable import MobileCoin
+import XCTest
+
+class TransferPayloadTests: XCTestCase {
+
+    // The base64Encoded string below will decode to 32 bytes of data for a valid Data32
+    static var entropyData = Data(base64Encoded: "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ=")!
+    static let entropyData32 = Data32(entropyData)!
+    static let ristretto = RistrettoPublic(base64Encoded:
+                                            "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!
+    static let ristrettoCompressed = External_CompressedRistretto(ristretto)
+    static let memo = "test memo"
+
+    func testEncodingToPrintableWithBip39NoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create TransferPayload
+            let transferPayload = TransferPayload(
+                bip39: Self.entropyData32,
+                txOutPublicKey: Self.ristretto)
+            XCTAssertNotNil(transferPayload)
+
+            // create Printable_TransferPayload from TransferPayload
+            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+
+            // Validate
+            XCTAssertNotNil(printableTransferPayload)
+            XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
+            XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
+            XCTAssertEqual(printableTransferPayload.txOutPublicKey,
+                           Self.ristrettoCompressed)
+            XCTAssertEqual(printableTransferPayload.memo.count, 0)
+        })
+    }
+
+    func testDecodingFromPrintableWithBip39NoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_TransferPayload
+            var printableTransferPayload = Printable_TransferPayload()
+            printableTransferPayload.bip39Entropy = Self.entropyData
+            printableTransferPayload.rootEntropy = Data()
+            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+
+            // create TransferPayload from Printable_TransferPayload
+            let transferPayload = TransferPayload(printableTransferPayload)
+            
+            // Validate
+            XCTAssertNotNil(transferPayload)
+            if let transferPayload = transferPayload {
+                XCTAssertNil(transferPayload.rootEntropy32)
+                XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
+                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+                XCTAssertNil(transferPayload.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintableWithBip39AndMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create TransferPayload
+            let transferPayload = TransferPayload(
+                bip39: Self.entropyData32,
+                txOutPublicKey: Self.ristretto,
+                memo: Self.memo)
+            XCTAssertNotNil(transferPayload)
+
+            // create Printable_TransferPayload from TransferPayload
+            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+
+            // Validate
+            XCTAssertNotNil(printableTransferPayload)
+            XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
+            XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
+            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+            XCTAssertEqual(printableTransferPayload.memo, Self.memo)
+        })
+    }
+
+    func testDecodingFromPrintableWithBip39AndMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_TransferPayload
+            var printableTransferPayload = Printable_TransferPayload()
+            printableTransferPayload.bip39Entropy = Self.entropyData
+            printableTransferPayload.rootEntropy = Data()
+            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+            printableTransferPayload.memo = Self.memo
+
+            // create TransferPayload from Printable_TransferPayload
+            let transferPayload = TransferPayload(printableTransferPayload)
+
+            // Validate
+            XCTAssertNotNil(transferPayload)
+            if let transferPayload = transferPayload {
+                XCTAssertNil(transferPayload.rootEntropy32)
+                XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
+                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+                XCTAssertEqual(transferPayload.memo, Self.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintableWithRootEntropyNoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create TransferPayload
+            let transferPayload = TransferPayload(
+                rootEntropy: Self.entropyData32,
+                txOutPublicKey: Self.ristretto)
+            XCTAssertNotNil(transferPayload)
+
+            // create Printable_TransferPayload from TransferPayload
+            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+
+            // Validate
+            XCTAssertNotNil(printableTransferPayload)
+            XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+            XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
+            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+            XCTAssertEqual(printableTransferPayload.memo.count, 0)
+        })
+    }
+
+    func testDecodingFromPrintableWithRootEntropyNoMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_TransferPayload
+            var printableTransferPayload = Printable_TransferPayload()
+            printableTransferPayload.rootEntropy = Self.entropyData
+            printableTransferPayload.bip39Entropy = Data()
+            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+
+            // create TransferPayload from Printable_TransferPayload
+            let transferPayload = TransferPayload(printableTransferPayload)
+
+            // Validate
+            XCTAssertNotNil(transferPayload)
+            if let transferPayload = transferPayload {
+                XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+                XCTAssertNil(transferPayload.bip39_32)
+                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+                XCTAssertNil(transferPayload.memo)
+            }
+        })
+    }
+
+    func testEncodingToPrintableWithRootEntropyAndMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create TransferPayload
+            let transferPayload = TransferPayload(
+                rootEntropy: Self.entropyData32,
+                txOutPublicKey: Self.ristretto,
+                memo: Self.memo)
+            XCTAssertNotNil(transferPayload)
+
+            // create Printable_TransferPayload from TransferPayload
+            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+
+            // Validate
+            XCTAssertNotNil(printableTransferPayload)
+            XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+            XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
+            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+            XCTAssertEqual(printableTransferPayload.memo, Self.memo)
+        })
+    }
+
+    func testDecodingFromPrintableWithRootEntropyAndMemo() throws {
+        XCTAssertNoThrow(evaluating: {
+            // create Printable_TransferPayload
+            var printableTransferPayload = Printable_TransferPayload()
+            printableTransferPayload.rootEntropy = Self.entropyData
+            printableTransferPayload.bip39Entropy = Data()
+            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+            printableTransferPayload.memo = Self.memo
+
+            // create TransferPayload from Printable_TransferPayload
+            let transferPayload = TransferPayload(printableTransferPayload)
+
+            // Validate
+            XCTAssertNotNil(transferPayload)
+            if let transferPayload = transferPayload {
+                XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+                XCTAssertNil(transferPayload.bip39_32)
+                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+                XCTAssertEqual(transferPayload.memo, Self.memo)
+            }
+        })
+    }
+}

--- a/Tests/Unit/Encodings/TransferPayloadTests.swift
+++ b/Tests/Unit/Encodings/TransferPayloadTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//  Copyright (c) 2022 MobileCoin. All rights reserved.
 //
 
 import LibMobileCoin
@@ -7,21 +7,14 @@ import LibMobileCoin
 import XCTest
 
 class TransferPayloadTests: XCTestCase {
-    static var
-    
-    // The base64Encoded string below will decode to 32 bytes of data for a valid Data32
-    static var entropyData: Data(base64Encoded: "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ=")!
-    static let entropyData32: Data32 = Data32(entropyData)!
-    static let ristretto = RistrettoPublic(base64Encoded:
-                                            "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!
-    static let ristrettoCompressed = External_CompressedRistretto(ristretto)
-    static let memo = "test memo"
 
     func testEncodingToPrintableWithBip39NoMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create TransferPayload
         let transferPayload = TransferPayload(
-            bip39: Self.entropyData32,
-            txOutPublicKey: Self.ristretto)
+            bip39: defaultFixture.entropyData32,
+            txOutPublicKey: defaultFixture.ristretto)
         XCTAssertNotNil(transferPayload)
 
         // create Printable_TransferPayload from TransferPayload
@@ -30,38 +23,41 @@ class TransferPayloadTests: XCTestCase {
         // Validate
         XCTAssertNotNil(printableTransferPayload)
         XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
-        XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
-        XCTAssertEqual(printableTransferPayload.txOutPublicKey,
-                       Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy, defaultFixture.entropyData)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, defaultFixture.ristrettoCompressed)
         XCTAssertEqual(printableTransferPayload.memo.count, 0)
     }
 
     func testDecodingFromPrintableWithBip39NoMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create Printable_TransferPayload
         var printableTransferPayload = Printable_TransferPayload()
-        printableTransferPayload.bip39Entropy = Self.entropyData
+        printableTransferPayload.bip39Entropy = defaultFixture.entropyData
         printableTransferPayload.rootEntropy = Data()
-        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
 
         // create TransferPayload from Printable_TransferPayload
         let transferPayload = TransferPayload(printableTransferPayload)
-        
+
         // Validate
         XCTAssertNotNil(transferPayload)
         if let transferPayload = transferPayload {
             XCTAssertNil(transferPayload.rootEntropy32)
-            XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
-            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertEqual(transferPayload.bip39_32, defaultFixture.entropyData32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, defaultFixture.ristretto)
             XCTAssertNil(transferPayload.memo)
         }
     }
 
     func testEncodingToPrintableWithBip39AndMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create TransferPayload
         let transferPayload = TransferPayload(
-            bip39: Self.entropyData32,
-            txOutPublicKey: Self.ristretto,
-            memo: Self.memo)
+            bip39: defaultFixture.entropyData32,
+            txOutPublicKey: defaultFixture.ristretto,
+            memo: defaultFixture.memo)
         XCTAssertNotNil(transferPayload)
 
         // create Printable_TransferPayload from TransferPayload
@@ -70,18 +66,20 @@ class TransferPayloadTests: XCTestCase {
         // Validate
         XCTAssertNotNil(printableTransferPayload)
         XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
-        XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
-        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
-        XCTAssertEqual(printableTransferPayload.memo, Self.memo)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy, defaultFixture.entropyData)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, defaultFixture.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo, defaultFixture.memo)
     }
 
     func testDecodingFromPrintableWithBip39AndMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create Printable_TransferPayload
         var printableTransferPayload = Printable_TransferPayload()
-        printableTransferPayload.bip39Entropy = Self.entropyData
+        printableTransferPayload.bip39Entropy = defaultFixture.entropyData
         printableTransferPayload.rootEntropy = Data()
-        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
-        printableTransferPayload.memo = Self.memo
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
 
         // create TransferPayload from Printable_TransferPayload
         let transferPayload = TransferPayload(printableTransferPayload)
@@ -90,17 +88,19 @@ class TransferPayloadTests: XCTestCase {
         XCTAssertNotNil(transferPayload)
         if let transferPayload = transferPayload {
             XCTAssertNil(transferPayload.rootEntropy32)
-            XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
-            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-            XCTAssertEqual(transferPayload.memo, Self.memo)
+            XCTAssertEqual(transferPayload.bip39_32, defaultFixture.entropyData32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, defaultFixture.ristretto)
+            XCTAssertEqual(transferPayload.memo, defaultFixture.memo)
         }
     }
 
     func testEncodingToPrintableWithRootEntropyNoMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create TransferPayload
         let transferPayload = TransferPayload(
-            rootEntropy: Self.entropyData32,
-            txOutPublicKey: Self.ristretto)
+            rootEntropy: defaultFixture.entropyData32,
+            txOutPublicKey: defaultFixture.ristretto)
         XCTAssertNotNil(transferPayload)
 
         // create Printable_TransferPayload from TransferPayload
@@ -108,18 +108,20 @@ class TransferPayloadTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printableTransferPayload)
-        XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.rootEntropy, defaultFixture.entropyData)
         XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
-        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, defaultFixture.ristrettoCompressed)
         XCTAssertEqual(printableTransferPayload.memo.count, 0)
     }
 
     func testDecodingFromPrintableWithRootEntropyNoMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create Printable_TransferPayload
         var printableTransferPayload = Printable_TransferPayload()
-        printableTransferPayload.rootEntropy = Self.entropyData
+        printableTransferPayload.rootEntropy = defaultFixture.entropyData
         printableTransferPayload.bip39Entropy = Data()
-        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
 
         // create TransferPayload from Printable_TransferPayload
         let transferPayload = TransferPayload(printableTransferPayload)
@@ -127,19 +129,21 @@ class TransferPayloadTests: XCTestCase {
         // Validate
         XCTAssertNotNil(transferPayload)
         if let transferPayload = transferPayload {
-            XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+            XCTAssertEqual(transferPayload.rootEntropy32, defaultFixture.entropyData32)
             XCTAssertNil(transferPayload.bip39_32)
-            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertEqual(transferPayload.txOutPublicKey, defaultFixture.ristretto)
             XCTAssertNil(transferPayload.memo)
         }
     }
 
     func testEncodingToPrintableWithRootEntropyAndMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create TransferPayload
         let transferPayload = TransferPayload(
-            rootEntropy: Self.entropyData32,
-            txOutPublicKey: Self.ristretto,
-            memo: Self.memo)
+            rootEntropy: defaultFixture.entropyData32,
+            txOutPublicKey: defaultFixture.ristretto,
+            memo: defaultFixture.memo)
         XCTAssertNotNil(transferPayload)
 
         // create Printable_TransferPayload from TransferPayload
@@ -147,19 +151,21 @@ class TransferPayloadTests: XCTestCase {
 
         // Validate
         XCTAssertNotNil(printableTransferPayload)
-        XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.rootEntropy, defaultFixture.entropyData)
         XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
-        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
-        XCTAssertEqual(printableTransferPayload.memo, Self.memo)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, defaultFixture.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo, defaultFixture.memo)
     }
 
     func testDecodingFromPrintableWithRootEntropyAndMemo() throws {
+        let defaultFixture = try TransferPayload.Fixtures.Default()
+
         // create Printable_TransferPayload
         var printableTransferPayload = Printable_TransferPayload()
-        printableTransferPayload.rootEntropy = Self.entropyData
+        printableTransferPayload.rootEntropy = defaultFixture.entropyData
         printableTransferPayload.bip39Entropy = Data()
-        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
-        printableTransferPayload.memo = Self.memo
+        printableTransferPayload.txOutPublicKey = defaultFixture.ristrettoCompressed
+        printableTransferPayload.memo = defaultFixture.memo
 
         // create TransferPayload from Printable_TransferPayload
         let transferPayload = TransferPayload(printableTransferPayload)
@@ -167,10 +173,10 @@ class TransferPayloadTests: XCTestCase {
         // Validate
         XCTAssertNotNil(transferPayload)
         if let transferPayload = transferPayload {
-            XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+            XCTAssertEqual(transferPayload.rootEntropy32, defaultFixture.entropyData32)
             XCTAssertNil(transferPayload.bip39_32)
-            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-            XCTAssertEqual(transferPayload.memo, Self.memo)
+            XCTAssertEqual(transferPayload.txOutPublicKey, defaultFixture.ristretto)
+            XCTAssertEqual(transferPayload.memo, defaultFixture.memo)
         }
     }
 }

--- a/Tests/Unit/Encodings/TransferPayloadTests.swift
+++ b/Tests/Unit/Encodings/TransferPayloadTests.swift
@@ -7,185 +7,170 @@ import LibMobileCoin
 import XCTest
 
 class TransferPayloadTests: XCTestCase {
-
+    static var
+    
     // The base64Encoded string below will decode to 32 bytes of data for a valid Data32
-    static var entropyData = Data(base64Encoded: "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ=")!
-    static let entropyData32 = Data32(entropyData)!
+    static var entropyData: Data(base64Encoded: "ajaEQTHHDeZEZDk1rGYQRF0ErcpmcPa7buRpNchz4hQ=")!
+    static let entropyData32: Data32 = Data32(entropyData)!
     static let ristretto = RistrettoPublic(base64Encoded:
                                             "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!
     static let ristrettoCompressed = External_CompressedRistretto(ristretto)
     static let memo = "test memo"
 
     func testEncodingToPrintableWithBip39NoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create TransferPayload
-            let transferPayload = TransferPayload(
-                bip39: Self.entropyData32,
-                txOutPublicKey: Self.ristretto)
-            XCTAssertNotNil(transferPayload)
+        // create TransferPayload
+        let transferPayload = TransferPayload(
+            bip39: Self.entropyData32,
+            txOutPublicKey: Self.ristretto)
+        XCTAssertNotNil(transferPayload)
 
-            // create Printable_TransferPayload from TransferPayload
-            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+        // create Printable_TransferPayload from TransferPayload
+        let printableTransferPayload = Printable_TransferPayload(transferPayload)
 
-            // Validate
-            XCTAssertNotNil(printableTransferPayload)
-            XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
-            XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
-            XCTAssertEqual(printableTransferPayload.txOutPublicKey,
-                           Self.ristrettoCompressed)
-            XCTAssertEqual(printableTransferPayload.memo.count, 0)
-        })
+        // Validate
+        XCTAssertNotNil(printableTransferPayload)
+        XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey,
+                       Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo.count, 0)
     }
 
     func testDecodingFromPrintableWithBip39NoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_TransferPayload
-            var printableTransferPayload = Printable_TransferPayload()
-            printableTransferPayload.bip39Entropy = Self.entropyData
-            printableTransferPayload.rootEntropy = Data()
-            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        // create Printable_TransferPayload
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.bip39Entropy = Self.entropyData
+        printableTransferPayload.rootEntropy = Data()
+        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
 
-            // create TransferPayload from Printable_TransferPayload
-            let transferPayload = TransferPayload(printableTransferPayload)
-            
-            // Validate
-            XCTAssertNotNil(transferPayload)
-            if let transferPayload = transferPayload {
-                XCTAssertNil(transferPayload.rootEntropy32)
-                XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
-                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-                XCTAssertNil(transferPayload.memo)
-            }
-        })
+        // create TransferPayload from Printable_TransferPayload
+        let transferPayload = TransferPayload(printableTransferPayload)
+        
+        // Validate
+        XCTAssertNotNil(transferPayload)
+        if let transferPayload = transferPayload {
+            XCTAssertNil(transferPayload.rootEntropy32)
+            XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertNil(transferPayload.memo)
+        }
     }
 
     func testEncodingToPrintableWithBip39AndMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create TransferPayload
-            let transferPayload = TransferPayload(
-                bip39: Self.entropyData32,
-                txOutPublicKey: Self.ristretto,
-                memo: Self.memo)
-            XCTAssertNotNil(transferPayload)
+        // create TransferPayload
+        let transferPayload = TransferPayload(
+            bip39: Self.entropyData32,
+            txOutPublicKey: Self.ristretto,
+            memo: Self.memo)
+        XCTAssertNotNil(transferPayload)
 
-            // create Printable_TransferPayload from TransferPayload
-            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+        // create Printable_TransferPayload from TransferPayload
+        let printableTransferPayload = Printable_TransferPayload(transferPayload)
 
-            // Validate
-            XCTAssertNotNil(printableTransferPayload)
-            XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
-            XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
-            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
-            XCTAssertEqual(printableTransferPayload.memo, Self.memo)
-        })
+        // Validate
+        XCTAssertNotNil(printableTransferPayload)
+        XCTAssertEqual(printableTransferPayload.rootEntropy.data.count, 0)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo, Self.memo)
     }
 
     func testDecodingFromPrintableWithBip39AndMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_TransferPayload
-            var printableTransferPayload = Printable_TransferPayload()
-            printableTransferPayload.bip39Entropy = Self.entropyData
-            printableTransferPayload.rootEntropy = Data()
-            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
-            printableTransferPayload.memo = Self.memo
+        // create Printable_TransferPayload
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.bip39Entropy = Self.entropyData
+        printableTransferPayload.rootEntropy = Data()
+        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        printableTransferPayload.memo = Self.memo
 
-            // create TransferPayload from Printable_TransferPayload
-            let transferPayload = TransferPayload(printableTransferPayload)
+        // create TransferPayload from Printable_TransferPayload
+        let transferPayload = TransferPayload(printableTransferPayload)
 
-            // Validate
-            XCTAssertNotNil(transferPayload)
-            if let transferPayload = transferPayload {
-                XCTAssertNil(transferPayload.rootEntropy32)
-                XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
-                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-                XCTAssertEqual(transferPayload.memo, Self.memo)
-            }
-        })
+        // Validate
+        XCTAssertNotNil(transferPayload)
+        if let transferPayload = transferPayload {
+            XCTAssertNil(transferPayload.rootEntropy32)
+            XCTAssertEqual(transferPayload.bip39_32, Self.entropyData32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertEqual(transferPayload.memo, Self.memo)
+        }
     }
 
     func testEncodingToPrintableWithRootEntropyNoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create TransferPayload
-            let transferPayload = TransferPayload(
-                rootEntropy: Self.entropyData32,
-                txOutPublicKey: Self.ristretto)
-            XCTAssertNotNil(transferPayload)
+        // create TransferPayload
+        let transferPayload = TransferPayload(
+            rootEntropy: Self.entropyData32,
+            txOutPublicKey: Self.ristretto)
+        XCTAssertNotNil(transferPayload)
 
-            // create Printable_TransferPayload from TransferPayload
-            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+        // create Printable_TransferPayload from TransferPayload
+        let printableTransferPayload = Printable_TransferPayload(transferPayload)
 
-            // Validate
-            XCTAssertNotNil(printableTransferPayload)
-            XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
-            XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
-            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
-            XCTAssertEqual(printableTransferPayload.memo.count, 0)
-        })
+        // Validate
+        XCTAssertNotNil(printableTransferPayload)
+        XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo.count, 0)
     }
 
     func testDecodingFromPrintableWithRootEntropyNoMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_TransferPayload
-            var printableTransferPayload = Printable_TransferPayload()
-            printableTransferPayload.rootEntropy = Self.entropyData
-            printableTransferPayload.bip39Entropy = Data()
-            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        // create Printable_TransferPayload
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = Self.entropyData
+        printableTransferPayload.bip39Entropy = Data()
+        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
 
-            // create TransferPayload from Printable_TransferPayload
-            let transferPayload = TransferPayload(printableTransferPayload)
+        // create TransferPayload from Printable_TransferPayload
+        let transferPayload = TransferPayload(printableTransferPayload)
 
-            // Validate
-            XCTAssertNotNil(transferPayload)
-            if let transferPayload = transferPayload {
-                XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
-                XCTAssertNil(transferPayload.bip39_32)
-                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-                XCTAssertNil(transferPayload.memo)
-            }
-        })
+        // Validate
+        XCTAssertNotNil(transferPayload)
+        if let transferPayload = transferPayload {
+            XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+            XCTAssertNil(transferPayload.bip39_32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertNil(transferPayload.memo)
+        }
     }
 
     func testEncodingToPrintableWithRootEntropyAndMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create TransferPayload
-            let transferPayload = TransferPayload(
-                rootEntropy: Self.entropyData32,
-                txOutPublicKey: Self.ristretto,
-                memo: Self.memo)
-            XCTAssertNotNil(transferPayload)
+        // create TransferPayload
+        let transferPayload = TransferPayload(
+            rootEntropy: Self.entropyData32,
+            txOutPublicKey: Self.ristretto,
+            memo: Self.memo)
+        XCTAssertNotNil(transferPayload)
 
-            // create Printable_TransferPayload from TransferPayload
-            let printableTransferPayload = Printable_TransferPayload(transferPayload)
+        // create Printable_TransferPayload from TransferPayload
+        let printableTransferPayload = Printable_TransferPayload(transferPayload)
 
-            // Validate
-            XCTAssertNotNil(printableTransferPayload)
-            XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
-            XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
-            XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
-            XCTAssertEqual(printableTransferPayload.memo, Self.memo)
-        })
+        // Validate
+        XCTAssertNotNil(printableTransferPayload)
+        XCTAssertEqual(printableTransferPayload.rootEntropy, Self.entropyData)
+        XCTAssertEqual(printableTransferPayload.bip39Entropy.data.count, 0)
+        XCTAssertEqual(printableTransferPayload.txOutPublicKey, Self.ristrettoCompressed)
+        XCTAssertEqual(printableTransferPayload.memo, Self.memo)
     }
 
     func testDecodingFromPrintableWithRootEntropyAndMemo() throws {
-        XCTAssertNoThrow(evaluating: {
-            // create Printable_TransferPayload
-            var printableTransferPayload = Printable_TransferPayload()
-            printableTransferPayload.rootEntropy = Self.entropyData
-            printableTransferPayload.bip39Entropy = Data()
-            printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
-            printableTransferPayload.memo = Self.memo
+        // create Printable_TransferPayload
+        var printableTransferPayload = Printable_TransferPayload()
+        printableTransferPayload.rootEntropy = Self.entropyData
+        printableTransferPayload.bip39Entropy = Data()
+        printableTransferPayload.txOutPublicKey = Self.ristrettoCompressed
+        printableTransferPayload.memo = Self.memo
 
-            // create TransferPayload from Printable_TransferPayload
-            let transferPayload = TransferPayload(printableTransferPayload)
+        // create TransferPayload from Printable_TransferPayload
+        let transferPayload = TransferPayload(printableTransferPayload)
 
-            // Validate
-            XCTAssertNotNil(transferPayload)
-            if let transferPayload = transferPayload {
-                XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
-                XCTAssertNil(transferPayload.bip39_32)
-                XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
-                XCTAssertEqual(transferPayload.memo, Self.memo)
-            }
-        })
+        // Validate
+        XCTAssertNotNil(transferPayload)
+        if let transferPayload = transferPayload {
+            XCTAssertEqual(transferPayload.rootEntropy32, Self.entropyData32)
+            XCTAssertNil(transferPayload.bip39_32)
+            XCTAssertEqual(transferPayload.txOutPublicKey, Self.ristretto)
+            XCTAssertEqual(transferPayload.memo, Self.memo)
+        }
     }
 }


### PR DESCRIPTION
 * TransferPayload <-> Printable_TransferPayload
 * PaymentRequest <-> Printable_PaymentRequest

### Motivation

Increase unit test code coverage

### In this PR
* Added TransferPayloadTests and PaymentRequestTests to UnitTests
