### PR TITLE
Adjust Public API - Remove Error conformance from `HttpStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-pre9] - 2022-02-03
+
+### Changed
+
+- Simplified Publicly Exposed Error's conformers.
+
 ## [1.2.0-pre8] - 2022-01-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0-pre9] - 2022-02-03
-
-### Changed
-
-- Simplified Publicly Exposed Error's conformers.
-
 ## [1.2.0-pre8] - 2022-01-31
 
 ### Added

--- a/Sources/Network/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
+++ b/Sources/Network/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
@@ -65,8 +65,14 @@ extension ArbitraryHttpConnection {
         func processResponse<Response>(callResult: HttpCallResult<Response>)
             -> Result<Response, ConnectionError>
         {
-            guard callResult.status.isOk, let response = callResult.response else {
-                return .failure(.connectionFailure(String(describing: callResult.status)))
+            guard let status = callResult.status else {
+                return .failure(.connectionFailure(
+                    ["Invalid parameters, request not made.",
+                     callResult.error?.localizedDescription].compactMap({$0}).joined(separator: " ")))
+            }
+            
+            guard status.isOk, let response = callResult.response else {
+                return .failure(.connectionFailure(String(describing: status)))
             }
 
             if let headerFields = callResult.allHeaderFields {

--- a/Sources/Network/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
+++ b/Sources/Network/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
@@ -67,8 +67,10 @@ extension ArbitraryHttpConnection {
         {
             guard let status = callResult.status else {
                 return .failure(.connectionFailure(
-                    ["Invalid parameters, request not made.",
-                     callResult.error?.localizedDescription].compactMap({$0}).joined(separator: " ")))
+                            ["Invalid parameters, request not made.",
+                             callResult.error?.localizedDescription,]
+                                .compactMap({$0})
+                                .joined(separator: " ")))
             }
             
             guard status.isOk, let response = callResult.response else {

--- a/Sources/Network/HTTPS/HttpConnection/HTTPInterface/HTTPStatus.swift
+++ b/Sources/Network/HTTPS/HttpConnection/HTTPInterface/HTTPStatus.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Encapsulates the result of a HTTP call.
-public struct HTTPStatus : Error {
+public struct HTTPStatus {
     
     /// The REST status code
     public var code: Int
@@ -28,15 +28,13 @@ public struct HTTPStatus : Error {
     public static let processingError: HTTPStatus = .init(code: 500, message: "Error")
 }
 
-extension HTTPStatus : CustomStringConvertible {
+extension HTTPStatus: CustomStringConvertible {
     public var description: String {
-        codeDescription + (message ?? "")
+        codeDescription + (["", message].compactMap({ $0 }).joined(separator: " "))
     }
     
     private var codeDescription: String {
         switch code {
-        case 1:
-            return "Unknown Error: "
         case 200:
             return "Success: "
         case 400:
@@ -52,7 +50,7 @@ extension HTTPStatus : CustomStringConvertible {
         case 503:
             return "Unavailable: "
         default:
-            return ""
+            return "Unknown Error: "
         }
     }
 }

--- a/Sources/Network/HTTPS/HttpConnection/HttpConnection.swift
+++ b/Sources/Network/HTTPS/HttpConnection/HttpConnection.swift
@@ -81,12 +81,19 @@ extension HttpConnection {
         func processResponse<Response>(callResult: HttpCallResult<Response>)
             -> Result<Response, ConnectionError>
         {
-            guard [403, 401].contains(callResult.status.code) == false else {
+            
+            guard let status = callResult.status else {
+                return .failure(.connectionFailure(
+                    ["Invalid parameters, request not made.",
+                     callResult.error?.localizedDescription].compactMap({$0}).joined(separator: " ")))
+            }
+            
+            guard [403, 401].contains(status.code) == false else {
                 return .failure(.authorizationFailure("url: \(url)"))
             }
 
-            guard callResult.status.isOk, let response = callResult.response else {
-                return .failure(.connectionFailure("url: \(url), status: \(callResult.status)"))
+            guard status.isOk, let response = callResult.response else {
+                return .failure(.connectionFailure("url: \(url), status: \(status)"))
             }
 
             if let headerFields = callResult.allHeaderFields {

--- a/Sources/Network/HTTPS/Utils/HttpCallResult.swift
+++ b/Sources/Network/HTTPS/Utils/HttpCallResult.swift
@@ -6,16 +6,20 @@ import Foundation
 
 
 public struct HttpCallResult<ResponsePayload> {
-    let status: HTTPStatus
+    let error: Error?
+    let status: HTTPStatus?
     let allHeaderFields: [AnyHashable: Any]?
     let response: ResponsePayload?
-}
-
-extension HttpCallResult {
+    
     init(
-        status: HTTPStatus
+        error: Error? = nil,
+        status: HTTPStatus? = nil,
+        allHeaderFields: [AnyHashable: Any]? = nil,
+        response: ResponsePayload? = nil
     ) {
-        self.init(status: status, allHeaderFields: nil, response: nil)
+        self.error = error
+        self.status = status
+        self.allHeaderFields = allHeaderFields
+        self.response = response
     }
 }
-


### PR DESCRIPTION
Soundtrack of this PR: [Introbeats - Word](https://soundcloud.com/musicismysanctuary/exclusive-premiere-introbeatz-word)

### Motivation

`HttpStatus` conforms to the `Error` protocol even though it's not neccessary.  This adds extra complexity for SDK consumers who want to wrap all publicly exposed `Error`s. 

### In this PR

Remove `Error` conformance from `HttpStatus`, previously early exit errors (before the request was sent) were being represented by HttpStatus == 1. This was a hack so those early exit errors are now stored on the `HttpCallResult` as `error`. Code paths that return early exit errors have "assertionFailure" logging so they can be identified in debug.

Code paths that process `HttpCallResult` now check for a `.some(HttpStatus)` before continuing. A nil value is assumed to be an early exit error and is handled as a generic server error for now. 

### Future Work
* Using `Result<Success, Failure>` in place of an `HttpCallResult` might be better because the early exit paths can return `InvalidInputError` instead of `HttpCallResult`.  That change would be high impact because all of the Http networking code (including "generated" client files) would need to be updated. The motivation todo any further changes would be for better code semantics & readability.
