### PR TITLE
Serialize execution of integration tests for supported protocols

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - MobileCoin (1.2.0-pre8)
   - MobileCoin/Core (1.2.0-pre8):
     - gRPC-Swift
-    - LibMobileCoin/Core (~> 1.2.0-pre7)
+    - LibMobileCoin/Core (= 1.2.0-pre7)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
@@ -35,7 +35,7 @@ PODS:
     - SwiftProtobuf
   - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre8):
     - gRPC-Swift
-    - LibMobileCoin/Core (~> 1.2.0-pre7)
+    - LibMobileCoin/Core (= 1.2.0-pre7)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO
@@ -168,7 +168,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 9078b1492cee9d10be0b5ea2cee04dcdbf223359
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: a796294e7b14658e84fbd1303e5520054e457516
+  MobileCoin: d2ef1efd84c7b3acb34cf6444bfd198fc15d9986
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
   SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - Logging (1.4.0)
   - MobileCoin (1.2.0-pre8)
   - MobileCoin/CoreHTTP (1.2.0-pre8):
-    - LibMobileCoin/CoreHTTP (~> 1.2.0-pre7)
+    - LibMobileCoin/CoreHTTP (= 1.2.0-pre7)
     - Logging (~> 1.4)
     - SwiftLint
   - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre8):
-    - LibMobileCoin/CoreHTTP (~> 1.2.0-pre7)
+    - LibMobileCoin/CoreHTTP (= 1.2.0-pre7)
     - Logging (~> 1.4)
     - SwiftLint
   - MobileCoin/IntegrationTests (1.2.0-pre8)
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 9078b1492cee9d10be0b5ea2cee04dcdbf223359
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: a796294e7b14658e84fbd1303e5520054e457516
+  MobileCoin: d2ef1efd84c7b3acb34cf6444bfd198fc15d9986
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/Core", "~> 1.2.0-pre7"
+    subspec.dependency "LibMobileCoin/Core", "1.2.0-pre7"
 
     subspec.dependency "gRPC-Swift"
     subspec.dependency "Logging", "~> 1.4"
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/CoreHTTP", "~> 1.2.0-pre7"
+    subspec.dependency "LibMobileCoin/CoreHTTP", "1.2.0-pre7"
 
     subspec.dependency "Logging", "~> 1.4"
 

--- a/Sources/Network/TransportProtocol.swift
+++ b/Sources/Network/TransportProtocol.swift
@@ -21,6 +21,17 @@ extension TransportProtocol {
     }
 }
 
+extension TransportProtocol : CustomStringConvertible {
+    public var description: String {
+        switch option {
+        case .grpc:
+            return "GRPC"
+        case .http:
+            return "HTTP"
+        }
+    }
+}
+
 extension TransportProtocol : Equatable { }
 extension TransportProtocol : Hashable { }
 

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import MobileCoin
+
+extension XCTestCase {
+    /// Serialize the execution of tests for each supported protocol
+    func testSupportedProtocols(
+                description: String,
+                timeout: Double = 40.0,
+                interval: UInt32 = 10,
+                _ testCase: (TransportProtocol, XCTestExpectation) throws -> Void
+    ) rethrows {
+        let supportedProtocols = TransportProtocol.supportedProtocols
+        let last = supportedProtocols.last
+        try supportedProtocols.forEach { transportProtocol in
+            let description = "[\(transportProtocol.description)]:\(description)"
+            print("Testing ... \(description)")
+            let expect = expectation(description: description)
+            try testCase(transportProtocol, expect)
+            waitForExpectations(timeout: timeout)
+            sleep(transportProtocol == last ? 0 : interval)
+        }
+    }
+}

--- a/Tests/Integration/MobileCoinClientIntTests.swift
+++ b/Tests/Integration/MobileCoinClientIntTests.swift
@@ -10,15 +10,15 @@ import XCTest
 class MobileCoinClientIntTests: XCTestCase {
 
     func testTransactionDoubleSubmissionFails() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try transactionDoubleSubmissionFails(transportProtocol: transportProtocol)
+        let description = "Submitting transaction twice"
+        try testSupportedProtocols(description: description) {
+            try transactionDoubleSubmissionFails(transportProtocol: $0, expectation: $1)
         }
     }
 
-    func transactionDoubleSubmissionFails(transportProtocol: TransportProtocol) throws {
+    func transactionDoubleSubmissionFails(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
-        let expect = expectation(description: "Submitting transaction twice")
         try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect, transportProtocol: transportProtocol)
         { client in
             client.prepareTransaction(
@@ -45,21 +45,14 @@ class MobileCoinClientIntTests: XCTestCase {
                 }
             }
         }
-        waitForExpectations(timeout: 20)
     }
 
     /// Tests that the transaction status check fails if the inputs were spent by another
     /// transaction
     func testTransactionStatusFailsWhenInputIsAlreadySpent() throws {
-        let supportedProtocols = TransportProtocol.supportedProtocols
-        try supportedProtocols.enumerated().forEach { (index, transportProtocol) in
-            let expect = expectation(description: "Checking transaction status")
-            try transactionStatusFailsWhenInputIsAlreadySpent(transportProtocol: transportProtocol, expectation: expect)
-            waitForExpectations(timeout: 20)
-            
-            if index != (supportedProtocols.count - 1) {
-                sleep(10)
-            }
+        let description = "Checking transaction status"
+        try testSupportedProtocols(description: description) {
+            try transactionStatusFailsWhenInputIsAlreadySpent(transportProtocol: $0, expectation: $1)
         }
     }
     
@@ -143,16 +136,16 @@ class MobileCoinClientIntTests: XCTestCase {
     }
 
     func testTransactionStatusDoesNotSucceedWithoutSubmission() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: transportProtocol)
+        let description = "Checking transaction status"
+        try testSupportedProtocols(description: description) {
+            try transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol) throws {
+    func transactionStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
-        let expect = expectation(description: "Checking transaction status")
 
         func createTransaction(callback: @escaping (Transaction) -> Void) {
             senderClient.updateBalance {
@@ -201,23 +194,22 @@ class MobileCoinClientIntTests: XCTestCase {
             }
             checkStatus()
         }
-        waitForExpectations(timeout: 40)
     }
 
     func testReceiptStatusDoesNotSucceedWithoutSubmission() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: transportProtocol)
+        let description = "Checking receipt status fails"
+        try testSupportedProtocols(description: description) {
+            try receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol) throws {
+    func receiptStatusDoesNotSucceedWithoutSubmission(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
             accountKey: receiverAccountKey,
             transportProtocol: transportProtocol)
 
-        let expect = expectation(description: "Checking receipt status fails")
         func updateBalances(callback: @escaping () -> Void) {
             senderClient.updateBalance {
                 guard let senderBalance = $0.successOrFulfill(expectation: expect) else { return }
@@ -282,19 +274,18 @@ class MobileCoinClientIntTests: XCTestCase {
             }
             checkStatus()
         }
-        waitForExpectations(timeout: 60)
     }
 
     func testConcurrentBalanceChecks() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try concurrentBalanceChecks(transportProtocol: transportProtocol)
+        let description = "Checking account balance"
+        try testSupportedProtocols(description: description) {
+            try concurrentBalanceChecks(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func concurrentBalanceChecks(transportProtocol: TransportProtocol) throws {
+    func concurrentBalanceChecks(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
-        let expect = expectation(description: "Checking account balance")
         client.updateBalance {
             guard let balance = $0.successOrFulfill(expectation: expect) else { return }
 
@@ -323,19 +314,18 @@ class MobileCoinClientIntTests: XCTestCase {
                 expect.fulfill()
             }
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testConcurrentBalanceChecksWhileUpdating() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try concurrentBalanceChecksWhileUpdating(transportProtocol: transportProtocol)
+        let description = "Checking account balance"
+        try testSupportedProtocols(description: description) {
+            try concurrentBalanceChecksWhileUpdating(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func concurrentBalanceChecksWhileUpdating(transportProtocol: TransportProtocol) throws {
+    func concurrentBalanceChecksWhileUpdating(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
-        let expect = expectation(description: "Checking account balance")
         let group = DispatchGroup()
 
         for _ in (0..<100) {
@@ -368,19 +358,18 @@ class MobileCoinClientIntTests: XCTestCase {
         group.notify(queue: DispatchQueue.main) {
             expect.fulfill()
         }
-        waitForExpectations(timeout: 120)
     }
 
     func testConcurrentBalanceUpdates() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try concurrentBalanceUpdates(transportProtocol: transportProtocol)
+        let description = "Checking account balance"
+        try testSupportedProtocols(description: description) {
+            try concurrentBalanceUpdates(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func concurrentBalanceUpdates(transportProtocol: TransportProtocol) throws {
+    func concurrentBalanceUpdates(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
-        let expect = expectation(description: "Checking account balance")
         let group = DispatchGroup()
 
         for _ in (0..<5) {
@@ -401,7 +390,6 @@ class MobileCoinClientIntTests: XCTestCase {
         group.notify(queue: DispatchQueue.main) {
             expect.fulfill()
         }
-        waitForExpectations(timeout: 40)
     }
 
 }

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -33,7 +33,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 
     func testAccountActivity() throws {
         let description = "Updating account balance"
-        try testSupportedProtocols(description: description, timeout: 60.0) {
+        try testSupportedProtocols(description: description) {
             try accountActivity(transportProtocol: $0, expectation: $1)
         }
     }
@@ -52,6 +52,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             print("blockCount: \(accountActivity.blockCount)")
             XCTAssertGreaterThan(accountActivity.blockCount, 0)
 
+            expect.fulfill()
         }
     }
 

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -10,15 +10,15 @@ import XCTest
 class MobileCoinClientPublicApiIntTests: XCTestCase {
 
     func testBalance() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try balance(transportProtocol: transportProtocol)
+        let description = "Updating account balance"
+        try testSupportedProtocols(description: description) {
+            try balance(transportProtocol: $0, expectation: $1)
         }
     }
 
-    func balance(transportProtocol: TransportProtocol) throws {
+    func balance(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
-        let expect = expectation(description: "Updating account balance")
         client.updateBalance {
             guard $0.successOrFulfill(expectation: expect) != nil else { return }
 
@@ -29,19 +29,18 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 
             expect.fulfill()
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testAccountActivity() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try accountActivity(transportProtocol: transportProtocol)
+        let description = "Updating account balance"
+        try testSupportedProtocols(description: description, timeout: 60.0) {
+            try accountActivity(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func accountActivity(transportProtocol: TransportProtocol) throws {
+    func accountActivity(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol)
 
-        let expect = expectation(description: "Updating account balance")
         client.updateBalance {
             guard $0.successOrFulfill(expectation: expect) != nil else { return }
 
@@ -53,19 +52,17 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             print("blockCount: \(accountActivity.blockCount)")
             XCTAssertGreaterThan(accountActivity.blockCount, 0)
 
-            expect.fulfill()
         }
-        waitForExpectations(timeout: 40)
     }
 
     func testUpdateBalance() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try updateBalance(transportProtocol: transportProtocol)
+        let description = "Updating account balance"
+        try testSupportedProtocols(description: description) {
+            try updateBalance(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func updateBalance(transportProtocol: TransportProtocol) throws {
-        let expect = expectation(description: "Updating account balance")
+    func updateBalance(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         try IntegrationTestFixtures.createMobileCoinClient(transportProtocol:transportProtocol).updateBalance {
             guard let balance = $0.successOrFulfill(expectation: expect) else { return }
 
@@ -75,19 +72,18 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             }
             expect.fulfill()
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testPrepareTransaction() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try prepareTransaction(transportProtocol: transportProtocol)
+        let description = "Preparing transaction"
+        try testSupportedProtocols(description: description) {
+            try prepareTransaction(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func prepareTransaction(transportProtocol: TransportProtocol) throws {
+    func prepareTransaction(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
 
-        let expect = expectation(description: "Preparing transaction")
         try IntegrationTestFixtures.createMobileCoinClientWithBalance(expectation: expect, transportProtocol: transportProtocol)
         { client in
             client.prepareTransaction(
@@ -101,19 +97,12 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 expect.fulfill()
             }
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testSubmitTransaction() throws {
-        let supportedProtocols = TransportProtocol.supportedProtocols
-        try supportedProtocols.enumerated().forEach { (index, transportProtocol) in
-            let expect = expectation(description: "Submitting transaction")
-            try submitTransaction(transportProtocol: transportProtocol, expectation: expect)
-            waitForExpectations(timeout: 20)
-            
-            if index != (supportedProtocols.count - 1) {
-                sleep(10)
-            }
+        let description = "Submitting transaction"
+        try testSupportedProtocols(description: description) {
+            try submitTransaction(transportProtocol: $0, expectation: $1)
         }
     }
     
@@ -141,16 +130,16 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
     }
 
     func testSelfPaymentBalanceChange() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try selfPaymentBalanceChange(transportProtocol: transportProtocol)
+        let description = "Self payment"
+        try testSupportedProtocols(description: description) {
+            try selfPaymentBalanceChange(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func selfPaymentBalanceChange(transportProtocol: TransportProtocol) throws {
+    func selfPaymentBalanceChange(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 2)
         let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
-        let expect = expectation(description: "Self payment")
         func submitTransaction(callback: @escaping (Balance) -> Void) {
             client.updateBalance {
                 guard let balance = $0.successOrFulfill(expectation: expect) else { return }
@@ -207,20 +196,19 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             }
             checkBalance()
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testSelfPaymentBalanceChangeFeeLevel() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try selfPaymentBalanceChangeFeeLevel(transportProtocol: transportProtocol)
+        let description = "Self payment"
+        try testSupportedProtocols(description: description) {
+            try selfPaymentBalanceChangeFeeLevel(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func selfPaymentBalanceChangeFeeLevel(transportProtocol: TransportProtocol) throws {
+    func selfPaymentBalanceChangeFeeLevel(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let client = try IntegrationTestFixtures.createMobileCoinClient(accountKey: accountKey, transportProtocol: transportProtocol)
 
-        let expect = expectation(description: "Self payment")
         func submitTransaction(callback: @escaping (Balance) -> Void) {
             client.updateBalance {
                 guard let balance = $0.successOrFulfill(expectation: expect) else { return }
@@ -275,20 +263,19 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             }
             checkBalance()
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testTransactionStatus() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try transactionStatus(transportProtocol: transportProtocol)
+        let description = "Checking transaction status"
+        try testSupportedProtocols(description: description) {
+            try transactionStatus(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func transactionStatus(transportProtocol: TransportProtocol) throws {
+    func transactionStatus(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 1, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
-        let expect = expectation(description: "Checking transaction status")
 
         func submitTransaction(callback: @escaping (Transaction) -> Void) {
             client.updateBalance {
@@ -353,23 +340,22 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             }
             checkStatus()
         }
-        waitForExpectations(timeout: 20)
     }
 
     func testReceiptStatus() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try receiptStatus(transportProtocol: transportProtocol)
+        let description = "Checking receipt status"
+        try testSupportedProtocols(description: description) {
+            try receiptStatus(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func receiptStatus(transportProtocol: TransportProtocol) throws {
+    func receiptStatus(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         let senderClient = try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, transportProtocol: transportProtocol)
         let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
             accountKey: receiverAccountKey,
             transportProtocol: transportProtocol)
 
-        let expect = expectation(description: "Checking receipt status")
 
         func submitTransaction(callback: @escaping (Receipt) -> Void) {
             senderClient.updateBalance {
@@ -433,19 +419,12 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             }
             checkStatus()
         }
-        waitForExpectations(timeout: 40)
     }
 
     func testConsensusTrustRootWorks() throws {
-        let supportedProtocols = TransportProtocol.supportedProtocols
-        try supportedProtocols.enumerated().forEach { (index, transportProtocol) in
-            let expect = expectation(description: "Submitting transaction")
-            try consensusTrustRootWorks(transportProtocol: transportProtocol, expectation: expect)
-            waitForExpectations(timeout: 40)
-            
-            if index != (supportedProtocols.count - 1) {
-                sleep(10)
-            }
+        let description = "Submitting transaction"
+        try testSupportedProtocols(description: description) {
+            try consensusTrustRootWorks(transportProtocol: $0, expectation: $1)
         }
     }
     
@@ -483,15 +462,9 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
     }
 
     func testExtraConsensusTrustRootWorks() throws {
-        let supportedProtocols = TransportProtocol.supportedProtocols
-        try supportedProtocols.enumerated().forEach { (index, transportProtocol) in
-            let expect = expectation(description: "Submitting transaction")
-            try extraConsensusTrustRootWorks(transportProtocol: transportProtocol, expect: expect)
-            waitForExpectations(timeout: 40)
-            
-            if index != (supportedProtocols.count - 1) {
-                sleep(10)
-            }
+        let description = "Submitting transaction"
+        try testSupportedProtocols(description: description) {
+            try extraConsensusTrustRootWorks(transportProtocol: $0, expect: $1)
         }
     }
     
@@ -530,12 +503,13 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
     }
 
     func testWrongConsensusTrustRootReturnsError() throws {
-        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
-            try wrongConsensusTrustRootReturnsError(transportProtocol: transportProtocol)
+        let description = "Submitting transaction"
+        try testSupportedProtocols(description: description) {
+            try wrongConsensusTrustRootReturnsError(transportProtocol: $0, expectation: $1)
         }
     }
     
-    func wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol) throws {
+    func wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
         // Skipped because gRPC currently keeps retrying connection errors indefinitely.
         try XCTSkipIf(true)
 
@@ -547,7 +521,6 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             try IntegrationTestFixtures.createMobileCoinClient(accountIndex: 0, config: config, transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
-        let expect = expectation(description: "Submitting transaction")
         client.updateBalance {
             guard let balance = $0.successOrFulfill(expectation: expect) else { return }
             guard let picoMob = try? XCTUnwrap(balance.amountPicoMob()) else
@@ -571,7 +544,6 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 }
             }
         }
-        waitForExpectations(timeout: 20)
     }
 
 }


### PR DESCRIPTION
Soundtrack of this PR: [FIXATE - RIPGROOVE ReFIX](https://soundcloud.com/fixate_uk/ripgroove-refix)

### Motivation

Some integration tests fail from race conditions caused by running them back to back in short succession. 

### In this PR
* Add convenience function that iterates through supported protocols with a sleep interval between each test case.
* Convert `MobileCoinClientIntTests` and `MobileCoinClientPublicApiIntTests` to use new convenience function.