### PR TITLE
Move rotation of URL upstream in the init path

### DIFF
--- a/Sources/Network/AttestedConnectionConfig.swift
+++ b/Sources/Network/AttestedConnectionConfig.swift
@@ -9,32 +9,25 @@ protocol AttestedConnectionConfigProtocol: ConnectionConfigProtocol {
 }
 
 struct AttestedConnectionConfig<Url: MobileCoinUrlProtocol>: AttestedConnectionConfigProtocol {
-    let urlLoadBalancer: RandomUrlLoadBalancer<Url>
+    let urlTyped: Url
     let transportProtocolOption: TransportProtocol.Option
     let attestation: Attestation
     let trustRoots: [TransportProtocol: SSLCertificates]
     let authorization: BasicCredentials?
 
     init(
-        urlLoadBalancer: RandomUrlLoadBalancer<Url>,
+        url: Url,
         transportProtocolOption: TransportProtocol.Option,
         attestation: Attestation,
         trustRoots: [TransportProtocol: SSLCertificates],
         authorization: BasicCredentials?
     ) {
-        self.urlLoadBalancer = urlLoadBalancer
+        self.urlTyped = url
         self.transportProtocolOption = transportProtocolOption
         self.attestation = attestation
         self.trustRoots = trustRoots
         self.authorization = authorization
     }
 
-    func nextUrl() -> MobileCoinUrlProtocol {
-        self.urlLoadBalancer.nextUrl()
-    }
-
-    var currentUrl: MobileCoinUrlProtocol {
-        self.urlLoadBalancer.currentUrl
-    }
-
+    var url: MobileCoinUrlProtocol { urlTyped }
 }

--- a/Sources/Network/Connection/Connections/BlockchainConnection.swift
+++ b/Sources/Network/Connection/Connections/BlockchainConnection.swift
@@ -11,13 +11,13 @@ final class BlockchainConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: ConnectionConfig<ConsensusUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
 
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: ConnectionConfig<ConsensusUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?
     ) {
         self.httpFactory = httpFactory
@@ -27,21 +27,22 @@ final class BlockchainConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.blockchain
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeBlockchainService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 case .http:
                     return .http(httpService:
                             httpFactory.makeBlockchainService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.blockchain.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/ConsensusConnection.swift
+++ b/Sources/Network/Connection/Connections/ConsensusConnection.swift
@@ -10,7 +10,7 @@ final class ConsensusConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: AttestedConnectionConfig<ConsensusUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
     private let rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)?
     private let rngContext: Any?
@@ -18,7 +18,7 @@ final class ConsensusConnection:
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: AttestedConnectionConfig<ConsensusUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
@@ -32,23 +32,24 @@ final class ConsensusConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.consensus
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService: grpcFactory.makeConsensusService(
-                            config: config,
+                            config: rotatedConfig,
                             targetQueue: targetQueue,
                             rng: rng,
                             rngContext: rngContext))
                 case .http:
                     return .http(httpService: httpFactory.makeConsensusService(
-                            config: config,
+                            config: rotatedConfig,
                             targetQueue: targetQueue,
                             rng: rng,
                             rngContext: rngContext))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.consensus.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/FogBlockConnection.swift
+++ b/Sources/Network/Connection/Connections/FogBlockConnection.swift
@@ -10,13 +10,13 @@ final class FogBlockConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: ConnectionConfig<FogUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
 
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: ConnectionConfig<FogUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?
     ) {
         self.httpFactory = httpFactory
@@ -26,21 +26,22 @@ final class FogBlockConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.fogBlock
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeFogBlockService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 case .http:
                     return .http(httpService:
                             httpFactory.makeFogBlockService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.fogBlock.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/FogKeyImageConnection.swift
+++ b/Sources/Network/Connection/Connections/FogKeyImageConnection.swift
@@ -10,7 +10,7 @@ final class FogKeyImageConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: AttestedConnectionConfig<FogUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
     private let rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)?
     private let rngContext: Any?
@@ -18,7 +18,7 @@ final class FogKeyImageConnection:
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: AttestedConnectionConfig<FogUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
@@ -32,25 +32,26 @@ final class FogKeyImageConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.fogKeyImage
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeFogKeyImageService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
                 case .http:
                     return .http(httpService:
                             httpFactory.makeFogKeyImageService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.fogKeyImage.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/FogMerkleProofConnection.swift
+++ b/Sources/Network/Connection/Connections/FogMerkleProofConnection.swift
@@ -10,7 +10,7 @@ final class FogMerkleProofConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: AttestedConnectionConfig<FogUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
     private let rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)?
     private let rngContext: Any? 
@@ -18,7 +18,7 @@ final class FogMerkleProofConnection:
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: AttestedConnectionConfig<FogUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
@@ -32,25 +32,26 @@ final class FogMerkleProofConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.fogMerkleProof
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeFogMerkleProofService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
                 case .http:
                     return .http(httpService:
                             httpFactory.makeFogMerkleProofService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.fogMerkleProof.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
+++ b/Sources/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
@@ -11,13 +11,13 @@ final class FogUntrustedTxOutConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: ConnectionConfig<FogUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
 
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: ConnectionConfig<FogUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?
     ) {
         self.httpFactory = httpFactory
@@ -27,21 +27,22 @@ final class FogUntrustedTxOutConnection:
 
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.fogUntrustedTxOut
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeFogUntrustedTxOutService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 case .http:
                     return .http(httpService:
                             httpFactory.makeFogUntrustedTxOutService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.fogUntrustedTxOut.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/Connection/Connections/FogViewConnection.swift
+++ b/Sources/Network/Connection/Connections/FogViewConnection.swift
@@ -10,7 +10,7 @@ final class FogViewConnection:
 {
     private let httpFactory: HttpProtocolConnectionFactory
     private let grpcFactory: GrpcProtocolConnectionFactory
-    private let config: AttestedConnectionConfig<FogUrl>
+    private let config: NetworkConfig
     private let targetQueue: DispatchQueue?
     private let rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)?
     private let rngContext: Any?
@@ -18,7 +18,7 @@ final class FogViewConnection:
     init(
         httpFactory: HttpProtocolConnectionFactory,
         grpcFactory: GrpcProtocolConnectionFactory,
-        config: AttestedConnectionConfig<FogUrl>,
+        config: NetworkConfig,
         targetQueue: DispatchQueue?,
         rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
         rngContext: Any? = nil
@@ -31,12 +31,13 @@ final class FogViewConnection:
         self.rngContext = rngContext
         super.init(
             connectionOptionWrapperFactory: { transportProtocolOption in
+                let rotatedConfig = config.fogView
                 switch transportProtocolOption {
                 case .grpc:
                     return .grpc(
                         grpcService:
                             grpcFactory.makeFogViewService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
@@ -44,13 +45,13 @@ final class FogViewConnection:
                     return .http(
                         httpService:
                             httpFactory.makeFogViewService(
-                                config: config,
+                                config: rotatedConfig,
                                 targetQueue: targetQueue,
                                 rng: rng,
                                 rngContext: rngContext))
                 }
             },
-            transportProtocolOption: config.transportProtocolOption,
+            transportProtocolOption: config.fogView.transportProtocolOption,
             targetQueue: targetQueue)
     }
 

--- a/Sources/Network/ConnectionConfig.swift
+++ b/Sources/Network/ConnectionConfig.swift
@@ -5,36 +5,29 @@
 import Foundation
 
 protocol ConnectionConfigProtocol {
+    var url: MobileCoinUrlProtocol { get }
     var transportProtocolOption: TransportProtocol.Option { get }
     var trustRoots: [TransportProtocol:SSLCertificates] { get }
     var authorization: BasicCredentials? { get }
-    var currentUrl: MobileCoinUrlProtocol { get }
-    func nextUrl() -> MobileCoinUrlProtocol
 }
 
 struct ConnectionConfig<Url: MobileCoinUrlProtocol>: ConnectionConfigProtocol {
-    let urlLoadBalancer: RandomUrlLoadBalancer<Url>
+    let urlTyped: Url
     let transportProtocolOption: TransportProtocol.Option
     let trustRoots: [TransportProtocol:SSLCertificates]
     let authorization: BasicCredentials?
 
     init(
-        urlLoadBalancer: RandomUrlLoadBalancer<Url>,
+        url: Url,
         transportProtocolOption: TransportProtocol.Option,
         trustRoots: [TransportProtocol:SSLCertificates],
         authorization: BasicCredentials?
     ) {
-        self.urlLoadBalancer = urlLoadBalancer
+        self.urlTyped = url
         self.transportProtocolOption = transportProtocolOption
         self.trustRoots = trustRoots
         self.authorization = authorization
     }
 
-    func nextUrl() -> MobileCoinUrlProtocol {
-        self.urlLoadBalancer.nextUrl()
-    }
-    
-    var currentUrl: MobileCoinUrlProtocol {
-        self.urlLoadBalancer.currentUrl
-    }
+    var url: MobileCoinUrlProtocol { urlTyped }
 }

--- a/Sources/Network/ConnectionSession.swift
+++ b/Sources/Network/ConnectionSession.swift
@@ -18,6 +18,10 @@ class ConnectionSession {
     let cookieStorage: HTTPCookieStorage
     var authorizationCredentials: BasicCredentials?
 
+    convenience init(config: ConnectionConfigProtocol) {
+        self.init(url: config.url, authorization: config.authorization)
+    }
+
     init(url: MobileCoinUrlProtocol, authorization: BasicCredentials? = nil) {
         self.url = url.httpBasedUrl
         self.cookieStorage = Self.ephemeralCookieStorage

--- a/Sources/Network/GRPC/GrpcChannelManager.swift
+++ b/Sources/Network/GRPC/GrpcChannelManager.swift
@@ -13,7 +13,7 @@ final class GrpcChannelManager {
 
     func channel(for config: ConnectionConfigProtocol) -> GRPCChannel {
         let wrappedTrustRoots = config.trustRoots[.grpc] as? WrappedNIOSSLCertificate
-        return channel(for: config.currentUrl, trustRoots: wrappedTrustRoots?.trustRoots)
+        return channel(for: config.url, trustRoots: wrappedTrustRoots?.trustRoots)
     }
 
     func channel(for url: MobileCoinUrlProtocol, trustRoots: [NIOSSLCertificate]? = nil)

--- a/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
@@ -123,11 +123,11 @@ extension AttestedGrpcConnection {
             rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
             rngContext: Any? = nil
         ) {
-            self.url = config.nextUrl()
-            self.session = ConnectionSession(url: self.url, authorization: config.authorization)
+            self.url = config.url
+            self.session = ConnectionSession(config: config)
             self.client = client
             self.attestAke = AttestAke()
-            self.responderId = self.url.responderId
+            self.responderId = config.url.responderId
             self.attestationVerifier = AttestationVerifier(attestation: config.attestation)
             self.rng = rng
             self.rngContext = rngContext

--- a/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
@@ -67,8 +67,8 @@ extension GrpcConnection {
         private let session: ConnectionSession
 
         init(config: ConnectionConfigProtocol) {
-            self.url = config.nextUrl()
-            self.session = ConnectionSession(url: self.url, authorization: config.authorization)
+            self.url = config.url
+            self.session = ConnectionSession(config: config)
         }
 
         func setAuthorization(credentials: BasicCredentials) {

--- a/Sources/Network/HTTPS/HttpConnection/AttestedHttpConnection.swift
+++ b/Sources/Network/HTTPS/HttpConnection/AttestedHttpConnection.swift
@@ -127,12 +127,12 @@ extension AttestedHttpConnection {
             rng: (@convention(c) (UnsafeMutableRawPointer?) -> UInt64)? = securityRNG,
             rngContext: Any? = nil
         ) {
-            self.url = config.nextUrl()
-            self.session = ConnectionSession(url: self.url, authorization: config.authorization)
+            self.url = config.url
+            self.session = ConnectionSession(config: config)
             self.client = client
             self.requester = requester
             self.attestAke = AttestAke()
-            self.responderId = self.url.responderId
+            self.responderId = config.url.responderId
             self.attestationVerifier = AttestationVerifier(attestation: config.attestation)
             self.rng = rng
             self.rngContext = rngContext

--- a/Sources/Network/HTTPS/HttpConnection/HttpConnection.swift
+++ b/Sources/Network/HTTPS/HttpConnection/HttpConnection.swift
@@ -65,8 +65,8 @@ extension HttpConnection {
         private let session: ConnectionSession
 
         init(config: ConnectionConfigProtocol) {
-            self.url = config.nextUrl()
-            self.session = ConnectionSession(url: self.url, authorization: config.authorization)
+            self.url = config.url
+            self.session = ConnectionSession(config: config)
         }
 
         func setAuthorization(credentials: BasicCredentials) {

--- a/Sources/Network/HTTPS/HttpProtocolConnectionFactory.swift
+++ b/Sources/Network/HTTPS/HttpProtocolConnectionFactory.swift
@@ -10,7 +10,7 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     init(httpRequester: HttpRequester?) {
         self.requester = httpRequester ?? DefaultHttpRequester()
     }
-
+    
     func makeConsensusService(
         config: AttestedConnectionConfig<ConsensusUrl>,
         targetQueue: DispatchQueue?,
@@ -19,7 +19,7 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> ConsensusHttpConnection {
         ConsensusHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.nextUrl()),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue,
                         rng: rng,
                         rngContext: rngContext)
@@ -31,7 +31,7 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> BlockchainHttpConnection {
         BlockchainHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue)
     }
     
@@ -43,12 +43,12 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> FogViewHttpConnection {
         FogViewHttpConnection(
                 config: config,
-                requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                requester: RestApiRequester(requester: requester, baseUrl: config.url),
                 targetQueue: targetQueue,
                 rng: rng,
                 rngContext: rngContext)
     }
-
+        
     func makeFogMerkleProofService(
         config: AttestedConnectionConfig<FogUrl>,
         targetQueue: DispatchQueue?,
@@ -57,7 +57,7 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> FogMerkleProofHttpConnection {
         FogMerkleProofHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue,
                         rng: rng,
                         rngContext: rngContext)
@@ -71,7 +71,7 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> FogKeyImageHttpConnection {
         FogKeyImageHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue,
                         rng: rng,
                         rngContext: rngContext)
@@ -83,17 +83,17 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     ) -> FogBlockHttpConnection {
         FogBlockHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue)
     }
-
+    
     func makeFogUntrustedTxOutService(
         config: ConnectionConfig<FogUrl>,
         targetQueue: DispatchQueue?
     ) -> FogUntrustedTxOutHttpConnection {
         FogUntrustedTxOutHttpConnection(
                         config: config,
-                        requester: RestApiRequester(requester: requester, baseUrl: config.urlLoadBalancer.currentUrl),
+                        requester: RestApiRequester(requester: requester, baseUrl: config.url),
                         targetQueue: targetQueue)
     }
 
@@ -108,5 +108,4 @@ class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
             targetQueue: targetQueue)
     }
 }
-
 

--- a/Sources/Network/NetworkConfig.swift
+++ b/Sources/Network/NetworkConfig.swift
@@ -47,7 +47,7 @@ struct NetworkConfig {
 
     var consensus: AttestedConnectionConfig<ConsensusUrl> {
         AttestedConnectionConfig(
-            urlLoadBalancer: consensusUrlLoadBalancer,
+            url: consensusUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             attestation: attestation.consensus,
             trustRoots: consensusTrustRoots,
@@ -56,7 +56,7 @@ struct NetworkConfig {
 
     var blockchain: ConnectionConfig<ConsensusUrl> {
         ConnectionConfig(
-            urlLoadBalancer: consensusUrlLoadBalancer,
+            url: consensusUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             trustRoots: consensusTrustRoots,
             authorization: consensusAuthorization)
@@ -64,7 +64,7 @@ struct NetworkConfig {
 
     var fogView: AttestedConnectionConfig<FogUrl> {
         AttestedConnectionConfig(
-            urlLoadBalancer: fogUrlLoadBalancer,
+            url: fogUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             attestation: attestation.fogView,
             trustRoots: fogTrustRoots,
@@ -73,7 +73,7 @@ struct NetworkConfig {
 
     var fogMerkleProof: AttestedConnectionConfig<FogUrl> {
         AttestedConnectionConfig(
-            urlLoadBalancer: fogUrlLoadBalancer,
+            url: fogUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             attestation: attestation.fogMerkleProof,
             trustRoots: fogTrustRoots,
@@ -82,7 +82,7 @@ struct NetworkConfig {
 
     var fogKeyImage: AttestedConnectionConfig<FogUrl> {
         AttestedConnectionConfig(
-            urlLoadBalancer: fogUrlLoadBalancer,
+            url: fogUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             attestation: attestation.fogKeyImage,
             trustRoots: fogTrustRoots,
@@ -91,7 +91,7 @@ struct NetworkConfig {
 
     var fogBlock: ConnectionConfig<FogUrl> {
         ConnectionConfig(
-            urlLoadBalancer: fogUrlLoadBalancer,
+            url: fogUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             trustRoots: fogTrustRoots,
             authorization: fogUserAuthorization)
@@ -99,7 +99,7 @@ struct NetworkConfig {
 
     var fogUntrustedTxOut: ConnectionConfig<FogUrl> {
         ConnectionConfig(
-            urlLoadBalancer: fogUrlLoadBalancer,
+            url: fogUrlLoadBalancer.nextUrl(),
             transportProtocolOption: transportProtocol.option,
             trustRoots: fogTrustRoots,
             authorization: fogUserAuthorization)

--- a/Sources/Network/Service/DefaultServiceProvider.swift
+++ b/Sources/Network/Service/DefaultServiceProvider.swift
@@ -32,37 +32,37 @@ final class DefaultServiceProvider: ServiceProvider {
         self.consensus = ConsensusConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.consensus,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.blockchain = BlockchainConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.blockchain,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.view = FogViewConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.fogView,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.merkleProof = FogMerkleProofConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.fogMerkleProof,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.keyImage = FogKeyImageConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.fogKeyImage,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.block = FogBlockConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.fogBlock,
+            config: networkConfig,
             targetQueue: targetQueue)
         self.untrustedTxOut = FogUntrustedTxOutConnection(
             httpFactory: self.httpConnectionFactory,
             grpcFactory: self.grpcConnectionFactory,
-            config: networkConfig.fogUntrustedTxOut,
+            config: networkConfig,
             targetQueue: targetQueue)
     }
 

--- a/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/ConsensusConnectionIntTests.swift
@@ -203,7 +203,7 @@ extension ConsensusConnectionIntTests {
         return ConsensusConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.consensus,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }

--- a/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogBlockConnectionIntTests.swift
@@ -194,7 +194,7 @@ extension FogBlockConnectionIntTests {
         return FogBlockConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.fogBlock,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }

--- a/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -147,7 +147,7 @@ extension FogKeyImageConnectionIntTests {
         return FogKeyImageConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.fogKeyImage,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }

--- a/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogMerkleProofConnectionIntTests.swift
@@ -198,7 +198,7 @@ extension FogMerkleProofConnectionIntTests {
         return FogMerkleProofConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.fogMerkleProof,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }

--- a/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
@@ -76,7 +76,7 @@ extension FogUntrustedTxOutConnectionIntTests {
         return FogUntrustedTxOutConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.fogUntrustedTxOut,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }

--- a/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogViewConnectionIntTests.swift
@@ -300,7 +300,7 @@ extension FogViewConnectionIntTests {
         return FogViewConnection(
             httpFactory: httpFactory,
             grpcFactory: grpcFactory,
-            config: networkConfig.fogView,
+            config: networkConfig,
             targetQueue: DispatchQueue.main)
     }
 }


### PR DESCRIPTION
 Has the benefit of preserving immutable data structures in more code, and isolates the rotation to the point at which a new connection is created for a given service. Seems like a lower impact change