### PR TITLE
Fix Integration test regression

### DIFF
--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -504,6 +504,9 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
     }
 
     func testWrongConsensusTrustRootReturnsError() throws {
+        // Skipped because gRPC currently keeps retrying connection errors indefinitely.
+        try XCTSkipIf(true)
+
         let description = "Submitting transaction"
         try testSupportedProtocols(description: description) {
             try wrongConsensusTrustRootReturnsError(transportProtocol: $0, expectation: $1)
@@ -511,9 +514,6 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
     }
     
     func wrongConsensusTrustRootReturnsError(transportProtocol: TransportProtocol, expectation expect: XCTestExpectation) throws {
-        // Skipped because gRPC currently keeps retrying connection errors indefinitely.
-        try XCTSkipIf(true)
-
         var config = try IntegrationTestFixtures.createMobileCoinClientConfig(transportProtocol:transportProtocol)
         XCTAssertSuccess(config.setConsensusTrustRoots([
             try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes,


### PR DESCRIPTION
Soundtrack of this PR: [Roy Ayers - Sweet Tears 1978](https://youtu.be/Pjm4oS9bUao)

### Motivation

The `func testWrongConsensusTrustRootReturnsError()` test should be skipped but recent changes to prevent race conditions was causing it to be run. 

### In this PR
* Move `XCTSkip` to outer scope with its associated in-line code comment

### Future Work
* Fix or remove test instead of skipping it.