### PR TITLE
Add GRPC ConnectionOption.timeLimit and integration tests for same

### DIFF
--- a/Sources/Network/GRPC/GrpcChannelManager.swift
+++ b/Sources/Network/GRPC/GrpcChannelManager.swift
@@ -29,6 +29,12 @@ final class GrpcChannelManager {
     }
 }
 
+extension GrpcChannelManager {
+    enum Defaults {
+        static let callOptionsTimeLimit = TimeLimit.timeout(TimeAmount.seconds(30))
+    }
+}
+
 extension ClientConnection {
     fileprivate static func create(group: EventLoopGroup, config: GrpcChannelConfig) -> GRPCChannel
     {

--- a/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
@@ -333,6 +333,7 @@ extension AttestedGrpcConnection {
         private func requestCallOptions() -> CallOptions {
             var callOptions = CallOptions()
             session.addRequestHeaders(to: &callOptions.customMetadata)
+            callOptions.timeLimit = GrpcChannelManager.Defaults.callOptionsTimeLimit
             return callOptions
         }
 

--- a/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
@@ -78,6 +78,7 @@ extension GrpcConnection {
         func requestCallOptions() -> CallOptions {
             var callOptions = CallOptions()
             session.addRequestHeaders(to: &callOptions.customMetadata)
+            callOptions.timeLimit = GrpcChannelManager.Defaults.callOptionsTimeLimit
             return callOptions
         }
 

--- a/Tests/Integration/IntegrationTestFixtures.swift
+++ b/Tests/Integration/IntegrationTestFixtures.swift
@@ -9,6 +9,8 @@ import XCTest
 
 enum IntegrationTestFixtures {
     static let network: NetworkPreset = .testNet
+    static let invalidConsensusUrl = "mc://invalid.mobilecoin.com"
+    static let invalidFogUrl = "fog://invalid.mobilecoin.com"
 }
 
 extension IntegrationTestFixtures {
@@ -63,6 +65,14 @@ extension IntegrationTestFixtures {
         networkConfig.setConsensusTrustRoots(trustRoots)
         networkConfig.setFogTrustRoots(trustRoots)
         return networkConfig
+    }
+
+    static func createNetworkConfigWithInvalidUrls(transportProtocol: TransportProtocol) throws -> NetworkConfig {
+        try NetworkConfig.make(
+            consensusUrl: invalidConsensusUrl,
+            fogUrl: invalidFogUrl,
+            attestation: network.attestationConfig(),
+            transportProtocol: transportProtocol).get()
     }
 
     static func createNetworkConfigWithInvalidCredentials(transportProtocol: TransportProtocol) throws -> NetworkConfig {

--- a/Tests/Integration/Network/Protocol/ConnectionIntTests.swift
+++ b/Tests/Integration/Network/Protocol/ConnectionIntTests.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright (c) 2020-2022 MobileCoin. All rights reserved.
+//
+
+import LibMobileCoin
+@testable import MobileCoin
+import XCTest
+
+class ConnectionIntTests: XCTestCase {
+    func testCallTimeoutWithInvalidUrl() throws {
+        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
+            try testCallTimeoutWithInvalidUrl(transportProtocol: transportProtocol)
+        }
+    }
+
+    func testCallTimeoutWithInvalidUrl(transportProtocol: TransportProtocol) throws {
+        let expect = expectation(description: "Making Fog View enclave request")
+
+        var request = FogLedger_BlockRequest()
+        request.rangeValues = [1..<2]
+        try createFogBlockConnectionWithInvalidUrls(transportProtocol: transportProtocol).getBlocks(request: request) {
+            guard let error = $0.failureOrFulfill(expectation: expect) else { return }
+
+            switch error {
+            case .connectionFailure:
+                break
+            default:
+                XCTFail("error of type \(type(of: error)), \(error)")
+            }
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 35)
+    }
+
+    func testAttestedCallTimeoutWithInvalidUrl() throws {
+        try TransportProtocol.supportedProtocols.forEach { transportProtocol in
+            try testAttestedCallTimeoutWithInvalidUrl(transportProtocol: transportProtocol)
+        }
+    }
+
+    func testAttestedCallTimeoutWithInvalidUrl(transportProtocol: TransportProtocol) throws {
+        let fixture = try Transaction.Fixtures.Default()
+
+        let expect = expectation(description: "Attested Call to invalid URL should timeout for protocol: \(transportProtocol.description)")
+        try createConsensusConnectionWithInvalidUrls(transportProtocol: transportProtocol).proposeTx(fixture.tx, completion: {
+            guard let error = $0.failureOrFulfill(expectation: expect) else { return }
+
+            switch error {
+            case .connectionFailure:
+                break
+            default:
+                XCTFail("error of type \(type(of: error)), \(error)")
+            }
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: 35)
+    }
+}
+
+extension ConnectionIntTests {
+    func createConsensusConnectionWithInvalidUrls(transportProtocol: TransportProtocol) throws -> ConsensusConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidUrls(transportProtocol: transportProtocol)
+        return createConsensusConnection(networkConfig: networkConfig)
+    }
+
+    func createConsensusConnection(networkConfig: NetworkConfig) -> ConsensusConnection {
+        let httpFactory = HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester ?? DefaultHttpRequester())
+        let grpcFactory = GrpcProtocolConnectionFactory()
+        return ConsensusConnection(
+            httpFactory: httpFactory,
+            grpcFactory: grpcFactory,
+            config: networkConfig.consensus,
+            targetQueue: DispatchQueue.main)
+    }
+
+    func createFogBlockConnectionWithInvalidUrls(transportProtocol: TransportProtocol) throws -> FogBlockConnection {
+        let networkConfig = try IntegrationTestFixtures.createNetworkConfigWithInvalidUrls(transportProtocol: transportProtocol)
+        return createFogBlockConnection(networkConfig: networkConfig)
+    }
+
+    func createFogBlockConnection(networkConfig: NetworkConfig) -> FogBlockConnection {
+        let httpFactory = HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester ?? DefaultHttpRequester())
+        let grpcFactory = GrpcProtocolConnectionFactory()
+        return FogBlockConnection(
+            httpFactory: httpFactory,
+            grpcFactory: grpcFactory,
+            config: networkConfig.fogBlock,
+            targetQueue: DispatchQueue.main)
+    }
+
+}


### PR DESCRIPTION
Soundtrack of this PR: [I can't wait for you](https://www.youtube.com/watch?v=lgXvsH0VOqM)

### Motivation

GRPC requests must timeout / can't be left hanging forever without a response

### In this PR
* added timelimit setting to CallOptions created by AttestedGrpcConnection and GrpcConnection's requestCallOptions() functions
