### PR TITLE
Version lock gRPC and SwiftNIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-pre11] - 2022-02-03
+
+### Changed
+
+- Version lock gRPC and SwiftNIO for robustness with idle connections
+
+### Added
+
+- Internal Load Balancer, default connection timeout for gRPC
+
 ## [1.2.0-pre10] - 2022-02-03
 
 ### Changed

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -22,8 +22,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.0-pre10)
-  - MobileCoin/Core (1.2.0-pre10):
+  - MobileCoin (1.2.0-pre11)
+  - MobileCoin/Core (1.2.0-pre11):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin/Core (~> 1.2.0-pre10)
     - Logging (~> 1.4)
@@ -32,7 +32,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.27.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre10):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre11):
     - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin/Core (~> 1.2.0-pre10)
     - Logging (~> 1.4)
@@ -41,9 +41,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.27.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.0-pre10)
-  - MobileCoin/PerformanceTests (1.2.0-pre10)
-  - MobileCoin/Tests (1.2.0-pre10)
+  - MobileCoin/IntegrationTests (1.2.0-pre11)
+  - MobileCoin/PerformanceTests (1.2.0-pre11)
+  - MobileCoin/Tests (1.2.0-pre11)
   - SwiftLint (0.45.0)
   - SwiftNIO (2.27.0):
     - CNIODarwin (= 2.27.0)
@@ -144,7 +144,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 40d2d7d685321a6128871b6c6b4bb7cba25e848f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: f0f9374d921acaddb2de0eb50d2de738ff5ab1d1
+  MobileCoin: 7eed08dfa921456a97b0df4a52c1faeae09d6697
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftNIO: 81d33ce8c500b7e41b6cdde5f2f12330b9750219
   SwiftNIOConcurrencyHelpers: 23fc68bac541a465162d7225d2c743edd2f1012c

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,22 +1,21 @@
 PODS:
-  - _NIODataStructures (2.32.3)
-  - CGRPCZlib (1.6.1)
-  - CNIOAtomics (2.32.3)
-  - CNIOBoringSSL (2.15.1)
-  - CNIOBoringSSLShims (2.15.1):
-    - CNIOBoringSSL (= 2.15.1)
-  - CNIODarwin (2.32.3)
-  - CNIOHTTPParser (2.32.3)
-  - CNIOLinux (2.32.3)
-  - CNIOWindows (2.32.3)
-  - gRPC-Swift (1.6.1):
-    - CGRPCZlib (= 1.6.1)
+  - CGRPCZlib (1.0.0)
+  - CNIOAtomics (2.27.0)
+  - CNIOBoringSSL (2.12.0)
+  - CNIOBoringSSLShims (2.12.0):
+    - CNIOBoringSSL (= 2.12.0)
+  - CNIODarwin (2.27.0)
+  - CNIOHTTPParser (2.27.0)
+  - CNIOLinux (2.27.0)
+  - CNIOWindows (2.27.0)
+  - gRPC-Swift (1.0.0):
+    - CGRPCZlib (= 1.0.0)
     - Logging (< 2.0.0, >= 1.4.0)
-    - SwiftNIO (< 3.0.0, >= 2.32.0)
+    - SwiftNIO (< 3.0.0, >= 2.22.0)
     - SwiftNIOExtras (< 2.0.0, >= 1.4.0)
-    - SwiftNIOHTTP2 (< 2.0.0, >= 1.18.2)
-    - SwiftNIOSSL (< 3.0.0, >= 2.14.0)
-    - SwiftNIOTransportServices (< 2.0.0, >= 1.11.1)
+    - SwiftNIOHTTP2 (< 2.0.0, >= 1.16.1)
+    - SwiftNIOSSL (< 3.0.0, >= 2.8.0)
+    - SwiftNIOTransportServices (< 2.0.0, >= 1.6.0)
     - SwiftProtobuf (< 2.0.0, >= 1.9.0)
   - Keys (1.0.1)
   - LibMobileCoin/Core (1.2.0-pre10):
@@ -25,84 +24,66 @@ PODS:
   - Logging (1.4.0)
   - MobileCoin (1.2.0-pre10)
   - MobileCoin/Core (1.2.0-pre10):
-    - gRPC-Swift
+    - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin/Core (~> 1.2.0-pre10)
     - Logging (~> 1.4)
     - SwiftLint
-    - SwiftNIO
-    - SwiftNIOHPACK
-    - SwiftNIOHTTP1
+    - SwiftNIO (~> 2.27.0)
+    - SwiftNIOHPACK (~> 1.16.3)
+    - SwiftNIOHTTP1 (~> 2.27.0)
     - SwiftProtobuf
   - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre10):
-    - gRPC-Swift
+    - gRPC-Swift (~> 1.0.0)
     - LibMobileCoin/Core (~> 1.2.0-pre10)
     - Logging (~> 1.4)
     - SwiftLint
-    - SwiftNIO
-    - SwiftNIOHPACK
-    - SwiftNIOHTTP1
+    - SwiftNIO (~> 2.27.0)
+    - SwiftNIOHPACK (~> 1.16.3)
+    - SwiftNIOHTTP1 (~> 2.27.0)
     - SwiftProtobuf
   - MobileCoin/IntegrationTests (1.2.0-pre10)
   - MobileCoin/PerformanceTests (1.2.0-pre10)
   - MobileCoin/Tests (1.2.0-pre10)
   - SwiftLint (0.45.0)
-  - SwiftNIO (2.32.3):
-    - SwiftNIOCore (= 2.32.3)
-    - SwiftNIOEmbedded (= 2.32.3)
-    - SwiftNIOPosix (= 2.32.3)
-  - SwiftNIOConcurrencyHelpers (2.32.3):
-    - CNIOAtomics (= 2.32.3)
-  - SwiftNIOCore (2.32.3):
-    - CNIOLinux (= 2.32.3)
-    - SwiftNIOConcurrencyHelpers (= 2.32.3)
-  - SwiftNIOEmbedded (2.32.3):
-    - _NIODataStructures (= 2.32.3)
-    - SwiftNIOCore (= 2.32.3)
-  - SwiftNIOExtras (1.10.2):
-    - SwiftNIO (< 3, >= 2.32.0)
-  - SwiftNIOFoundationCompat (2.32.3):
-    - SwiftNIO (= 2.32.3)
-    - SwiftNIOCore (= 2.32.3)
-  - SwiftNIOHPACK (1.18.3):
-    - SwiftNIO (< 3, >= 2.32.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.32.0)
-    - SwiftNIOCore (< 3, >= 2.32.0)
-    - SwiftNIOHTTP1 (< 3, >= 2.32.0)
-  - SwiftNIOHTTP1 (2.32.3):
-    - CNIOHTTPParser (= 2.32.3)
-    - SwiftNIO (= 2.32.3)
-    - SwiftNIOConcurrencyHelpers (= 2.32.3)
-    - SwiftNIOCore (= 2.32.3)
-  - SwiftNIOHTTP2 (1.18.3):
-    - SwiftNIO (< 3, >= 2.32.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.32.0)
-    - SwiftNIOCore (< 3, >= 2.32.0)
-    - SwiftNIOHPACK (= 1.18.3)
-    - SwiftNIOHTTP1 (< 3, >= 2.32.0)
-    - SwiftNIOTLS (< 3, >= 2.32.0)
-  - SwiftNIOPosix (2.32.3):
-    - _NIODataStructures (= 2.32.3)
-    - CNIODarwin (= 2.32.3)
-    - CNIOLinux (= 2.32.3)
-    - CNIOWindows (= 2.32.3)
-    - SwiftNIOConcurrencyHelpers (= 2.32.3)
-    - SwiftNIOCore (= 2.32.3)
-  - SwiftNIOSSL (2.15.1):
-    - CNIOBoringSSL (= 2.15.1)
-    - CNIOBoringSSLShims (= 2.15.1)
-    - SwiftNIO (< 3, >= 2.32.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.32.0)
-    - SwiftNIOCore (< 3, >= 2.32.0)
-    - SwiftNIOTLS (< 3, >= 2.32.0)
-  - SwiftNIOTLS (2.32.3):
-    - SwiftNIO (= 2.32.3)
-    - SwiftNIOCore (= 2.32.3)
-  - SwiftNIOTransportServices (1.11.3):
-    - SwiftNIO (< 3, >= 2.32.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.32.0)
-    - SwiftNIOFoundationCompat (< 3, >= 2.32.0)
-    - SwiftNIOTLS (< 3, >= 2.32.0)
-  - SwiftProtobuf (1.18.0)
+  - SwiftNIO (2.27.0):
+    - CNIODarwin (= 2.27.0)
+    - CNIOLinux (= 2.27.0)
+    - CNIOWindows (= 2.27.0)
+    - SwiftNIOConcurrencyHelpers (= 2.27.0)
+  - SwiftNIOConcurrencyHelpers (2.27.0):
+    - CNIOAtomics (= 2.27.0)
+  - SwiftNIOExtras (1.8.0):
+    - SwiftNIO (< 3, >= 2.9.0)
+  - SwiftNIOFoundationCompat (2.27.0):
+    - SwiftNIO (= 2.27.0)
+  - SwiftNIOHPACK (1.16.3):
+    - SwiftNIO (< 3, >= 2.18.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.18.0)
+    - SwiftNIOHTTP1 (< 3, >= 2.18.0)
+  - SwiftNIOHTTP1 (2.27.0):
+    - CNIOHTTPParser (= 2.27.0)
+    - SwiftNIO (= 2.27.0)
+    - SwiftNIOConcurrencyHelpers (= 2.27.0)
+  - SwiftNIOHTTP2 (1.16.3):
+    - SwiftNIO (< 3, >= 2.18.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.18.0)
+    - SwiftNIOHPACK (= 1.16.3)
+    - SwiftNIOHTTP1 (< 3, >= 2.18.0)
+    - SwiftNIOTLS (< 3, >= 2.18.0)
+  - SwiftNIOSSL (2.12.0):
+    - CNIOBoringSSL (= 2.12.0)
+    - CNIOBoringSSLShims (= 2.12.0)
+    - SwiftNIO (< 3, >= 2.15.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.15.0)
+    - SwiftNIOTLS (< 3, >= 2.15.0)
+  - SwiftNIOTLS (2.27.0):
+    - SwiftNIO (= 2.27.0)
+  - SwiftNIOTransportServices (1.10.0):
+    - SwiftNIO (< 3, >= 2.27.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.27.0)
+    - SwiftNIOFoundationCompat (< 3, >= 2.27.0)
+    - SwiftNIOTLS (< 3, >= 2.27.0)
+  - SwiftProtobuf (1.19.0)
 
 DEPENDENCIES:
   - gRPC-Swift
@@ -119,7 +100,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - _NIODataStructures
     - CGRPCZlib
     - CNIOAtomics
     - CNIOBoringSSL
@@ -133,14 +113,11 @@ SPEC REPOS:
     - SwiftLint
     - SwiftNIO
     - SwiftNIOConcurrencyHelpers
-    - SwiftNIOCore
-    - SwiftNIOEmbedded
     - SwiftNIOExtras
     - SwiftNIOFoundationCompat
     - SwiftNIOHPACK
     - SwiftNIOHTTP1
     - SwiftNIOHTTP2
-    - SwiftNIOPosix
     - SwiftNIOSSL
     - SwiftNIOTLS
     - SwiftNIOTransportServices
@@ -155,35 +132,31 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  _NIODataStructures: e2077c7dc7c1d6c93e698c85fe04d663a17f53a4
-  CGRPCZlib: 85aa377bf9000ab80ff54f12aa5b0075e1e732fd
-  CNIOAtomics: 4dde57e1838a29a9b23ef91617505f34751cdbe5
-  CNIOBoringSSL: c99129423da079a9eb74bcfc7cfec41a6775cf94
-  CNIOBoringSSLShims: 902ae35fea0b6be5eefb4fdce906751886cfa46f
-  CNIODarwin: 0489511f8486443af71ff986ccd5abbc680ae713
-  CNIOHTTPParser: f7a6816f7ddbe7dfa57a74cd36dc2db2c53b56e8
-  CNIOLinux: 5921dfefbc4bbe017380b34c510855622147ea41
-  CNIOWindows: f5aa9dfb401b440a7b4c9cd911e53e981a787193
-  gRPC-Swift: 4336e01aad8ec517734d79b2c7f64c6db9ab35e3
+  CGRPCZlib: b0c9d704a12fa667f1824ffff20688f191945989
+  CNIOAtomics: 43316aa185f4bd639aa0a9cd49741151bbe8de7f
+  CNIOBoringSSL: 2433ef7bb7f34e0903f576771c3004b42a8c30df
+  CNIOBoringSSLShims: 97f8c084e74a2d2f7e3bfa1695e4a0c7e1e7ecc5
+  CNIODarwin: 9eb3c09e9f3fc5ed47cecdd032aad926df81e3a6
+  CNIOHTTPParser: c6051552c5f332e4ec0756581e5cbd5632ca24e6
+  CNIOLinux: 79227941d64216792c3c59238b0106b9e0df25bc
+  CNIOWindows: f2baa102255e986467578337ffa2f777cb6bdf7f
+  gRPC-Swift: 77154009a019e97f8c4bd8f2bb75fe9726801157
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 40d2d7d685321a6128871b6c6b4bb7cba25e848f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 601063ea125ec87305adeb776acae28b72db7b9f
+  MobileCoin: f0f9374d921acaddb2de0eb50d2de738ff5ab1d1
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
-  SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
-  SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3
-  SwiftNIOCore: 9deed6620f80c7c82e8e2c2ffb9864495416d892
-  SwiftNIOEmbedded: b7ccf12b402dff35a5d4356990a6253621e4337d
-  SwiftNIOExtras: 70f09aa8eca3ab6baeaf1993da9c855b6e95e97f
-  SwiftNIOFoundationCompat: d3b888766e7c67354a4e4e145d38edf9586efa0c
-  SwiftNIOHPACK: e2fc784ce453bec4c058b21071e89fb7e542ac30
-  SwiftNIOHTTP1: 349a16aae363250cd49f430a9fdb93cff518adfa
-  SwiftNIOHTTP2: a0322f3dcecd949e03df65f4dac106411df0f12c
-  SwiftNIOPosix: e4988a8dcfd5a6319bde219d7a3d0acc5fbe7a89
-  SwiftNIOSSL: 7c2ddcbcbb2a8188468b7fe9c2bc6124df4b3772
-  SwiftNIOTLS: 1b8290ec775238ccc714ed842d929494df95a2c2
-  SwiftNIOTransportServices: 1fbbdb58510af3c53a838a1dbea98f18132dc952
-  SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
+  SwiftNIO: 81d33ce8c500b7e41b6cdde5f2f12330b9750219
+  SwiftNIOConcurrencyHelpers: 23fc68bac541a465162d7225d2c743edd2f1012c
+  SwiftNIOExtras: aa561b71020cd6844f722cf4513fb176c577414d
+  SwiftNIOFoundationCompat: 0e52ac0e2c9b7b60ff9141eebb64f5a82d974118
+  SwiftNIOHPACK: 38e855a72ae0c5176485ddd039b3933b99daa2b7
+  SwiftNIOHTTP1: 846277d7fc7661fba655540e529d7ba3c728ca50
+  SwiftNIOHTTP2: de7eff9d32fd347338f85b86c6fd0e13c3fbd1a0
+  SwiftNIOSSL: 6a212ff5802c39cdee830c613501fcb414218427
+  SwiftNIOTLS: 4f8df225f03393f08e0b47b4d876ae38167f8a27
+  SwiftNIOTransportServices: eee29d06a617e6b37c534d8589ae27c31b119f81
+  SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 
 PODFILE CHECKSUM: 7d2f58823b670a258c26e93d3ab390010eb33536
 

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.0-pre10):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.0-pre10)
-  - MobileCoin/CoreHTTP (1.2.0-pre10):
+  - MobileCoin (1.2.0-pre11)
+  - MobileCoin/CoreHTTP (1.2.0-pre11):
     - LibMobileCoin/CoreHTTP (~> 1.2.0-pre10)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre10):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre11):
     - LibMobileCoin/CoreHTTP (~> 1.2.0-pre10)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.0-pre10)
-  - MobileCoin/PerformanceTests (1.2.0-pre10)
-  - MobileCoin/Tests (1.2.0-pre10)
+  - MobileCoin/IntegrationTests (1.2.0-pre11)
+  - MobileCoin/PerformanceTests (1.2.0-pre11)
+  - MobileCoin/Tests (1.2.0-pre11)
   - SwiftLint (0.45.0)
   - SwiftProtobuf (1.18.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 40d2d7d685321a6128871b6c6b4bb7cba25e848f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: f0f9374d921acaddb2de0eb50d2de738ff5ab1d1
+  MobileCoin: 7eed08dfa921456a97b0df4a52c1faeae09d6697
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
 

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 40d2d7d685321a6128871b6c6b4bb7cba25e848f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 601063ea125ec87305adeb776acae28b72db7b9f
+  MobileCoin: f0f9374d921acaddb2de0eb50d2de738ff5ab1d1
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -60,11 +60,11 @@ Pod::Spec.new do |s|
 
     subspec.dependency "LibMobileCoin/Core", "~> 1.2.0-pre10"
 
-    subspec.dependency "gRPC-Swift"
+    subspec.dependency "gRPC-Swift", "~> 1.0.0"
     subspec.dependency "Logging", "~> 1.4"
-    subspec.dependency "SwiftNIO"
-    subspec.dependency "SwiftNIOHPACK"
-    subspec.dependency "SwiftNIOHTTP1"
+    subspec.dependency "SwiftNIO", "~> 2.27.0"
+    subspec.dependency "SwiftNIOHPACK", "~> 1.16.3"
+    subspec.dependency "SwiftNIOHTTP1", "~> 2.27.0"
     subspec.dependency "SwiftProtobuf"
 
     subspec.test_spec 'ProtocolUnitTests' do |test_spec|

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.0-pre10"
+  s.version      = "1.2.0-pre11"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Network/GRPC/GrpcChannelManager.swift
+++ b/Sources/Network/GRPC/GrpcChannelManager.swift
@@ -40,7 +40,7 @@ extension ClientConnection {
     {
         let builder: Builder
         if config.useTls {
-            let secureBuilder = ClientConnection.usingTLSBackedByNIOSSL(on: group)
+            let secureBuilder = ClientConnection.secure(group: group)
             if let trustRoots = config.trustRoots {
                 secureBuilder.withTLS(trustRoots: .certificates(trustRoots))
             }

--- a/Sources/Network/GRPC/GrpcConnection/ArbitraryGrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/ArbitraryGrpcConnection.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import GRPC
+import NIO
 
 class ArbitraryGrpcConnection {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/Network/GRPC/GrpcConnection/ArbitraryGrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/ArbitraryGrpcConnection.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import GRPC
-import NIOCore
 
 class ArbitraryGrpcConnection {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/AttestedGrpcConnection.swift
@@ -8,7 +8,6 @@
 import Foundation
 import GRPC
 import LibMobileCoin
-import NIOCore
 
 enum AttestedGrpcConnectionError: Error {
     case connectionError(ConnectionError)

--- a/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
+++ b/Sources/Network/GRPC/GrpcConnection/GrpcConnection.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import GRPC
-import NIOCore
 
 class GrpcConnection: ConnectionProtocol {
     private let inner: SerialDispatchLock<Inner>


### PR DESCRIPTION
Soundtrack of this PR: [Cherrelle - Saturday](https://youtu.be/efLcgUQmyT8)

### Motivation

Version lock GRPC and SwiftNIO dependencies to preserve network robustness when connections are idle. Integrating apps may see this error after a connection goes idle `NIOCore/EventLoopFuture.swift:429: Precondition failed: leaking an unfulfilled Promise`.

### In this PR
* Version locking for GRPC and SwiftNIO dependencies, latest versions cause errors
* Revert changes that were implemented based on higher-version's deprecations

### Future Work
* Fix idle connection memory leak for newer versions of GRPC & SwiftNIO
