### PR TITLE
Lock to LibMobileCoin Core 1.2.0-pre12 to avoid breaking changes

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - MobileCoin (1.2.0-pre11)
   - MobileCoin/Core (1.2.0-pre11):
     - gRPC-Swift (= 1.0.0)
-    - LibMobileCoin/Core (~> 1.2.0-pre12)
+    - LibMobileCoin/Core (= 1.2.0-pre12)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.32.0)
@@ -35,7 +35,7 @@ PODS:
     - SwiftProtobuf
   - MobileCoin/Core/ProtocolUnitTests (1.2.0-pre11):
     - gRPC-Swift (= 1.0.0)
-    - LibMobileCoin/Core (~> 1.2.0-pre12)
+    - LibMobileCoin/Core (= 1.2.0-pre12)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.32.0)
@@ -166,7 +166,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 49a5206a95b2efcb7f381ce6731cf12a76b3c9d0
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 4b4c93443b2b62b08898afc6adc53d2721d0fc71
+  MobileCoin: c5804e6cbda5450e5e0b6af0d105ebcd7391ce95
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: bb336ceef32850e9671d3fa0e0cc2b9add3b5948
   SwiftNIOConcurrencyHelpers: ca2594e10749655f42baf5468212be83d2f94fe3

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - Logging (1.4.0)
   - MobileCoin (1.2.0-pre11)
   - MobileCoin/CoreHTTP (1.2.0-pre11):
-    - LibMobileCoin/CoreHTTP (~> 1.2.0-pre12)
+    - LibMobileCoin/CoreHTTP (= 1.2.0-pre12)
     - Logging (~> 1.4)
     - SwiftLint
   - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.0-pre11):
-    - LibMobileCoin/CoreHTTP (~> 1.2.0-pre12)
+    - LibMobileCoin/CoreHTTP (= 1.2.0-pre12)
     - Logging (~> 1.4)
     - SwiftLint
   - MobileCoin/IntegrationTests (1.2.0-pre11)
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 49a5206a95b2efcb7f381ce6731cf12a76b3c9d0
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 4b4c93443b2b62b08898afc6adc53d2721d0fc71
+  MobileCoin: c5804e6cbda5450e5e0b6af0d105ebcd7391ce95
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/CoreHTTP", "~> 1.2.0-pre12"
+    subspec.dependency "LibMobileCoin/CoreHTTP", "1.2.0-pre12"
 
     subspec.dependency "Logging", "~> 1.4"
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/Core", "~> 1.2.0-pre12"
+    subspec.dependency "LibMobileCoin/Core", "1.2.0-pre12"
 
     subspec.dependency "gRPC-Swift", "1.0.0"
     subspec.dependency "Logging", "~> 1.4"


### PR DESCRIPTION
Quick fix - lock podspec to 1.2.0-pre12 for mobilecoin core