### PR TITLE
Update version of Xcode used in CICD 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "12.2.0"
+  default-xcode-version: &default-xcode-version "12.5.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment


### PR DESCRIPTION
Soundtrack of this PR: [Janet Jackson - Time Flies](https://www.youtube.com/watch?v=B2tyZjh-eD0)

### Motivation

Xcode 12.2 is kind of old now, and we need 12.5 for some new features in XCTest.

### In this PR
* Update Xcode version used in CICD 
