### PR TITLE
Linting Improvements - `pre-commit` hooks & CICD Strict Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,30 @@ jobs:
       - store_artifacts: { path: ~/Library/Logs/DiagnosticReports }
       - check-dirty-git
 
+  swiftlint:
+    parameters:
+      xcode-version:
+        type: string
+        default: *default-xcode-version
+    macos:
+      xcode: << parameters.xcode-version >>
+    environment:
+      <<: *default-environment
+      FL_BUILDLOG_PATH: ../output/buildlogs
+      SCAN_OUTPUT_DIRECTORY: ../output/scan
+      SCAN_OUTPUT_TYPES: junit
+    steps:
+      - checkout
+      - init-artifacts-submodule
+      - set-ruby-version
+      - install-gems
+      - print-tool-versions
+      - run:
+          name: Install swiftlint
+          command: brew install swiftlint
+      - run: make lint-strict
+      - check-dirty-git
+
   generate-docs:
     parameters:
       xcode-version:
@@ -360,6 +384,11 @@ workflows:
               xcode-version: [*default-xcode-version]
       - build-and-test-example-http:
           name: build-and-test-example-http-xcode-<< matrix.xcode-version >>
+          matrix:
+            parameters:
+              xcode-version: [*default-xcode-version]
+      - swiftlint:
+          name: swiftlint-<< matrix.xcode-version >>
           matrix:
             parameters:
               xcode-version: [*default-xcode-version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: local
+    hooks:
+      - id: autocorrect
+        name: autocorrect
+        entry: ./scripts/autocorrect.sh
+        language: script
+        files: \.swift$
+  - repo: https://github.com/realm/SwiftLint
+    rev: 0.46.0
+    hooks:
+      - id: swiftlint

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ clean-example-http: clean-docs
 .PHONY: lint
 lint: swiftlint
 
+.PHONY: lint-strict
+lint: swiftlint --strict
+
 .PHONY: lint-all
 lint-all: lint lint-circleci lint-podspec lint-docs
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clean-example-http: clean-docs
 lint: swiftlint
 
 .PHONY: lint-strict
-lint: swiftlint --strict
+lint-strict: swiftlint --strict
 
 .PHONY: lint-all
 lint-all: lint lint-circleci lint-podspec lint-docs

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ The workspace can be built with `make`.
     gem install bundler
     ```
 
+1. Install swiftlint
+
+    ```
+    brew install swiftlint
+    ```
+
+1. Install pre-commit
+
+    ```
+    brew install pre-commit
+    pre-commit install
+    ```
+
 1. Build the MobileCoin Swift SDK
 
     ```

--- a/scripts/autocorrect.sh
+++ b/scripts/autocorrect.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SWIFT_LINT=$(which swiftlint)
+
+# Change directory to repo root
+cd "$(git rev-parse --show-toplevel)" || exit;
+
+if [[ -e "${SWIFT_LINT}" ]]; then
+    # Export files in SCRIPT_INPUT_FILE_$count to lint against later
+    count=0
+    while IFS= read -r file_path; do
+        export SCRIPT_INPUT_FILE_$count="$file_path"
+        count=$((count + 1))
+    done < <(git diff --name-only --diff-filter=d | grep ".swift$")
+    export SCRIPT_INPUT_FILE_COUNT=$count
+
+    if [ "$count" -eq 0 ]; then
+        echo "No files to lint!"
+        exit 0
+    fi
+
+    echo "Found $count lintable files! Linting now.."
+    $SWIFT_LINT autocorrect --use-script-input-files --config "$(git rev-parse --show-toplevel)/.swiftlint.yml"
+    $SWIFT_LINT --use-script-input-files --strict --config "$(git rev-parse --show-toplevel)/.swiftlint.yml"
+    RESULT=$? # swiftline exit value is number of errors
+
+    if [ $RESULT -eq 0 ]; then
+        echo "🎉  Well done. No violation."
+    fi
+    exit $RESULT
+else
+    echo "⚠️  WARNING: SwiftLint not found in $SWIFT_LINT"
+    echo "⚠️  You might want to edit .git/hooks/pre-commit to locate your swiftlint"
+    exit 0
+fi


### PR DESCRIPTION
Soundtrack of this PR: [Drexciya - Sighting in the Abyss](https://www.youtube.com/watch?v=pry4TMuSnbY)

### Motivation

In an effort to improve and enforce high-quality coding standards. Linting is now part of CICD. Any linting warning will cause a test failure and must be fixed before merge.

Additionally to help keep warnings to a minimum a `swiftlint autocorrect` pre-commit hook will run on all changed files, and then a `swiftlint lint` will run on those same files which will highlight any remaining linting issues. Not all warnings are auto-correctable. 

### In this PR
* Add pre-commit config
* Update .circleci to enforce strict linting rules
* Update README.md with new setup instructions

### Future Work
* Fix all outstanding linting issues
