### PR TITLE
Change to filter non-MOB transactions for legacy txOuts property of A…

### DIFF
--- a/Sources/Account/AccountActivity.swift
+++ b/Sources/Account/AccountActivity.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//  Copyright (c) 2020-2022 MobileCoin. All rights reserved.
 //
 
 import Foundation
@@ -7,12 +7,14 @@ import Foundation
 /// Provides a snapshot of account activity at a particular point in the ledger, as indicated by
 /// `blockCount`.
 public struct AccountActivity {
+    public let allTxOuts: Set<OwnedTxOut>
+    @available(*, deprecated, message: "use new allTxOuts property")
     public let txOuts: Set<OwnedTxOut>
-
     public let blockCount: UInt64
 
     init(txOuts: [OwnedTxOut], blockCount: UInt64) {
-        self.txOuts = Set(txOuts)
+        self.allTxOuts = Set(txOuts)
+        self.txOuts = self.allTxOuts.filter { $0.tokenId == .MOB }
         self.blockCount = blockCount
     }
 }

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -104,8 +104,8 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 
             let accountActivity = client.accountActivity
 
-            print("txOuts.count: \(accountActivity.txOuts.count)")
-            XCTAssertGreaterThan(accountActivity.txOuts.count, 0)
+            print("txOuts.count: \(accountActivity.allTxOuts.count)")
+            XCTAssertGreaterThan(accountActivity.allTxOuts.count, 0)
 
             print("blockCount: \(accountActivity.blockCount)")
             XCTAssertGreaterThan(accountActivity.blockCount, 0)
@@ -773,7 +773,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 extension AccountActivity {
     public func describeUnspentTxOuts() -> String {
         [
-            self.txOuts.filter { $0.spentBlock == nil }.map {
+            self.allTxOuts.filter { $0.spentBlock == nil }.map {
                 "Unspent TxOut \($0.value) \($0.tokenId.name)"
             }
         ]

--- a/Tests/Unit/Account/BalanceTests.swift
+++ b/Tests/Unit/Account/BalanceTests.swift
@@ -72,10 +72,10 @@ extension BalanceTests.Fixtures {
     static func describe(accountActivity: AccountActivity) -> String {
         [
             ["Account Activity:"],
-            accountActivity.txOuts.filter { $0.spentBlock != nil }.map {
+            accountActivity.allTxOuts.filter { $0.spentBlock != nil }.map {
                 "TxOut Spent in Block \($0.spentBlock!), \($0.value) \($0.tokenId.name)"
             },
-            accountActivity.txOuts.filter { $0.spentBlock == nil }.map {
+            accountActivity.allTxOuts.filter { $0.spentBlock == nil }.map {
                 "Unspent TxOut \($0.value) \($0.tokenId.name)"
             }
         ]


### PR DESCRIPTION
Quick change to filter txOuts to only MOB so non MOB transactions don't apear in Signal's history.

Note, there may be a better alternate approach for iOS - I'll submit another PR early tomrrow.

I think for iOS, it'll be better to keep the AccountActivity struct as-is, and to modify the MobileCoinClient's methods as follows:

```
    public var accountActivity: AccountActivity {
        accountActivity(for: .MOB)
    }

    public func accountActivity(for tokenId: TokenId) -> AccountActivity {
        accountLock.readSync { $0.cachedAccountActivity(for: tokenId) }
    }
```

and add corresponding support to filter for cachedAccountActivity...