### PR TITLE
Fix integration test issues

### DIFF
--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -156,8 +156,10 @@ extension NetworkPreset {
             return "mc://node1.prod.mobilecoinww.com"
         case .testNet:
             return "mc://node1.test.mobilecoin.com"
+        case .alpha:
+            return "mc://node1.alpha.development.mobilecoin.com"
 
-        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+        case .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return "mc://node1.\(self).mobilecoin.com"
         case .dynamic(let preset):
             return "mc://node1.\(preset.namespace).\(preset.environment).mobilecoin.com"
@@ -169,8 +171,10 @@ extension NetworkPreset {
             return "fog://fog.prod.mobilecoinww.com"
         case .testNet:
             return "fog://fog.test.mobilecoin.com"
+        case .alpha:
+            return "fog://fog.alpha.development.mobilecoin.com"
 
-        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+        case .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return "fog://fog.\(self).mobilecoin.com"
         case .dynamic(let preset):
             return "fog://\(preset.user)fog." +
@@ -483,6 +487,7 @@ extension NetworkPreset {
                 allowedHardeningAdvisories: ["INTEL-SA-00334"]))
         }
     }
+
     func fogViewAttestation() throws -> Attestation {
         switch networkGroup {
         case .mainNet:
@@ -497,6 +502,7 @@ extension NetworkPreset {
                 allowedHardeningAdvisories: ["INTEL-SA-00334"]))
         }
     }
+
     func fogLedgerAttestation() throws -> Attestation {
         switch networkGroup {
         case .mainNet:
@@ -511,6 +517,7 @@ extension NetworkPreset {
                 allowedHardeningAdvisories: ["INTEL-SA-00334"]))
         }
     }
+
     func fogReportAttestation() throws -> Attestation {
         switch networkGroup {
         case .mainNet:
@@ -525,6 +532,7 @@ extension NetworkPreset {
                 allowedHardeningAdvisories: ["INTEL-SA-00334"]))
         }
     }
+
     private func defaultAttestation(mrEnclaveHex: String) throws -> Attestation {
         Attestation(mrEnclaves: [
             try XCTUnwrapSuccess(Attestation.MrEnclave.make(
@@ -545,6 +553,7 @@ extension NetworkPreset {
             return false
         }
     }
+
     var consensusCredentials: BasicCredentials? {
         switch self {
         case .mainNet, .testNet:
@@ -565,6 +574,7 @@ extension NetworkPreset {
             return true
         }
     }
+
     var fogUserCredentials: BasicCredentials? {
         switch self {
         case .mainNet, .testNet:

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -556,19 +556,19 @@ extension NetworkPreset {
 
     var consensusCredentials: BasicCredentials? {
         switch self {
-        case .mainNet, .testNet:
+        case .mainNet, .testNet, .mobiledev:
             // No credentials necessary.
             return nil
-        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran, .dynamic:
+        case .alpha, .master, .build, .demo, .diogenes, .drakeley, .eran, .dynamic:
             return BasicCredentials(username: Self.devAuthUsername, password: Self.devAuthPassword)
         }
     }
 
     var fogRequiresCredentials: Bool {
         switch self {
-        case .mainNet, .testNet:
+        case .mainNet, .testNet, .mobiledev:
             return false
-        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+        case .alpha, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return true
         case .dynamic:
             return true
@@ -577,10 +577,10 @@ extension NetworkPreset {
 
     var fogUserCredentials: BasicCredentials? {
         switch self {
-        case .mainNet, .testNet:
+        case .mainNet, .testNet, .mobiledev:
             // No credentials necessary.
             return nil
-        case .alpha, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+        case .alpha, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return BasicCredentials(username: Self.devAuthUsername, password: Self.devAuthPassword)
         case .dynamic:
             return BasicCredentials(username: Self.devAuthUsername, password: Self.devAuthPassword)

--- a/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -156,7 +156,8 @@ extension FogKeyImageConnectionIntTests {
     func createFogKeyImageConnectionWithInvalidCredentials(
         transportProtocol: TransportProtocol
     ) throws -> FogKeyImageConnection {
-        let networkConfig = try NetworkConfigFixtures.create(using: transportProtocol)
+        let networkConfig = try NetworkConfigFixtures.createWithInvalidCredentials(
+                using: transportProtocol)
         return createFogKeyImageConnection(networkConfig: networkConfig)
     }
 


### PR DESCRIPTION
### Motivation

Fixing integration tests... 

### In this PR
* cert pinning was failing b/c alpha URL was updated, and old URL did not have matching SecKey.  Updating to new URL allows cert pinning to succeed for alpha integration tests.
* fixed one of the invalid creds int tests - it was creating valid creds instead of invalid creds, causing test to fail.
* disable auth for mobileDev env - not required as per @jgreat 