### PR TITLE
return consensus block index from submitTransaction

### DIFF
--- a/Sources/Common/Errors.swift
+++ b/Sources/Common/Errors.swift
@@ -142,13 +142,25 @@ extension DefragTransactionPreparationError: CustomStringConvertible {
     }
 }
 
+public struct SubmitTransactionError: Error {
+    public let submissionError: TransactionSubmissionError
+    public let consensusBlockCount: UInt64?
+}
+
+extension SubmitTransactionError: CustomStringConvertible {
+    public var description: String {
+        "Submit Transaction Error: Consensus Block Count == \(consensusBlockCount), " +
+        "\(submissionError)"
+    }
+}
+
 public enum TransactionSubmissionError: Error {
     case connectionError(ConnectionError)
-    case invalidTransaction(UInt64, String = String())
-    case feeError(UInt64, String = String())
-    case tombstoneBlockTooFar(UInt64, String = String())
-    case missingMemo(UInt64, String = String())
-    case inputsAlreadySpent(UInt64, String = String())
+    case invalidTransaction(String = String())
+    case feeError(String = String())
+    case tombstoneBlockTooFar(String = String())
+    case missingMemo(String = String())
+    case inputsAlreadySpent(String = String())
 }
 
 extension TransactionSubmissionError: CustomStringConvertible {
@@ -157,15 +169,15 @@ extension TransactionSubmissionError: CustomStringConvertible {
             switch self {
             case .connectionError(let connectionError):
                 return "\(connectionError)"
-            case .missingMemo(_, let reason):
+            case .missingMemo(let reason):
                 return "Missing memo error\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .feeError(_, let reason):
+            case .feeError(let reason):
                 return "Fee error\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .invalidTransaction(_, let reason):
+            case .invalidTransaction(let reason):
                 return "Invalid transaction\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .tombstoneBlockTooFar(_, let reason):
+            case .tombstoneBlockTooFar(let reason):
                 return "Tombstone block too far\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .inputsAlreadySpent(_, let reason):
+            case .inputsAlreadySpent(let reason):
                 return "Inputs already spent\(!reason.isEmpty ? ": \(reason)" : "")"
             }
         }()

--- a/Sources/Common/Errors.swift
+++ b/Sources/Common/Errors.swift
@@ -144,11 +144,11 @@ extension DefragTransactionPreparationError: CustomStringConvertible {
 
 public enum TransactionSubmissionError: Error {
     case connectionError(ConnectionError)
-    case invalidTransaction(String = String())
-    case feeError(String = String())
-    case tombstoneBlockTooFar(String = String())
-    case missingMemo(String = String())
-    case inputsAlreadySpent(String = String())
+    case invalidTransaction(UInt64, String = String())
+    case feeError(UInt64, String = String())
+    case tombstoneBlockTooFar(UInt64, String = String())
+    case missingMemo(UInt64, String = String())
+    case inputsAlreadySpent(UInt64, String = String())
 }
 
 extension TransactionSubmissionError: CustomStringConvertible {
@@ -157,15 +157,15 @@ extension TransactionSubmissionError: CustomStringConvertible {
             switch self {
             case .connectionError(let connectionError):
                 return "\(connectionError)"
-            case .missingMemo(let reason):
+            case .missingMemo(_, let reason):
                 return "Missing memo error\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .feeError(let reason):
+            case .feeError(_, let reason):
                 return "Fee error\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .invalidTransaction(let reason):
+            case .invalidTransaction(_, let reason):
                 return "Invalid transaction\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .tombstoneBlockTooFar(let reason):
+            case .tombstoneBlockTooFar(_, let reason):
                 return "Tombstone block too far\(!reason.isEmpty ? ": \(reason)" : "")"
-            case .inputsAlreadySpent(let reason):
+            case .inputsAlreadySpent(_, let reason):
                 return "Inputs already spent\(!reason.isEmpty ? ": \(reason)" : "")"
             }
         }()

--- a/Sources/MobileCoinClient+Deprecated.swift
+++ b/Sources/MobileCoinClient+Deprecated.swift
@@ -238,4 +238,36 @@ extension MobileCoinClient {
             completion: completion)
     }
 
+    @available(*, deprecated, message:
+        """
+        Use the new `submitTransaction(...)` which accepts a completion closure with a new result
+        type with the success type being a UInt64 representing the conensus block height, and the
+        failure type is a new error `SubmitTransactionError` which wraps the consensus block height
+        and the existing `TransactionSubmissionError`. Consensus Block Height can be useful for
+        querying fog to get information about the block your transaction landed in and/or when
+        determining the "freshness"/"staleness" of an AccountActivitySnapshot.
+
+        ```
+        public func submitTransaction(
+            transaction: Transaction,
+            completion: @escaping (Result<UInt64, SubmitTransactionError>) -> Void
+        )
+        ```
+
+        this function prepares transactions assuming assuming the default TokenId == .MOB
+        """)
+    public func submitTransaction(
+        _ transaction: Transaction,
+        completion: @escaping (Result<(), TransactionSubmissionError>) -> Void
+    ) {
+        // Wrap the new call, and map the success and error states for existing signature.
+        submitTransaction(transaction: transaction) { result in
+            completion(result.map({ _ in
+                ()
+            }).mapError({ submitTransactionError in
+                submitTransactionError.submissionError
+            }))
+        }
+    }
+
 }

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -271,8 +271,8 @@ public final class MobileCoinClient {
     }
 
     public func submitTransaction(
-        _ transaction: Transaction,
-        completion: @escaping (Result<(UInt64), TransactionSubmissionError>) -> Void
+        transaction: Transaction,
+        completion: @escaping (Result<UInt64, SubmitTransactionError>) -> Void
     ) {
         TransactionSubmitter(
             consensusService: serviceProvider.consensusService,

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -272,7 +272,7 @@ public final class MobileCoinClient {
 
     public func submitTransaction(
         _ transaction: Transaction,
-        completion: @escaping (Result<(), TransactionSubmissionError>) -> Void
+        completion: @escaping (Result<(UInt64), TransactionSubmissionError>) -> Void
     ) {
         TransactionSubmitter(
             consensusService: serviceProvider.consensusService,

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -22,7 +22,7 @@ struct TransactionSubmitter {
 
     func submitTransaction(
         _ transaction: Transaction,
-        completion: @escaping (Result<(), TransactionSubmissionError>) -> Void
+        completion: @escaping (Result<(UInt64), TransactionSubmissionError>) -> Void
     ) {
         logger.info(
             "Submitting transaction... transaction: " +
@@ -58,11 +58,11 @@ struct TransactionSubmitter {
     }
 
     func processResponse(_ response: ConsensusCommon_ProposeTxResponse)
-        -> Result<(), TransactionSubmissionError>
+        -> Result<(UInt64), TransactionSubmissionError>
     {
         switch response.result {
         case .ok:
-            return .success(())
+            return .success((response.blockIndex - 1))
         case .inputsProofsLengthMismatch, .noInputs, .tooManyInputs,
              .insufficientInputSignatures, .invalidInputSignature,
              .invalidTransactionSignature, .invalidRangeProof, .insufficientRingSize,

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -75,15 +75,15 @@ struct TransactionSubmitter {
              .membershipProofValidationError, .keyError, .unsortedInputs,
              .tokenNotYetConfigured, .missingMaskedTokenID, .maskedTokenIDNotAllowed,
              .unsortedOutputs:
-            return .failure(.invalidTransaction(
+            return .failure(.invalidTransaction(blockIndex,
                         "Error Code: \(response.result) " +
                         "(\(response.result.rawValue))"))
         case .txFeeError:
-            return .failure(.feeError())
+            return .failure(.feeError(blockIndex))
         case .tombstoneBlockTooFar:
-            return .failure(.tombstoneBlockTooFar())
+            return .failure(.tombstoneBlockTooFar(blockIndex))
         case .missingMemo:
-            return .failure(.missingMemo("Missing memo"))
+            return .failure(.missingMemo(blockIndex, "Missing memo"))
         case .containsSpentKeyImage, .containsExistingOutputPublicKey:
             // This exact Tx might have already been submitted (and succeeded), or else the
             // inputs were already spent by another Tx.
@@ -96,7 +96,7 @@ struct TransactionSubmitter {
             // For the time being, we'll just return .inputsAlreadySpent and let the user
             // decide how they want to proceed. Note: performing a Transaction status check
             // can help disambiguate the situation.
-            return .failure(.inputsAlreadySpent())
+            return .failure(.inputsAlreadySpent(blockIndex))
         case .ledger:
             return .failure(.connectionError(
                 .invalidServerResponse("Consensus.proposeTx returned ledger error")))

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -33,13 +33,13 @@ struct TransactionSubmitter {
             switch $0 {
             case .success(let response):
                 // Consensus Block Index Cannot be less than 0
-                let blockCount = response.blockCount > 0 ? response.blockCount - 1 : 0
+                let blockIndex = response.blockCount > 0 ? response.blockCount - 1 : 0
 
                 syncCheckerLock.writeSync {
-                    $0.setConsensusHighestKnownBlock(blockCount)
+                    $0.setConsensusHighestKnownBlock(blockIndex)
                 }
 
-                let responseResult = self.processResponse(response, blockCount)
+                let responseResult = self.processResponse(response, blockIndex)
 
                 if case .txFeeError = response.result {
                     self.metaFetcher.resetCache {
@@ -58,12 +58,12 @@ struct TransactionSubmitter {
         }
     }
 
-    func processResponse(_ response: ConsensusCommon_ProposeTxResponse, _ blockCount: UInt64)
+    func processResponse(_ response: ConsensusCommon_ProposeTxResponse, _ blockIndex: UInt64)
         -> Result<(UInt64), TransactionSubmissionError>
     {
         switch response.result {
         case .ok:
-            return .success(blockCount)
+            return .success(blockIndex)
         case .inputsProofsLengthMismatch, .noInputs, .tooManyInputs,
              .insufficientInputSignatures, .invalidInputSignature,
              .invalidTransactionSignature, .invalidRangeProof, .insufficientRingSize,

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -33,7 +33,7 @@ struct TransactionSubmitter {
             switch $0 {
             case .success(let response):
                 // Consensus Block Index Cannot be less than 0
-                let blockCount = response.blockCount > 0 ? response.blockCount - 1 : 0;
+                let blockCount = response.blockCount > 0 ? response.blockCount - 1 : 0
 
                 syncCheckerLock.writeSync {
                     $0.setConsensusHighestKnownBlock(blockCount)

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -75,7 +75,8 @@ struct TransactionSubmitter {
              .membershipProofValidationError, .keyError, .unsortedInputs,
              .tokenNotYetConfigured, .missingMaskedTokenID, .maskedTokenIDNotAllowed,
              .unsortedOutputs:
-            return .failure(.invalidTransaction(blockIndex,
+            return .failure(.invalidTransaction(
+                        blockIndex,
                         "Error Code: \(response.result) " +
                         "(\(response.result.rawValue))"))
         case .txFeeError:

--- a/Sources/Transaction/TransactionSubmitter.swift
+++ b/Sources/Transaction/TransactionSubmitter.swift
@@ -22,7 +22,7 @@ struct TransactionSubmitter {
 
     func submitTransaction(
         _ transaction: Transaction,
-        completion: @escaping (Result<(UInt64), SubmitTransactionError>) -> Void
+        completion: @escaping (Result<UInt64, SubmitTransactionError>) -> Void
     ) {
         logger.info(
             "Submitting transaction... transaction: " +
@@ -64,7 +64,7 @@ struct TransactionSubmitter {
     }
 
     func processResponse(_ response: ConsensusCommon_ProposeTxResponse, _ blockIndex: UInt64)
-        -> Result<(UInt64), TransactionSubmissionError>
+        -> Result<UInt64, TransactionSubmissionError>
     {
         switch response.result {
         case .ok:


### PR DESCRIPTION
### Motivation

[task](https://www.pivotaltracker.com/story/show/182613898)

[comment on Moby Idempotence document](https://docs.google.com/document/d/1ayX6H_EjeCRVhu8lqUi7y1-D14RqyGDrewu70XcpYGY/edit?disco=AAAAbNCWhqI):

> Alex Voloshyn: 
> 1. KeyImages can be retrieved from TxOuts. (i.e. OwnedTxOut.getKeyImage)
> 2. Transaction object contains all KeyImages as a set (i.e. transaction.getKeyImages)
> 3. Fog View, Fog Ledger, and Consensus are all separate services with separate block heights. The SDK simplifies working with Fog by synchronizing View and Ledger block heights, but not consensus. So if you see that consensus is at block 1000 and it returns ContansSpentImages you will need to query Fog until it reports block height 1000 as well. (getTransactionStatus returns Status that contains current Fog block index, AccountSnapshot contains block index, etc). **SubmitTransaction does not return the consensus block index, so we will need to either add that or make BlockchainClient block height public to have it available at all times, not only after you submit**.

### In this PR
* return consensus block index from `submitTransaction`

### Related PR (Android):

https://github.com/mobilecoinofficial/android-sdk/pull/94