### PR TITLE
Release v1.2.2-pre1 w/ new `submitTransaction` API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-pre1] - 2022-07-13
+
+### Added
+
+- New method for `submitTransaction` that always returns the conensus block count
+
+### Changed
+
+- Old method for `submitTransaction` deprecated
+
 ## [1.2.2-pre0] - 2022-06-24
 
 ### Changed

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre0)
-  - MobileCoin/Core (1.2.2-pre0):
+  - MobileCoin (1.2.2-pre1)
+  - MobileCoin/Core (1.2.2-pre1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre0):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.2-pre0)
-  - MobileCoin/PerformanceTests (1.2.2-pre0)
-  - MobileCoin/Tests (1.2.2-pre0)
+  - MobileCoin/IntegrationTests (1.2.2-pre1)
+  - MobileCoin/PerformanceTests (1.2.2-pre1)
+  - MobileCoin/Tests (1.2.2-pre1)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 6b26750c072f65c51f5e930176dc4dc3e73994ad
+  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.1):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre0)
-  - MobileCoin/CoreHTTP (1.2.2-pre0):
+  - MobileCoin (1.2.2-pre1)
+  - MobileCoin/CoreHTTP (1.2.2-pre1):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre0):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre1):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.2-pre0)
-  - MobileCoin/PerformanceTests (1.2.2-pre0)
-  - MobileCoin/Tests (1.2.2-pre0)
+  - MobileCoin/IntegrationTests (1.2.2-pre1)
+  - MobileCoin/PerformanceTests (1.2.2-pre1)
+  - MobileCoin/Tests (1.2.2-pre1)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 6b26750c072f65c51f5e930176dc4dc3e73994ad
+  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.2-pre0"
+  s.version      = "1.2.2-pre1"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"


### PR DESCRIPTION
Soundtrack of this PR: [Larry Heard - The Sun Can't Compare](https://www.youtube.com/watch?v=tdIQTEYXDP4)

### Motivation

Having the consensus block count for success and failure from the `submitTransaction` call is important. That change was previously added in this PR - https://github.com/mobilecoinofficial/MobileCoin-Swift/pull/160 - but not released. This PR updates the CHANGELOG and releases the latest code from master.

### In this PR
* Increment Version
* Update CHANGELOG.md
