### PR TITLE
Release v1.2.2-pre2 simulate multiple enclave measurements on testNet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-pre1] - 2022-07-13
+
+### Added
+
+- New method for `submitTransaction` that always returns the conensus block count
+
+### Changed
+
+- Old method for `submitTransaction` deprecated
+
 ## [1.2.2-pre0] - 2022-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-pre2] - 2022-07-13
+
+### Added
+
+- New testNet enclave measurements
+
 ## [1.2.2-pre1] - 2022-07-13
 
 ### Added

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre1)
-  - MobileCoin/Core (1.2.2-pre1):
+  - MobileCoin (1.2.2-pre2)
+  - MobileCoin/Core (1.2.2-pre2):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre1):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre2):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.2-pre1)
-  - MobileCoin/PerformanceTests (1.2.2-pre1)
-  - MobileCoin/Tests (1.2.2-pre1)
+  - MobileCoin/IntegrationTests (1.2.2-pre2)
+  - MobileCoin/PerformanceTests (1.2.2-pre2)
+  - MobileCoin/Tests (1.2.2-pre2)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
+  MobileCoin: c0a11748165ff40ce23f98ae63f4521f7a4e7042
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre0)
-  - MobileCoin/Core (1.2.2-pre0):
+  - MobileCoin (1.2.2-pre1)
+  - MobileCoin/Core (1.2.2-pre1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre0):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.2-pre0)
-  - MobileCoin/PerformanceTests (1.2.2-pre0)
-  - MobileCoin/Tests (1.2.2-pre0)
+  - MobileCoin/IntegrationTests (1.2.2-pre1)
+  - MobileCoin/PerformanceTests (1.2.2-pre1)
+  - MobileCoin/Tests (1.2.2-pre1)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 6b26750c072f65c51f5e930176dc4dc3e73994ad
+  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.1):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre1)
-  - MobileCoin/CoreHTTP (1.2.2-pre1):
+  - MobileCoin (1.2.2-pre2)
+  - MobileCoin/CoreHTTP (1.2.2-pre2):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre1):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre2):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.2-pre1)
-  - MobileCoin/PerformanceTests (1.2.2-pre1)
-  - MobileCoin/Tests (1.2.2-pre1)
+  - MobileCoin/IntegrationTests (1.2.2-pre2)
+  - MobileCoin/PerformanceTests (1.2.2-pre2)
+  - MobileCoin/Tests (1.2.2-pre2)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
+  MobileCoin: c0a11748165ff40ce23f98ae63f4521f7a4e7042
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.1):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre0)
-  - MobileCoin/CoreHTTP (1.2.2-pre0):
+  - MobileCoin (1.2.2-pre1)
+  - MobileCoin/CoreHTTP (1.2.2-pre1):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre0):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre1):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.2-pre0)
-  - MobileCoin/PerformanceTests (1.2.2-pre0)
-  - MobileCoin/Tests (1.2.2-pre0)
+  - MobileCoin/IntegrationTests (1.2.2-pre1)
+  - MobileCoin/PerformanceTests (1.2.2-pre1)
+  - MobileCoin/Tests (1.2.2-pre1)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 6b26750c072f65c51f5e930176dc4dc3e73994ad
+  MobileCoin: d3b11483e01785d082fb3d57715ae0abf54374ee
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.2-pre0"
+  s.version      = "1.2.2-pre1"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.2-pre1"
+  s.version      = "1.2.2-pre2"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Common/Errors.swift
+++ b/Sources/Common/Errors.swift
@@ -149,7 +149,8 @@ public struct SubmitTransactionError: Error {
 
 extension SubmitTransactionError: CustomStringConvertible {
     public var description: String {
-        "Submit Transaction Error: Consensus Block Count == \(consensusBlockCount), " +
+        "Submit Transaction Error: " +
+        "Consensus Block Count == \(consensusBlockCount?.description ?? "nil"), " +
         "\(submissionError)"
     }
 }

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-public struct SignedContingentInput {
-
-}
-
 public final class MobileCoinClient {
     /// - Returns: `InvalidInputError` when `accountKey` isn't configured to use Fog.
     public static func make(accountKey: AccountKey, config: Config)
@@ -190,27 +186,6 @@ public final class MobileCoinClient {
             txOutSelectionStrategy: txOutSelectionStrategy,
             targetQueue: serialQueue
         ).requiresDefragmentation(toSendAmount: amount, feeLevel: feeLevel, completion: completion)
-    }
-
-    public func prepareSCI(
-        inputAmount: Amount,
-        outputAmount: Amount,
-        completion: @escaping (
-            Result<PendingSinglePayloadTransaction, TransactionPreparationError>
-        ) -> Void
-    ) {
-        // Create a new public type for the transaction Fragment, which can be shared with others.
-        // Return SignedContingentInput
-    }
-
-    public func prepareTransactionWithSCI(
-        sci: SignedContingentInput,
-        completion: @escaping (
-            Result<PendingSinglePayloadTransaction, TransactionPreparationError>
-        ) -> Void
-    ) {
-        // Create a new public type for the transaction Fragment, which can be shared with others.
-        // Return SignedContingentInput
     }
 
     public func prepareTransaction(

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+public struct SignedContingentInput {
+
+}
+
 public final class MobileCoinClient {
     /// - Returns: `InvalidInputError` when `accountKey` isn't configured to use Fog.
     public static func make(accountKey: AccountKey, config: Config)
@@ -186,6 +190,27 @@ public final class MobileCoinClient {
             txOutSelectionStrategy: txOutSelectionStrategy,
             targetQueue: serialQueue
         ).requiresDefragmentation(toSendAmount: amount, feeLevel: feeLevel, completion: completion)
+    }
+
+    public func prepareSCI(
+        inputAmount: Amount,
+        outputAmount: Amount,
+        completion: @escaping (
+            Result<PendingSinglePayloadTransaction, TransactionPreparationError>
+        ) -> Void
+    ) {
+        // Create a new public type for the transaction Fragment, which can be shared with others.
+        // Return SignedContingentInput
+    }
+
+    public func prepareTransactionWithSCI(
+        sci: SignedContingentInput,
+        completion: @escaping (
+            Result<PendingSinglePayloadTransaction, TransactionPreparationError>
+        ) -> Void
+    ) {
+        // Create a new public type for the transaction Fragment, which can be shared with others.
+        // Return SignedContingentInput
     }
 
     public func prepareTransaction(

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -1,7 +1,7 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-// swiftlint:disable file_length multiline_function_chains
+// swiftlint:disable file_length multiline_function_chains vertical_parameter_alignment_on_call
 
 @testable import MobileCoin
 import XCTest
@@ -213,14 +213,25 @@ extension NetworkPreset {
 //    private static let mainNetFogReportMrEnclaveHex =
 //        "709ab90621e3a8d9eb26ed9e2830e091beceebd55fb01c5d7c31d27e83b9b0d1"
 
-    private static let testNetConsensusMrEnclaveHex =
+    // v1.1.0 Enclave Values
+    private static let legacy_v1_1_0_testNetConsensusMrEnclaveHex =
         "9659ea738275b3999bf1700398b60281be03af5cb399738a89b49ea2496595af"
-    private static let testNetFogViewMrEnclaveHex =
+    private static let legacy_v1_1_0_testNetFogViewMrEnclaveHex =
         "e154f108c7758b5aa7161c3824c176f0c20f63012463bf3cc5651e678f02fb9e"
-    private static let testNetFogLedgerMrEnclaveHex =
+    private static let legacy_v1_1_0_testNetFogLedgerMrEnclaveHex =
         "768f7bea6171fb83d775ee8485e4b5fcebf5f664ca7e8b9ceef9c7c21e9d9bf3"
-    private static let testNetFogReportMrEnclaveHex =
+    private static let legacy_v1_1_0_testNetFogReportMrEnclaveHex =
         "a4764346f91979b4906d4ce26102228efe3aba39216dec1e7d22e6b06f919f11"
+
+    // v1.2.0 Enclave Values
+    private static let testNetConsensusMrEnclaveHex =
+        "4f134dcfd9c0885956f2f9af0f05c2050d8bdee2dc63b468a640670d7adeb7f8"
+    private static let testNetFogViewMrEnclaveHex =
+        "719ca43abbe02f507bb91ea11ff8bc900aa86363a7d7e77b8130426fc53d8684"
+    private static let testNetFogLedgerMrEnclaveHex =
+        "685481b33f2846585f33506ab65649c98a4a6d1244989651fd0fcde904ebd82f"
+    private static let testNetFogReportMrEnclaveHex =
+        "8f2f3bf81f24bf493fa6d76e29e0f081815022592b1e854f95bda750aece7452"
 
     private static let devMrSignerHex =
         "7ee5e29d74623fdbc6fbf1454be6f3bb0b86c12366b7b478ad13353e44de8411"
@@ -237,17 +248,17 @@ extension NetworkPreset {
         AwEAAQ==
         """
     private static let testNetFogAuthoritySpkiB64Encoded = """
-        MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rI\
-        XiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFF\
-        jVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9\
-        yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9b\
-        kS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI\
-        /cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvS\
-        pp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPI\
-        EOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cC\
-        AwEAAQ==
+        MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOA\
+        Qj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALA\
+        WNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeT\
+        CvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTAT\
+        V8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ\
+        7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK\
+        9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSE\
+        TxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOh\
+        Yh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCV\
+        rQYHI2cCAwEAAQ==
         """
-
     private static let alphaFogAuthoritySpkiB64Encoded = """
         MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyFOockvCEc9TcO1NvsiUfFVzvtDsR64UIRRUl3tBM2Bh8KB\
         A932/Up86RtgJVnbslxuUCrTJZCV4dgd5hAo/mzuJOy9lAGxUTpwWWG0zZJdpt8HJRVLX76CBpWrWEt7JMoEmduvsCR\
@@ -478,7 +489,9 @@ extension NetworkPreset {
         case .mainNet:
             return try defaultAttestation(mrEnclaveHex: Self.mainNetConsensusMrEnclaveHex)
         case .testNet:
-            return try defaultAttestation(mrEnclaveHex: Self.testNetConsensusMrEnclaveHex)
+            return try defaultAttestation(mrEnclaveHex:
+                                            Self.legacy_v1_1_0_testNetConsensusMrEnclaveHex,
+                                            Self.testNetConsensusMrEnclaveHex)
         case .devNetwork:
             return try XCTUnwrapSuccess(Attestation.make(
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
@@ -493,7 +506,9 @@ extension NetworkPreset {
         case .mainNet:
             return try defaultAttestation(mrEnclaveHex: Self.mainNetFogViewMrEnclaveHex)
         case .testNet:
-            return try defaultAttestation(mrEnclaveHex: Self.testNetFogViewMrEnclaveHex)
+            return try defaultAttestation(mrEnclaveHex:
+                                            Self.legacy_v1_1_0_testNetFogViewMrEnclaveHex,
+                                            Self.testNetFogViewMrEnclaveHex)
         case .devNetwork:
             return try XCTUnwrapSuccess(Attestation.make(
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
@@ -508,7 +523,9 @@ extension NetworkPreset {
         case .mainNet:
             return try defaultAttestation(mrEnclaveHex: Self.mainNetFogLedgerMrEnclaveHex)
         case .testNet:
-            return try defaultAttestation(mrEnclaveHex: Self.testNetFogLedgerMrEnclaveHex)
+            return try defaultAttestation(mrEnclaveHex:
+                                            Self.legacy_v1_1_0_testNetFogLedgerMrEnclaveHex,
+                                            Self.testNetFogLedgerMrEnclaveHex)
         case .devNetwork:
             return try XCTUnwrapSuccess(Attestation.make(
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
@@ -523,7 +540,9 @@ extension NetworkPreset {
         case .mainNet:
             return try defaultAttestation(mrEnclaveHex: Self.mainNetFogReportMrEnclaveHex)
         case .testNet:
-            return try defaultAttestation(mrEnclaveHex: Self.testNetFogReportMrEnclaveHex)
+            return try defaultAttestation(mrEnclaveHex:
+                                            Self.legacy_v1_1_0_testNetFogReportMrEnclaveHex,
+                                            Self.testNetFogReportMrEnclaveHex)
         case .devNetwork:
             return try XCTUnwrapSuccess(Attestation.make(
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
@@ -533,12 +552,14 @@ extension NetworkPreset {
         }
     }
 
-    private func defaultAttestation(mrEnclaveHex: String) throws -> Attestation {
-        Attestation(mrEnclaves: [
-            try XCTUnwrapSuccess(Attestation.MrEnclave.make(
-                mrEnclave: try XCTUnwrap(Data(hexEncoded: mrEnclaveHex)),
-                allowedHardeningAdvisories: ["INTEL-SA-00334"])),
-        ])
+    private func defaultAttestation(mrEnclaveHex: String...) throws -> Attestation {
+        Attestation(mrEnclaves:
+            try mrEnclaveHex.map({
+                try XCTUnwrapSuccess(Attestation.MrEnclave.make(
+                        mrEnclave: try XCTUnwrap(Data(hexEncoded: $0)),
+                        allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+            })
+        )
     }
 
     static func trustRootsBytes() throws -> [Data] {

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -39,7 +39,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         }
     }
 
-    func testPrintBalance() throws {
+    func testPrintBalances() throws {
         let description = "Printing account balance"
         try testSupportedProtocols(description: description) {
             try printBalance(transportProtocol: $0, expectation: $1)
@@ -63,7 +63,6 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 if let amountPicoMob = try? XCTUnwrap(client.balance.amountPicoMob()) {
                     print("account index \(index) public address \(key.publicAddress)")
                     print("account index \(index) balance: \(amountPicoMob)")
-                    XCTAssertGreaterThan(amountPicoMob, 0)
                 }
 
                 if index == 9 {

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -5,12 +5,7 @@
 // swiftlint:disable file_length
 
 import MobileCoin
-@testable import NIOPosix
 import XCTest
-
-enum TestError: Error {
-    case mock
-}
 
 class MobileCoinClientPublicApiIntTests: XCTestCase {
 

--- a/Tests/Integration/Network/NetworkConfigFixtures.swift
+++ b/Tests/Integration/Network/NetworkConfigFixtures.swift
@@ -10,7 +10,7 @@ import XCTest
 
 enum NetworkConfigFixtures {
     static let dyanmicConfig = DynamicNetworkConfig.AlphaDevelopment.make()
-    static let network: NetworkPreset = .dynamic(dyanmicConfig)
+    static let network: NetworkPreset = .testNet
 }
 
 extension NetworkConfigFixtures {


### PR DESCRIPTION
Soundtrack of this PR: [Letta Mbulu Nomalizo](https://www.youtube.com/watch?v=_dNCFXjSXSY)

### Motivation

Fix warning preventing pre1 release, update default network configurations to work with legacy & new testNet (simulating what will be necc. for a mainnet upgrade).

### In this PR
* Fix warning preventing pre1 release
* new testNet enclave measurements
* update Attestation builder to accept multiple hex strings (enclave measurements).
