### PR TITLE
Make mobBalance public to avoid needing to deal with optional

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre2)
-  - MobileCoin/Core (1.2.2-pre2):
+  - MobileCoin (1.2.2-pre3)
+  - MobileCoin/Core (1.2.2-pre3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre2):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.2-pre3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.1)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.2-pre2)
-  - MobileCoin/PerformanceTests (1.2.2-pre2)
-  - MobileCoin/Tests (1.2.2-pre2)
+  - MobileCoin/IntegrationTests (1.2.2-pre3)
+  - MobileCoin/PerformanceTests (1.2.2-pre3)
+  - MobileCoin/Tests (1.2.2-pre3)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: c0a11748165ff40ce23f98ae63f4521f7a4e7042
+  MobileCoin: 6e35a39c84b2ae2a4dcd158045df025cc6305efe
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.1):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2-pre2)
-  - MobileCoin/CoreHTTP (1.2.2-pre2):
+  - MobileCoin (1.2.2-pre3)
+  - MobileCoin/CoreHTTP (1.2.2-pre3):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre2):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2-pre3):
     - LibMobileCoin/CoreHTTP (= 1.2.1)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.2-pre2)
-  - MobileCoin/PerformanceTests (1.2.2-pre2)
-  - MobileCoin/Tests (1.2.2-pre2)
+  - MobileCoin/IntegrationTests (1.2.2-pre3)
+  - MobileCoin/PerformanceTests (1.2.2-pre3)
+  - MobileCoin/Tests (1.2.2-pre3)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8b00413a2be5d116f62aa1c3e2f1b0f4818b52da
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: c0a11748165ff40ce23f98ae63f4521f7a4e7042
+  MobileCoin: 6e35a39c84b2ae2a4dcd158045df025cc6305efe
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.2-pre2"
+  s.version      = "1.2.2-pre3"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Account/Balances.swift
+++ b/Sources/Account/Balances.swift
@@ -10,7 +10,7 @@ public struct Balances {
         Set(balances.keys)
     }
 
-    var mobBalance: Balance {
+    public var mobBalance: Balance {
         guard let balance = balances[.MOB] else {
             return Balance(
                 amountLow: 0,


### PR DESCRIPTION
Soundtrack of this PR: [DeBarge- Stay With Me](https://www.youtube.com/watch?v=CinavBPMy-I)

### Motivation

SDK consumers that want to upgrade to the new public APIs will run into an optional `Balance` where this was previously non-optional. We can publicly expose the non-optional fallback that was previously scoped internal.

### In this PR
* Publicly expose `mobBalance` to avoid optional
