### PR TITLE
Fix for readlink -f not supported on older mac OS

### DIFF
--- a/scripts/secrets_manager
+++ b/scripts/secrets_manager
@@ -37,7 +37,7 @@ function check_dependencies_silent() {
 }
 
 function project_directory() {
-  script_path=$(readlink -f "${BASH_SOURCE[0]}")
+  script_path=$(stat -f "${BASH_SOURCE[0]}")
   script_dir=$(dirname "$script_path")
   project_dir=$(dirname "$script_dir")
   echo "$project_dir"
@@ -77,7 +77,7 @@ function check_for_existing_keys() {
 function decrypt_secrets() {
   security find-generic-password -w -s swift-repo-private > /dev/null 2>&1
 
-  script_path=$(readlink -f "${BASH_SOURCE}")
+  script_path=$(stat -f "${BASH_SOURCE}")
   script_dir=$(dirname "$script_path")
   project_dir=$(dirname "$script_dir")
   keys_encrypted="$project_dir/secrets/keys.encrypted"


### PR DESCRIPTION
Simple fix - switch from `readlink` to `stat`, tested on both Big Sur and Monterey