### PR TITLE
Async/Await API wrappers for MobileCoinClient

### DIFF
--- a/MobileCoinClient+Async.swift
+++ b/MobileCoinClient+Async.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+// swiftlint:disable multiline_function_chains
+// swiftlint:disable function_default_parameter_at_end
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension MobileCoinClient {
+
+    @discardableResult
+    public func updateBalances() async throws -> Balances {
+        try await withCheckedThrowingContinuation { continuation in
+            updateBalances { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    public func blockVersion() async throws -> BlockVersion {
+        try await withCheckedThrowingContinuation { continuation in
+            blockVersion { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func  prepareTransaction(
+        to recipient: PublicAddress,
+        memoType: MemoType = .recoverable,
+        amount: Amount,
+        fee: UInt64
+    ) async throws -> PendingSinglePayloadTransaction {
+        try await withCheckedThrowingContinuation { continuation in
+            prepareTransaction(to: recipient,
+                               memoType: memoType,
+                               amount: amount,
+                               fee: fee) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    public func submitTransaction(
+        transaction: Transaction
+    ) async throws -> UInt64 {
+        try await withCheckedThrowingContinuation { continuation in
+            submitTransaction(transaction: transaction) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func estimateTotalFee(
+        toSendAmount amount: Amount,
+        feeLevel: FeeLevel = .minimum
+    ) async throws -> UInt64 {
+        try await withCheckedThrowingContinuation { continuation in
+            estimateTotalFee(toSendAmount: amount,
+                             feeLevel: feeLevel) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func status(
+        of transaction: Transaction
+    ) async throws -> TransactionStatus {
+        try await withCheckedThrowingContinuation { continuation in
+            status(of: transaction) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+}

--- a/Sources/Common/Errors.swift
+++ b/Sources/Common/Errors.swift
@@ -20,9 +20,21 @@ extension InvalidInputError: CustomStringConvertible {
     }
 }
 
+extension InvalidInputError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 public enum BalanceUpdateError: Error {
     case connectionError(ConnectionError)
     case fogSyncError(FogSyncError)
+}
+
+extension BalanceUpdateError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
 }
 
 public enum ConnectionError: Error {
@@ -55,6 +67,12 @@ extension ConnectionError: CustomStringConvertible {
     }
 }
 
+extension ConnectionError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 public enum BalanceTransferEstimationFetcherError: Error {
     case feeExceedsBalance(String = String())
     case balanceOverflow(String = String())
@@ -76,6 +94,12 @@ extension BalanceTransferEstimationFetcherError: CustomStringConvertible {
     }
 }
 
+extension BalanceTransferEstimationFetcherError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 public enum TransactionEstimationFetcherError: Error {
     case invalidInput(String)
     case insufficientBalance(String = String())
@@ -94,6 +118,12 @@ extension TransactionEstimationFetcherError: CustomStringConvertible {
                 return "\(innerError)"
             }
         }()
+    }
+}
+
+extension TransactionEstimationFetcherError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
     }
 }
 
@@ -121,6 +151,12 @@ extension TransactionPreparationError: CustomStringConvertible {
     }
 }
 
+extension TransactionPreparationError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 public enum DefragTransactionPreparationError: Error {
     case invalidInput(String)
     case insufficientBalance(String = String())
@@ -142,6 +178,12 @@ extension DefragTransactionPreparationError: CustomStringConvertible {
     }
 }
 
+extension DefragTransactionPreparationError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 public struct SubmitTransactionError: Error {
     public let submissionError: TransactionSubmissionError
     public let consensusBlockCount: UInt64?
@@ -152,6 +194,12 @@ extension SubmitTransactionError: CustomStringConvertible {
         "Submit Transaction Error: " +
         "Consensus Block Count == \(consensusBlockCount?.description ?? "nil"), " +
         "\(submissionError)"
+    }
+}
+
+extension SubmitTransactionError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
     }
 }
 
@@ -185,6 +233,12 @@ extension TransactionSubmissionError: CustomStringConvertible {
     }
 }
 
+extension TransactionSubmissionError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
 @available(*, deprecated)
 public enum BalanceTransferEstimationError: Error {
     case feeExceedsBalance(String = String())
@@ -206,6 +260,13 @@ extension BalanceTransferEstimationError: CustomStringConvertible {
 }
 
 @available(*, deprecated)
+extension BalanceTransferEstimationError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
+    }
+}
+
+@available(*, deprecated)
 public enum TransactionEstimationError: Error {
     case invalidInput(String)
     case insufficientBalance(String = String())
@@ -222,6 +283,13 @@ extension TransactionEstimationError: CustomStringConvertible {
                 return "Insufficient balance\(!reason.isEmpty ? ": \(reason)" : "")"
             }
         }()
+    }
+}
+
+@available(*, deprecated)
+extension TransactionEstimationError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
     }
 }
 
@@ -249,5 +317,11 @@ extension SecurityError: CustomStringConvertible {
         } else {
             return "Security Error Code - \(osstatus) ... see Apple Security Framework SecBase.h"
         }
+    }
+}
+
+extension SecurityError: LocalizedError {
+    public var errorDescription: String? {
+        "\(self)"
     }
 }

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -10,13 +10,8 @@ extension MobileCoinClient {
     @discardableResult
     public func updateBalances() async throws -> Balances {
         try await withCheckedThrowingContinuation { continuation in
-            updateBalances { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            updateBalances {
+                continuation.resume(with: $0)
             }
         }
     }
@@ -24,13 +19,8 @@ extension MobileCoinClient {
     @discardableResult
     public func blockVersion() async throws -> BlockVersion {
         try await withCheckedThrowingContinuation { continuation in
-            blockVersion { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            blockVersion {
+                continuation.resume(with: $0)
             }
         }
     }
@@ -45,13 +35,8 @@ extension MobileCoinClient {
             prepareTransaction(to: recipient,
                                memoType: memoType,
                                amount: amount,
-                               fee: fee) { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+                               fee: fee) {
+                continuation.resume(with: $0)
             }
         }
     }
@@ -61,13 +46,8 @@ extension MobileCoinClient {
         transaction: Transaction
     ) async throws -> UInt64 {
         try await withCheckedThrowingContinuation { continuation in
-            submitTransaction(transaction: transaction) { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            submitTransaction(transaction: transaction) {
+                continuation.resume(with: $0)
             }
         }
     }
@@ -78,13 +58,8 @@ extension MobileCoinClient {
     ) async throws -> UInt64 {
         try await withCheckedThrowingContinuation { continuation in
             estimateTotalFee(toSendAmount: amount,
-                             feeLevel: feeLevel) { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+                             feeLevel: feeLevel) {
+                continuation.resume(with: $0)
             }
         }
     }
@@ -93,13 +68,8 @@ extension MobileCoinClient {
         of transaction: Transaction
     ) async throws -> TransactionStatus {
         try await withCheckedThrowingContinuation { continuation in
-            status(of: transaction) { result in
-                switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            status(of: transaction) {
+                continuation.resume(with: $0)
             }
         }
     }

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -2,9 +2,6 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
-// swiftlint:disable multiline_function_chains
-// swiftlint:disable function_default_parameter_at_end
-
 import Foundation
 
 @available(iOS 13.0, *)

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -35,11 +35,11 @@ extension MobileCoinClient {
         }
     }
 
-    public func  prepareTransaction(
+    public func prepareTransaction(
         to recipient: PublicAddress,
-        memoType: MemoType = .recoverable,
         amount: Amount,
-        fee: UInt64
+        fee: UInt64,
+        memoType: MemoType = .recoverable
     ) async throws -> PendingSinglePayloadTransaction {
         try await withCheckedThrowingContinuation { continuation in
             prepareTransaction(to: recipient,

--- a/Tests/Common/Utils/Result+Fulfill.swift
+++ b/Tests/Common/Utils/Result+Fulfill.swift
@@ -6,7 +6,7 @@ import XCTest
 
 extension Result {
     func successOrFulfill(
-        expectation: XCTestExpectation,
+        expectation: XCTestExpectation? = nil,
         _ message: @autoclosure () -> String = "",
         file: StaticString = #file,
         line: UInt = #line
@@ -17,7 +17,7 @@ extension Result {
         case .success(let value):
             return value
         case .failure:
-            expectation.fulfill()
+            expectation?.fulfill()
             return nil
         }
     }

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -30,15 +30,16 @@ extension XCTestCase {
     func testSupportedProtocols(
                 description: String,
                 timeout: Double = 40.0,
-                interval: UInt32 = 10,
+                interval: UInt64 = 10,
                 _ testCase: (TransportProtocol) async throws -> Void
     ) async throws {
         let supportedProtocols = TransportProtocol.supportedProtocols
         let last = supportedProtocols.last
         for transportProtocol in supportedProtocols {
             try await testCase(transportProtocol)
-            let sleepDuration = UInt64(transportProtocol == last ? 0 : interval * 1_000_000_000)
-            try await Task.sleep(nanoseconds: sleepDuration)
+            try await Task.sleep(
+                nanoseconds: UInt64(transportProtocol == last ? 0 : interval * 1_000_000_000)
+            )
         }
     }
 

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -32,12 +32,13 @@ extension XCTestCase {
                 timeout: Double = 40.0,
                 interval: UInt32 = 10,
                 _ testCase: (TransportProtocol) async throws -> Void
-    ) async rethrows {
+    ) async throws {
         let supportedProtocols = TransportProtocol.supportedProtocols
         let last = supportedProtocols.last
         for transportProtocol in supportedProtocols {
             try await testCase(transportProtocol)
-            sleep(transportProtocol == last ? 0 : interval)
+            let sleepDuration = UInt64(transportProtocol == last ? 0 : interval * 1_000_000_000)
+            try await Task.sleep(nanoseconds: sleepDuration)
         }
     }
 

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -25,4 +25,17 @@ extension XCTestCase {
             sleep(transportProtocol == last ? 0 : interval)
         }
     }
+
+    @available(iOS 13.0, *)
+    func testSupportedProtocols(
+                description: String,
+                timeout: Double = 40.0,
+                interval: UInt32 = 10,
+                _ testCase: (TransportProtocol) async throws -> Void
+    ) async rethrows {
+        for transportProtocol in TransportProtocol.supportedProtocols {
+            try await testCase(transportProtocol)
+        }
+    }
+
 }

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -36,11 +36,7 @@ extension XCTestCase {
         let supportedProtocols = TransportProtocol.supportedProtocols
         let last = supportedProtocols.last
         for transportProtocol in supportedProtocols {
-            do {
-                try await testCase(transportProtocol)
-            } catch {
-                XCTFail((error as CustomStringConvertible).description)
-            }
+            try await testCase(transportProtocol)
             sleep(transportProtocol == last ? 0 : interval)
         }
     }

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -36,7 +36,11 @@ extension XCTestCase {
         let supportedProtocols = TransportProtocol.supportedProtocols
         let last = supportedProtocols.last
         for transportProtocol in supportedProtocols {
-            try await testCase(transportProtocol)
+            do {
+                try await testCase(transportProtocol)
+            } catch {
+                XCTFail((error as CustomStringConvertible).description)
+            }
             sleep(transportProtocol == last ? 0 : interval)
         }
     }

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -33,8 +33,11 @@ extension XCTestCase {
                 interval: UInt32 = 10,
                 _ testCase: (TransportProtocol) async throws -> Void
     ) async rethrows {
-        for transportProtocol in TransportProtocol.supportedProtocols {
+        let supportedProtocols = TransportProtocol.supportedProtocols
+        let last = supportedProtocols.last
+        for transportProtocol in supportedProtocols {
             try await testCase(transportProtocol)
+            sleep(transportProtocol == last ? 0 : interval)
         }
     }
 

--- a/Tests/Integration/IntegrationTestFixtures+Async.swift
+++ b/Tests/Integration/IntegrationTestFixtures+Async.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+// swiftlint:disable function_default_parameter_at_end multiline_function_chains
+
+@testable import MobileCoin
+import XCTest
+
+@available(iOS 13.0, *)
+extension IntegrationTestFixtures {
+
+    static func createMobileCoinClientWithBalance(
+        accountKey: AccountKey,
+        transportProtocol: TransportProtocol
+    ) async throws -> MobileCoinClient {
+        let client = try createMobileCoinClient(accountKey: accountKey,
+                                                transportProtocol: transportProtocol)
+        let balances = try await client.updateBalances()
+        let picoMob = try XCTUnwrap(balances.mobBalance.amount())
+        XCTAssertGreaterThan(picoMob, 0)
+        return client
+    }
+
+}

--- a/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
@@ -277,7 +277,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                             return
                         }
 
-                        Thread.sleep(forTimeInterval: 2)
+                        try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                         try await checkBalanceChange()
                         return
                     }
@@ -346,7 +346,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                         return
                     }
 
-                    Thread.sleep(forTimeInterval: 2)
+                    try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                     try await checkBalance()
                     return
                 }
@@ -400,7 +400,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                         return
                     }
 
-                    Thread.sleep(forTimeInterval: 2)
+                    try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                     try await checkBalance()
                     return
                 }
@@ -454,7 +454,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                     return
                 }
 
-                Thread.sleep(forTimeInterval: 2)
+                try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                 try await checkStatus()
                 return
             case .accepted(block: let block):
@@ -520,7 +520,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                     return
                 }
 
-                Thread.sleep(forTimeInterval: 2)
+                try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                 try await checkStatus()
                 return
             case .received(block: let block):

--- a/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
@@ -194,7 +194,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         let amount = Amount(100, in: .MOBUSD)
 
         func checkBlockVersionAndFee(
-                _ client: MobileCoinClient
+            _ client: MobileCoinClient
         ) async throws -> UInt64 {
             let blockVersion = try await client.blockVersion()
             XCTAssertGreaterThanOrEqual(blockVersion, 2, "Test cannot run on blockversion < 2 ...")
@@ -202,8 +202,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         }
 
         func prepareAndSubmit(
-                _ client: MobileCoinClient,
-                _ fee: UInt64
+            _ client: MobileCoinClient,
+            _ fee: UInt64
         ) async throws {
             let pendingTransaction = try await client.prepareTransaction(to: recipient,
                                                                          amount: amount,
@@ -222,7 +222,7 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         }
 
         func checkBalances(
-                _ client: MobileCoinClient
+            _ client: MobileCoinClient
         ) async throws -> Balances {
             try await client.updateBalances()
 
@@ -252,9 +252,9 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         }
 
         func verifyBalanceChange(
-                _ client: MobileCoinClient,
-                _ balancesBefore: Balances
-                ) async throws {
+            _ client: MobileCoinClient,
+            _ balancesBefore: Balances
+        ) async throws {
 
             var numChecksRemaining = 5
             func checkBalanceChange() async throws {
@@ -272,8 +272,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                     guard mobUSD != initialMobUSD else {
                         guard numChecksRemaining > 0 else {
                             XCTFail("Failed to receive a changed balance. initial balance: " +
-                                "\(initialMobUSD), current balance: " +
-                                "\(mobUSD) microMOBUSD")
+                                    "\(initialMobUSD), current balance: " +
+                                    "\(mobUSD) microMOBUSD")
                             return
                         }
 
@@ -283,8 +283,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                     }
                 } catch {}
             }
-                    try await checkBalanceChange()
-                }
+            try await checkBalanceChange()
+        }
 
         let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 0)
         let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
@@ -309,8 +309,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
     ) async throws {
         let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 2)
         let client = try IntegrationTestFixtures.createMobileCoinClient(
-                accountKey: accountKey,
-                transportProtocol: transportProtocol)
+            accountKey: accountKey,
+            transportProtocol: transportProtocol)
 
         func submitTransaction() async throws -> Balance {
             let balance = try await client.updateBalances().mobBalance
@@ -420,8 +420,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol
     ) async throws {
         let client = try IntegrationTestFixtures.createMobileCoinClient(
-                accountIndex: 1,
-                using: transportProtocol)
+            accountIndex: 1,
+            using: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         func submitTransaction() async throws -> Transaction {
@@ -482,8 +482,8 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol
     ) async throws {
         let senderClient = try IntegrationTestFixtures.createMobileCoinClient(
-                accountIndex: 0,
-                using: transportProtocol)
+            accountIndex: 0,
+            using: transportProtocol)
         let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
         let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
             accountKey: receiverAccountKey,
@@ -548,12 +548,12 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol
     ) async throws {
         var config = try IntegrationTestFixtures.createMobileCoinClientConfig(
-                using: transportProtocol)
+            using: transportProtocol)
         XCTAssertSuccess(
             config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()))
         let client = try IntegrationTestFixtures.createMobileCoinClient(
-                config: config,
-                transportProtocol: transportProtocol)
+            config: config,
+            transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
 
         let balance = try await client.updateBalances().mobBalance
@@ -581,14 +581,14 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol
     ) async throws {
         var config = try IntegrationTestFixtures.createMobileCoinClientConfig(
-                using: transportProtocol)
+            using: transportProtocol)
         XCTAssertSuccess(config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()
-            + [try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes]))
+                            + [try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes]))
         let client =
-            try IntegrationTestFixtures.createMobileCoinClient(
-                    accountIndex: 1,
-                    config: config,
-                    transportProtocol: transportProtocol)
+        try IntegrationTestFixtures.createMobileCoinClient(
+            accountIndex: 1,
+            config: config,
+            transportProtocol: transportProtocol)
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
         let balance = try await client.updateBalances().mobBalance
         guard let picoMob = try? XCTUnwrap(balance.amount()) else { return }

--- a/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
@@ -149,8 +149,10 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
     ) async throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
         let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
-        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
-                                                                                         transportProtocol: transportProtocol)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
+            accountKey: accountKey,
+            transportProtocol: transportProtocol
+        )
         _ = try await client.prepareTransaction(to: recipient,
                                                 amount: Amount(100, in: .MOB),
                                                 fee: IntegrationTestFixtures.fee)
@@ -168,8 +170,10 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
     ) async throws {
         let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
         let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 0)
-        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
-                                                                                         transportProtocol: transportProtocol)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
+            accountKey: accountKey,
+            transportProtocol: transportProtocol
+        )
         let transaction = try await client.prepareTransaction(to: recipient,
                                                               amount: Amount(100, in: .MOB),
                                                               fee: IntegrationTestFixtures.fee)
@@ -201,7 +205,9 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                 _ client: MobileCoinClient,
                 _ fee: UInt64
         ) async throws {
-            let pendingTransaction = try await client.prepareTransaction(to: recipient, amount: amount, fee: fee)
+            let pendingTransaction = try await client.prepareTransaction(to: recipient,
+                                                                         amount: amount,
+                                                                         fee: fee)
 
             let publicKey = pendingTransaction.changeTxOutContext.txOutPublicKey
             XCTAssertNotNil(publicKey)
@@ -277,12 +283,14 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
                     }
                 } catch {}
             }
-            try await checkBalanceChange()
-        }
+                    try await checkBalanceChange()
+                }
 
         let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 0)
-        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
-                                                                                         transportProtocol: transportProtocol)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
+            accountKey: accountKey,
+            transportProtocol: transportProtocol
+        )
         let fee = try await checkBlockVersionAndFee(client)
         let balancesBefore = try await checkBalances(client)
         try await prepareAndSubmit(client, fee)
@@ -418,7 +426,9 @@ class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
 
         func submitTransaction() async throws -> Transaction {
             try await client.updateBalances()
-            let transaction = try await client.prepareTransaction(to: recipient, amount: Amount(100, in: .MOB), fee: IntegrationTestFixtures.fee)
+            let transaction = try await client.prepareTransaction(to: recipient,
+                                                                  amount: Amount(100, in: .MOB),
+                                                                  fee: IntegrationTestFixtures.fee)
             try await client.submitTransaction(transaction: transaction.transaction)
             return transaction.transaction
         }

--- a/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicAsyncApiIntTests.swift
@@ -1,0 +1,632 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+// swiftlint:disable type_body_length
+// swiftlint:disable file_length
+
+import MobileCoin
+import XCTest
+
+@available(iOS 13.0, *)
+class MobileCoinClientPublicAsyncApiIntTests: XCTestCase {
+
+    func testBalance() async throws {
+        let description = "Updating account balance"
+        try await testSupportedProtocols(description: description) { transportProtocol in
+            try await balance(transportProtocol: transportProtocol)
+        }
+    }
+
+    func balance(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(using: transportProtocol)
+        try await client.updateBalances()
+        if let amountPicoMob = try? XCTUnwrap(client.balance(for: .MOB).amount()) {
+            print("balance: \(amountPicoMob)")
+            XCTAssertGreaterThan(amountPicoMob, 0)
+        }
+    }
+
+    func testPrintBalances() async throws {
+        let description = "Printing account balance"
+        try await testSupportedProtocols(description: description) {
+            try await printBalance(transportProtocol: $0)
+        }
+    }
+
+    func printBalance(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        for index in Array(0...9) {
+            let key = try IntegrationTestFixtures.createAccountKey(accountIndex: index)
+
+            let client = try IntegrationTestFixtures.createMobileCoinClient(
+                accountKey: key,
+                transportProtocol: transportProtocol)
+
+            try await client.updateBalances()
+
+            if let amountPicoMob = try? XCTUnwrap(client.balance(for: .MOB).amount()) {
+                print("account index \(index) public address \(key.publicAddress)")
+                print("account index \(index) balance: \(amountPicoMob)")
+            }
+        }
+    }
+
+    func testBalances() async throws {
+        let description = "Updating account balance"
+        try await testSupportedProtocols(description: description) {
+            try await balances(transportProtocol: $0)
+        }
+    }
+
+    func balances(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+            accountIndex: 0,
+            using: transportProtocol)
+
+        let blockVersion = try await client.blockVersion()
+        guard blockVersion >= 2 else {
+            print("Test cannot run on blockversion < 2 ... " +
+                  "fulfilling the expectation as a success")
+            return
+        }
+
+        try await client.updateBalances()
+
+        let balances = client.balances
+        print(balances)
+
+        XCTAssertGreaterThanOrEqual(balances.balances.count, 1)
+
+        print(client.accountActivity(for: .MOB).describeUnspentTxOuts())
+
+        guard let mobBalance = balances.balances[.MOB] else {
+            XCTFail("Expected Balance")
+            return
+        }
+
+        XCTAssertTrue(
+            mobBalance.amountParts.int > 0 ||
+            mobBalance.amountParts.frac > 0
+        )
+    }
+
+    func testAccountActivity() async throws {
+        let description = "Updating account balance"
+        try await testSupportedProtocols(description: description) {
+            try await accountActivity(transportProtocol: $0)
+        }
+    }
+
+    func accountActivity(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(using: transportProtocol)
+
+        try await client.updateBalances()
+
+        let accountActivity = client.accountActivity(for: .MOB)
+
+        print("txOuts.count: \(accountActivity.txOuts.count)")
+        XCTAssertGreaterThan(accountActivity.txOuts.count, 0)
+
+        print("blockCount: \(accountActivity.blockCount)")
+        XCTAssertGreaterThan(accountActivity.blockCount, 0)
+    }
+
+    func testUpdateBalance() async throws {
+        let description = "Updating account balance"
+        try await testSupportedProtocols(description: description) {
+            try await updateBalance(transportProtocol: $0)
+        }
+    }
+
+    func updateBalance(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(using: transportProtocol)
+        let balance = try await client.updateBalances().mobBalance
+
+        if let amountPicoMob = try? XCTUnwrap(balance.amount()) {
+            print("balance: \(amountPicoMob)")
+            XCTAssertGreaterThan(amountPicoMob, 0)
+        }
+    }
+
+    func testPrepareTransaction() async throws {
+        let description = "Preparing transaction"
+        try await testSupportedProtocols(description: description) {
+            try await prepareTransaction(transportProtocol: $0)
+        }
+    }
+
+    func prepareTransaction(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
+        let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
+                                                                                         transportProtocol: transportProtocol)
+        _ = try await client.prepareTransaction(to: recipient,
+                                                amount: Amount(100, in: .MOB),
+                                                fee: IntegrationTestFixtures.fee)
+    }
+
+    func testSubmitTransaction() async throws {
+        let description = "Submitting transaction"
+        try await testSupportedProtocols(description: description) {
+            try await submitTransaction(transportProtocol: $0)
+        }
+    }
+
+    func submitTransaction(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
+        let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 0)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
+                                                                                         transportProtocol: transportProtocol)
+        let transaction = try await client.prepareTransaction(to: recipient,
+                                                              amount: Amount(100, in: .MOB),
+                                                              fee: IntegrationTestFixtures.fee)
+        try await client.submitTransaction(transaction: transaction.transaction)
+    }
+
+    func testSubmitMobUSDTransaction() async throws {
+        let description = "Submitting transaction"
+        try await testSupportedProtocols(description: description) {
+            try await submitMobUSDTransaction(transportProtocol: $0)
+        }
+    }
+
+    func submitMobUSDTransaction(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
+        let amount = Amount(100, in: .MOBUSD)
+
+        func checkBlockVersionAndFee(
+                _ client: MobileCoinClient
+        ) async throws -> UInt64 {
+            let blockVersion = try await client.blockVersion()
+            XCTAssertGreaterThanOrEqual(blockVersion, 2, "Test cannot run on blockversion < 2 ...")
+            return try await client.estimateTotalFee(toSendAmount: amount, feeLevel: .minimum)
+        }
+
+        func prepareAndSubmit(
+                _ client: MobileCoinClient,
+                _ fee: UInt64
+        ) async throws {
+            let pendingTransaction = try await client.prepareTransaction(to: recipient, amount: amount, fee: fee)
+
+            let publicKey = pendingTransaction.changeTxOutContext.txOutPublicKey
+            XCTAssertNotNil(publicKey)
+
+            let sharedSecret = pendingTransaction.changeTxOutContext.sharedSecretBytes
+            XCTAssertNotNil(sharedSecret)
+
+            let transaction = pendingTransaction.transaction
+            print("transaction fixture: \(transaction.serializedData.hexEncodedString())")
+
+            try await client.submitTransaction(transaction: transaction)
+        }
+
+        func checkBalances(
+                _ client: MobileCoinClient
+        ) async throws -> Balances {
+            try await client.updateBalances()
+
+            let balances = client.balances
+            print(balances)
+
+            XCTAssertGreaterThan(balances.balances.count, 1)
+
+            print(client.accountActivity(for: .MOB).describeUnspentTxOuts())
+
+            let mobBalance = try XCTUnwrap(balances.balances[.MOB], "Expected Balance")
+            XCTAssertTrue(
+                mobBalance.amountParts.int > 0 ||
+                mobBalance.amountParts.frac > 0
+            )
+
+            let mobUSDBalance = try XCTUnwrap(balances.balances[.MOBUSD], "Expected Balance")
+            XCTAssertTrue(
+                mobUSDBalance.amountParts.int > 0 ||
+                mobUSDBalance.amountParts.frac > 0
+            )
+
+            let unknownTokenId = TokenId(UInt64(17000))
+            XCTAssertNil(balances.balances[unknownTokenId])
+
+            return balances
+        }
+
+        func verifyBalanceChange(
+                _ client: MobileCoinClient,
+                _ balancesBefore: Balances
+                ) async throws {
+
+            var numChecksRemaining = 5
+            func checkBalanceChange() async throws {
+                numChecksRemaining -= 1
+                print("Updating balance...")
+                let balances = try await client.updateBalances()
+                print("Balances: \(balances)")
+
+                do {
+                    let balancesMap = balances.balances
+                    let balancesBeforeMap = balancesBefore.balances
+                    let mobUSD = try XCTUnwrap(balancesMap[.MOBUSD]?.amount())
+                    let initialMobUSD = try XCTUnwrap(balancesBeforeMap[.MOBUSD]?.amount())
+
+                    guard mobUSD != initialMobUSD else {
+                        guard numChecksRemaining > 0 else {
+                            XCTFail("Failed to receive a changed balance. initial balance: " +
+                                "\(initialMobUSD), current balance: " +
+                                "\(mobUSD) microMOBUSD")
+                            return
+                        }
+
+                        Thread.sleep(forTimeInterval: 2)
+                        try await checkBalanceChange()
+                        return
+                    }
+                } catch {}
+            }
+            try await checkBalanceChange()
+        }
+
+        let accountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 0)
+        let client = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(accountKey: accountKey,
+                                                                                         transportProtocol: transportProtocol)
+        let fee = try await checkBlockVersionAndFee(client)
+        let balancesBefore = try await checkBalances(client)
+        try await prepareAndSubmit(client, fee)
+        try await verifyBalanceChange(client, balancesBefore)
+    }
+
+    func testSelfPaymentBalanceChange() async throws {
+        let description = "Self payment"
+        try await testSupportedProtocols(description: description) {
+            try await selfPaymentBalanceChange(transportProtocol: $0)
+        }
+    }
+
+    func selfPaymentBalanceChange(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 2)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+                accountKey: accountKey,
+                transportProtocol: transportProtocol)
+
+        func submitTransaction() async throws -> Balance {
+            let balance = try await client.updateBalances().mobBalance
+            print("Initial balance: \(balance)")
+
+            let transaction = try await client.prepareTransaction(
+                to: accountKey.publicAddress,
+                amount: Amount(100, in: .MOB),
+                fee: IntegrationTestFixtures.fee)
+            try await client.submitTransaction(transaction: transaction.transaction)
+            return balance
+        }
+
+        let initialBalance = try await submitTransaction()
+
+        var numChecksRemaining = 5
+        func checkBalance() async throws {
+            numChecksRemaining -= 1
+            print("Updating balance...")
+            let balance = try await client.updateBalances().mobBalance
+            print("Balance: \(balance)")
+
+            do {
+                let balancePicoMob = try XCTUnwrap(balance.amount())
+                let initialBalancePicoMob = try XCTUnwrap(initialBalance.amount())
+                let expectedBalancePicoMob =
+                initialBalancePicoMob - IntegrationTestFixtures.fee
+                guard balancePicoMob == expectedBalancePicoMob else {
+                    guard numChecksRemaining > 0 else {
+                        XCTFail("Failed to receive a changed balance. balance: " +
+                                "\(balancePicoMob), expected balance: " +
+                                "\(expectedBalancePicoMob) picoMOB")
+                        return
+                    }
+
+                    Thread.sleep(forTimeInterval: 2)
+                    try await checkBalance()
+                    return
+                }
+            } catch {}
+        }
+        try await checkBalance()
+    }
+
+    func testSelfPaymentBalanceChangeFeeLevel() async throws {
+        let description = "Self payment"
+        try await testSupportedProtocols(description: description) {
+            try await selfPaymentBalanceChangeFeeLevel(transportProtocol: $0)
+        }
+    }
+
+    func selfPaymentBalanceChangeFeeLevel(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let accountKey = try  IntegrationTestFixtures.createAccountKey(accountIndex: 1)
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+            accountKey: accountKey,
+            transportProtocol: transportProtocol)
+
+        func submitTransaction() async throws -> Balance {
+            let balance = try await client.updateBalances().mobBalance
+            print("Initial balance: \(balance)")
+            let transaction = try await client.prepareTransaction(
+                to: accountKey.publicAddress,
+                amount: Amount(100, in: .MOB),
+                fee: IntegrationTestFixtures.fee)
+            try await client.submitTransaction(transaction: transaction.transaction)
+            return balance
+        }
+
+        let initialBalance = try await submitTransaction()
+        var numChecksRemaining = 5
+        func checkBalance() async throws {
+            numChecksRemaining -= 1
+            print("Updating balance...")
+            let balance = try await client.updateBalances().mobBalance
+            print("Balance: \(balance)")
+
+            do {
+                let balancePicoMob = try XCTUnwrap(balance.amount())
+                let initialBalancePicoMob = try XCTUnwrap(initialBalance.amount())
+                guard balancePicoMob != initialBalancePicoMob else {
+                    guard numChecksRemaining > 0 else {
+                        XCTFail("Failed to receive a changed balance. initial balance: " +
+                                "\(initialBalancePicoMob), current balance: " +
+                                "\(balancePicoMob) picoMOB")
+                        return
+                    }
+
+                    Thread.sleep(forTimeInterval: 2)
+                    try await checkBalance()
+                    return
+                }
+            } catch {}
+        }
+        try await checkBalance()
+    }
+
+    func testTransactionStatus() async throws {
+        let description = "Checking transaction status"
+        try await testSupportedProtocols(description: description) {
+            try await transactionStatus(transportProtocol: $0)
+        }
+    }
+
+    func transactionStatus(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+                accountIndex: 1,
+                using: transportProtocol)
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
+
+        func submitTransaction() async throws -> Transaction {
+            try await client.updateBalances()
+            let transaction = try await client.prepareTransaction(to: recipient, amount: Amount(100, in: .MOB), fee: IntegrationTestFixtures.fee)
+            try await client.submitTransaction(transaction: transaction.transaction)
+            return transaction.transaction
+        }
+
+        let transaction = try await submitTransaction()
+
+        var numChecksRemaining = 5
+
+        func checkStatus() async throws {
+            numChecksRemaining -= 1
+            print("Updating balance...")
+            let balance = try await client.updateBalances().mobBalance
+            print("Balance: \(balance)")
+
+            print("Checking status...")
+            let status = try await client.status(of: transaction)
+            print("Transaction status: \(status)")
+
+            switch status {
+            case .unknown:
+                guard numChecksRemaining > 0 else {
+                    XCTFail("Failed to resolve transaction status check")
+                    return
+                }
+
+                Thread.sleep(forTimeInterval: 2)
+                try await checkStatus()
+                return
+            case .accepted(block: let block):
+                print("Block index: \(block.index)")
+                XCTAssertGreaterThan(block.index, 0)
+
+                if let timestamp = block.timestamp {
+                    print("Block timestamp: \(timestamp)")
+                }
+            case .failed:
+                XCTFail("Transaction status check: Transaction failed")
+            }
+        }
+        try await checkStatus()
+    }
+
+    func testReceiptStatus() async throws {
+        let description = "Checking receipt status"
+        try await testSupportedProtocols(description: description) {
+            try await receiptStatus(transportProtocol: $0)
+        }
+    }
+
+    func receiptStatus(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        let senderClient = try IntegrationTestFixtures.createMobileCoinClient(
+                accountIndex: 0,
+                using: transportProtocol)
+        let receiverAccountKey = try IntegrationTestFixtures.createAccountKey(accountIndex: 1)
+        let receiverClient = try IntegrationTestFixtures.createMobileCoinClient(
+            accountKey: receiverAccountKey,
+            transportProtocol: transportProtocol)
+
+        func submitTransaction() async throws -> Receipt {
+            let balance = try await senderClient.updateBalances().mobBalance
+            print("Account 0 balance: \(balance)")
+            let transaction = try await senderClient.prepareTransaction(
+                to: receiverAccountKey.publicAddress,
+                amount: Amount(100, in: .MOB),
+                fee: IntegrationTestFixtures.fee)
+            try await senderClient.submitTransaction(transaction: transaction.transaction)
+            return transaction.receipt
+        }
+
+        let receipt = try await submitTransaction()
+        var numChecksRemaining = 5
+
+        func checkStatus() async throws {
+            numChecksRemaining -= 1
+            print("Checking status...")
+            let balance = try await receiverClient.updateBalances().mobBalance
+            print("Account 1 balance: \(balance)")
+
+            guard let status = receiverClient.status(of: receipt)
+                .successOrFulfill() else { return }
+            print("Receipt status: \(status)")
+
+            switch status {
+            case .unknown:
+                guard numChecksRemaining > 0 else {
+                    XCTFail("Failed to resolve receipt status check")
+                    return
+                }
+
+                Thread.sleep(forTimeInterval: 2)
+                try await checkStatus()
+                return
+            case .received(block: let block):
+                print("Block index: \(block.index)")
+                XCTAssertGreaterThan(block.index, 0)
+
+                if let timestamp = block.timestamp {
+                    print("Block timestamp: \(timestamp)")
+                }
+            case .failed:
+                XCTFail("Receipt status check: Transaction failed")
+            }
+        }
+        try await checkStatus()
+    }
+
+    func testConsensusTrustRootWorks() async throws {
+        let description = "Submitting transaction"
+        try await testSupportedProtocols(description: description) {
+            try await consensusTrustRootWorks(transportProtocol: $0)
+        }
+    }
+
+    func consensusTrustRootWorks(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(
+                using: transportProtocol)
+        XCTAssertSuccess(
+            config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()))
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+                config: config,
+                transportProtocol: transportProtocol)
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
+
+        let balance = try await client.updateBalances().mobBalance
+        guard let picoMob = try? XCTUnwrap(balance.amount()) else { return }
+        print("balance: \(picoMob)")
+        XCTAssertGreaterThan(picoMob, 0)
+        guard picoMob > 0 else { return }
+
+        let transaction = try await client.prepareTransaction(
+            to: recipient,
+            amount: Amount(100, in: .MOB),
+            fee: IntegrationTestFixtures.fee
+        )
+        try await client.submitTransaction(transaction: transaction.transaction)
+    }
+
+    func testExtraConsensusTrustRootWorks() async throws {
+        let description = "Submitting transaction"
+        try await testSupportedProtocols(description: description) {
+            try await extraConsensusTrustRootWorks(transportProtocol: $0)
+        }
+    }
+
+    func extraConsensusTrustRootWorks(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(
+                using: transportProtocol)
+        XCTAssertSuccess(config.setConsensusTrustRoots(try NetworkPreset.trustRootsBytes()
+            + [try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes]))
+        let client =
+            try IntegrationTestFixtures.createMobileCoinClient(
+                    accountIndex: 1,
+                    config: config,
+                    transportProtocol: transportProtocol)
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 1)
+        let balance = try await client.updateBalances().mobBalance
+        guard let picoMob = try? XCTUnwrap(balance.amount()) else { return }
+        print("balance: \(picoMob)")
+        XCTAssertGreaterThan(picoMob, 0)
+        guard picoMob > 0 else { return }
+
+        let transaction = try await client.prepareTransaction(
+            to: recipient,
+            amount: Amount(100, in: .MOB),
+            fee: IntegrationTestFixtures.fee)
+        try await client.submitTransaction(transaction: transaction.transaction)
+    }
+
+    func testWrongConsensusTrustRootReturnsError() async throws {
+        // Skipped because gRPC currently keeps retrying connection errors indefinitely.
+        try XCTSkipIf(true)
+
+        let description = "Submitting transaction"
+        try await testSupportedProtocols(description: description) {
+            try await wrongConsensusTrustRootReturnsError(transportProtocol: $0)
+        }
+    }
+
+    func wrongConsensusTrustRootReturnsError(
+        transportProtocol: TransportProtocol
+    ) async throws {
+        var config = try IntegrationTestFixtures.createMobileCoinClientConfig(
+            using: transportProtocol)
+        XCTAssertSuccess(config.setConsensusTrustRoots([
+            try MobileCoinClient.Config.Fixtures.Init().wrongTrustRootBytes,
+        ]))
+        let client = try IntegrationTestFixtures.createMobileCoinClient(
+            accountIndex: 0,
+            config: config,
+            transportProtocol: transportProtocol)
+        let recipient = try IntegrationTestFixtures.createPublicAddress(accountIndex: 0)
+        let balance = try await client.updateBalances().mobBalance
+        guard let picoMob = try? XCTUnwrap(balance.amount()) else { return }
+        print("balance: \(picoMob)")
+        XCTAssertGreaterThan(picoMob, 0)
+        guard picoMob > 0 else { return }
+
+        let transaction = try await client.prepareTransaction(
+            to: recipient,
+            amount: Amount(100, in: .MOB),
+            fee: IntegrationTestFixtures.fee)
+        try await client.submitTransaction(transaction: transaction.transaction)
+    }
+
+}


### PR DESCRIPTION
### Motivation

Unfortunately this only works on iOS 13+.

Using `withCheckedThrowingContinuation` it is possible to add some quick async/await wrappers to the `MobileCoinClient` API.

This allows a more linear API style with less indentation and callbacks.

```
let balance = try await client.updateBalances()
let transaction = try await client.prepareTransaction(
    to: recipient,
    amount: Amount(100, in: .MOB),
    fee: McConstants.DEFAULT_MINIMUM_FEE
)
try await client.submitTransaction(transaction: transaction.transaction)
let status = try await client.status(of: transaction.transaction)
```

### In this PR

* Add `MobileCoinClient+Async.swift` with wrappers for current public API.
* Add async/await version of the tests.