### PR TITLE
Gemfile Cleanup - Remove empty `specs:`

### DIFF
--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -9,9 +9,6 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)

--- a/ExampleHTTP/Gemfile.lock
+++ b/ExampleHTTP/Gemfile.lock
@@ -9,9 +9,6 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)


### PR DESCRIPTION
### Motivation

Remove empty "specs:" sections, that bundler is removing upon project build. 

### In this PR
* Gemfile.lock chnages

### Future Work
* Update CICD? 
