### PR TITLE
Add `.invalidBlockVersion` error that can now be thrown by rust FFI's

### DIFF
--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -9,6 +9,9 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -9,9 +9,6 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)

--- a/ExampleHTTP/Gemfile.lock
+++ b/ExampleHTTP/Gemfile.lock
@@ -9,6 +9,9 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)

--- a/ExampleHTTP/Gemfile.lock
+++ b/ExampleHTTP/Gemfile.lock
@@ -9,9 +9,6 @@ GIT
       xcpretty (~> 0.3.0)
 
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   jazzy!
 
 BUNDLED WITH
-   2.2.24
+   2.2.20

--- a/Sources/Ledger/BlockVersion.swift
+++ b/Sources/Ledger/BlockVersion.swift
@@ -10,6 +10,7 @@ extension BlockVersion {
     static let versionZero: BlockVersion = 0
     static let versionOne: BlockVersion = 1
     static let versionTwo: BlockVersion = 2
+    static let versionMax: BlockVersion = UInt32.max
 
     static func canEnableRecoverableMemos(version: BlockVersion) -> Bool {
         version >= versionOne

--- a/Tests/Common/Fixtures/Transaction/Receipt+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Receipt+Fixtures.swift
@@ -53,7 +53,7 @@ extension Receipt.Fixtures.Default {
             amount: value,
             tombstoneBlockIndex: 100,
             blockVersion: defaultBlockVersion,
-            rng: MobileCoinDefaultRng()
+            rng: TestRng()
         ).get().receipt
     }
 

--- a/Tests/Unit/Transaction/TransactionTests.swift
+++ b/Tests/Unit/Transaction/TransactionTests.swift
@@ -72,6 +72,19 @@ class TransactionTests: XCTestCase {
         }
     }
 
+    func testFutureBlockVersionFailure() throws {
+        let fixture = try Transaction.Fixtures.BuildTx()
+        XCTAssertFailure(TransactionBuilder.build(
+            inputs: fixture.inputs,
+            accountKey: fixture.accountKey,
+            outputs: fixture.outputs,
+            memoType: .unused,
+            fee: fixture.fee,
+            tombstoneBlockIndex: fixture.tombstoneBlockIndex,
+            fogResolver: fixture.fogResolver,
+            blockVersion: .versionMax))
+    }
+
     func testExactChangeCreatesChangeOutput() throws {
         let fixture = try Transaction.Fixtures.ExactChange()
 

--- a/Tests/Unit/Transaction/TransactionTests.swift
+++ b/Tests/Unit/Transaction/TransactionTests.swift
@@ -82,7 +82,8 @@ class TransactionTests: XCTestCase {
             fee: fixture.fee,
             tombstoneBlockIndex: fixture.tombstoneBlockIndex,
             fogResolver: fixture.fogResolver,
-            blockVersion: .versionMax))
+            blockVersion: .versionMax,
+            rng: TestRng()))
     }
 
     func testExactChangeCreatesChangeOutput() throws {


### PR DESCRIPTION
### Motivation

A fix was made in the rust code to solve a potential panic if an unknown BlockVersion was passed in as a parameter to the TransactionBuilder. Unknown in this sense equals too "new". 

The FFIs are being updated here: https://github.com/mobilecoinfoundation/mobilecoin/pull/2335
libmobilecoin-ios-artifacs here: https://github.com/mobilecoinofficial/libmobilecoin-ios-artifacts/pull/32 

### In this PR
* Update code to catch and throw error if BlockVersion is invalid
* Add test-case
* Add error to enum
