### PR TITLE
Add requireInBalance flag to TransactionStatusChecker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "13.2.1"
+  default-xcode-version: &default-xcode-version "13.4.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "13.4.1"
+  default-xcode-version: &default-xcode-version "13.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "13.1"
+  default-xcode-version: &default-xcode-version "13.4.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "13.3.1"
+  default-xcode-version: &default-xcode-version "13.2.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  default-xcode-version: &default-xcode-version "13.4.1"
+  default-xcode-version: &default-xcode-version "13.3.1"
   default-ruby-version: &default-ruby-version "2.7"
 
   default-environment: &default-environment

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2)
-  - MobileCoin/Core (1.2.2):
+  - MobileCoin (1.2.3)
+  - MobileCoin/Core (1.2.3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.2)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.2):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.2)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.2)
-  - MobileCoin/PerformanceTests (1.2.2)
-  - MobileCoin/Tests (1.2.2)
+  - MobileCoin/IntegrationTests (1.2.3)
+  - MobileCoin/PerformanceTests (1.2.3)
+  - MobileCoin/Tests (1.2.3)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 860cbd565a4839cb8be784465100d9f09ac419aa
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 5bb3562820b1b20cd746ebf85b942707f5ca5a06
+  MobileCoin: 1a05fccd2f220ee45018ea7113f88c1185360b8c
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.2)
-  - MobileCoin/CoreHTTP (1.2.2):
+  - MobileCoin (1.2.3)
+  - MobileCoin/CoreHTTP (1.2.3):
     - LibMobileCoin/CoreHTTP (= 1.2.2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.2):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.3):
     - LibMobileCoin/CoreHTTP (= 1.2.2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.2)
-  - MobileCoin/PerformanceTests (1.2.2)
-  - MobileCoin/Tests (1.2.2)
+  - MobileCoin/IntegrationTests (1.2.3)
+  - MobileCoin/PerformanceTests (1.2.3)
+  - MobileCoin/Tests (1.2.3)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 860cbd565a4839cb8be784465100d9f09ac419aa
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 5bb3562820b1b20cd746ebf85b942707f5ca5a06
+  MobileCoin: 1a05fccd2f220ee45018ea7113f88c1185360b8c
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.2"
+  s.version      = "1.2.3"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -287,6 +287,7 @@ public final class MobileCoinClient {
 
     public func status(
         of transaction: Transaction,
+        requireInBalance: Bool = true,
         completion: @escaping (Result<TransactionStatus, ConnectionError>) -> Void
     ) {
         TransactionStatusChecker(
@@ -294,7 +295,7 @@ public final class MobileCoinClient {
             fogUntrustedTxOutService: serviceProvider.fogUntrustedTxOutService,
             fogKeyImageService: serviceProvider.fogKeyImageService,
             targetQueue: serialQueue
-        ).checkStatus(transaction) { result in
+        ).checkStatus(transaction, requireInBalance: requireInBalance) { result in
             self.callbackQueue.async {
                 completion(result)
             }

--- a/Sources/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Transaction/TransactionStatusChecker.swift
@@ -28,6 +28,7 @@ struct TransactionStatusChecker {
 
     func checkStatus(
         _ transaction: Transaction,
+        requireInBalance: Bool = true,
         completion: @escaping (Result<TransactionStatus, ConnectionError>) -> Void
     ) {
         logger.info(
@@ -41,7 +42,7 @@ struct TransactionStatusChecker {
                 case .accepted(block: let block):
                     // Make sure we only return success if it will also be reflected in the balance,
                     // otherwise, feign ignorance.
-                    guard block.index < self.account.readSync({ $0.knowableBlockCount }) else {
+                    guard !requireInBalance || (block.index < self.account.readSync({ $0.knowableBlockCount })) else {
                         return .unknown
                     }
                     return status

--- a/Sources/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Transaction/TransactionStatusChecker.swift
@@ -42,7 +42,7 @@ struct TransactionStatusChecker {
                 case .accepted(block: let block):
                     // Make sure we only return success if it will also be reflected in the balance,
                     // otherwise, feign ignorance.
-                    guard !(requireInBalance && (block.index >= self.account.readSync({ $0.knowableBlockCount }))) else {
+                    guard !requireInBalance || (block.index < self.account.readSync({ $0.knowableBlockCount })) else {
                         return .unknown
                     }
                     return status

--- a/Sources/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Transaction/TransactionStatusChecker.swift
@@ -42,7 +42,7 @@ struct TransactionStatusChecker {
                 case .accepted(block: let block):
                     // Make sure we only return success if it will also be reflected in the balance,
                     // otherwise, feign ignorance.
-                    guard !requireInBalance || (block.index < self.account.readSync({ $0.knowableBlockCount })) else {
+                    guard !(requireInBalance && (block.index < self.account.readSync({ $0.knowableBlockCount }))) else {
                         return .unknown
                     }
                     return status

--- a/Sources/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Transaction/TransactionStatusChecker.swift
@@ -42,7 +42,7 @@ struct TransactionStatusChecker {
                 case .accepted(block: let block):
                     // Make sure we only return success if it will also be reflected in the balance,
                     // otherwise, feign ignorance.
-                    guard !(requireInBalance && (block.index < self.account.readSync({ $0.knowableBlockCount }))) else {
+                    guard !(requireInBalance && (block.index >= self.account.readSync({ $0.knowableBlockCount }))) else {
                         return .unknown
                     }
                     return status

--- a/Sources/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Transaction/TransactionStatusChecker.swift
@@ -42,7 +42,8 @@ struct TransactionStatusChecker {
                 case .accepted(block: let block):
                     // Make sure we only return success if it will also be reflected in the balance,
                     // otherwise, feign ignorance.
-                    guard !requireInBalance || (block.index < self.account.readSync({ $0.knowableBlockCount })) else {
+                    guard !requireInBalance ||
+                            (block.index < self.account.readSync({ $0.knowableBlockCount })) else {
                         return .unknown
                     }
                     return status


### PR DESCRIPTION
Soundtrack of this PR: [Loading...](https://music.apple.com/us/album/loading-feat-hm-surf/1468495799?i=1468495800)

### Motivation

When sending transactions, sometimes a caller only needs to know that the txOut is found, and the keyImage is spent in ledger without checking the blocks included in the balance.

This balance check can make sending transactions appear slower since the balance needs to be updated before the transaction status can be checked.

### In this PR
* Adds `requireInBalance` flag to control whether `TransactionStatusChecker` feigns ignorance.

