### PR TITLE
Add TransactionStatusTxOutChecker for simpler and quicker transaction status

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.3)
-  - MobileCoin/Core (1.2.3):
+  - MobileCoin (1.2.4)
+  - MobileCoin/Core (1.2.4):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.2)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (1.2.3):
+  - MobileCoin/Core/ProtocolUnitTests (1.2.4):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 1.2.2)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (1.2.3)
-  - MobileCoin/PerformanceTests (1.2.3)
-  - MobileCoin/Tests (1.2.3)
+  - MobileCoin/IntegrationTests (1.2.4)
+  - MobileCoin/PerformanceTests (1.2.4)
+  - MobileCoin/Tests (1.2.4)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 860cbd565a4839cb8be784465100d9f09ac419aa
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 1a05fccd2f220ee45018ea7113f88c1185360b8c
+  MobileCoin: 66058555f1f237e882f4abd2039717cfab115bc5
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (1.2.2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (1.2.3)
-  - MobileCoin/CoreHTTP (1.2.3):
+  - MobileCoin (1.2.4)
+  - MobileCoin/CoreHTTP (1.2.4):
     - LibMobileCoin/CoreHTTP (= 1.2.2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.3):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (1.2.4):
     - LibMobileCoin/CoreHTTP (= 1.2.2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (1.2.3)
-  - MobileCoin/PerformanceTests (1.2.3)
-  - MobileCoin/Tests (1.2.3)
+  - MobileCoin/IntegrationTests (1.2.4)
+  - MobileCoin/PerformanceTests (1.2.4)
+  - MobileCoin/Tests (1.2.4)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 860cbd565a4839cb8be784465100d9f09ac419aa
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 1a05fccd2f220ee45018ea7113f88c1185360b8c
+  MobileCoin: 66058555f1f237e882f4abd2039717cfab115bc5
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "1.2.3"
+  s.version      = "1.2.4"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/LibMobileCoin/ProtoExtensions.swift
+++ b/Sources/LibMobileCoin/ProtoExtensions.swift
@@ -186,3 +186,16 @@ extension FogLedger_BlockData {
         BlockMetadata(index: index, timestampStatus: timestampStatus)
     }
 }
+
+extension FogLedger_TxOutResult {
+    var timestampDate: Date? {
+        get { timestamp != UInt64.max ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil }
+        set {
+            if let newValue = newValue {
+                timestamp = UInt64(newValue.timeIntervalSince1970)
+            } else {
+                timestamp = UInt64.max
+            }
+        }
+    }
+}

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -76,6 +76,16 @@ extension MobileCoinClient {
         }
     }
 
+    public func txOutStatus(
+        of transaction: Transaction
+    ) async throws -> TransactionStatus {
+        try await withCheckedThrowingContinuation { continuation in
+            txOutStatus(of: transaction) {
+                continuation.resume(with: $0)
+            }
+        }
+    }
+
 }
 
 #endif

--- a/Sources/MobileCoinClient.swift
+++ b/Sources/MobileCoinClient.swift
@@ -285,6 +285,20 @@ public final class MobileCoinClient {
         }
     }
 
+    public func txOutStatus(
+        of transaction: Transaction,
+        completion: @escaping (Result<TransactionStatus, ConnectionError>) -> Void
+    ) {
+        TransactionStatusTxOutChecker(
+            account: accountLock,
+            fogUntrustedTxOutService: serviceProvider.fogUntrustedTxOutService
+        ).checkStatus(transaction) { result in
+            self.callbackQueue.async {
+                completion(result)
+            }
+        }
+    }
+
     public func status(
         of transaction: Transaction,
         requireInBalance: Bool = true,

--- a/Sources/Transaction/TransactionStatusTxOutChecker.swift
+++ b/Sources/Transaction/TransactionStatusTxOutChecker.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import LibMobileCoin
+
+struct TransactionStatusTxOutChecker {
+    private let account: ReadWriteDispatchLock<Account>
+    private let fogUntrustedTxOutFetcher: FogUntrustedTxOutFetcher
+
+    init(
+        account: ReadWriteDispatchLock<Account>,
+        fogUntrustedTxOutService: FogUntrustedTxOutService
+    ) {
+        self.account = account
+        self.fogUntrustedTxOutFetcher =
+            FogUntrustedTxOutFetcher(fogUntrustedTxOutService: fogUntrustedTxOutService)
+    }
+
+    func checkStatus(
+        _ transaction: Transaction,
+        completion: @escaping (Result<TransactionStatus, ConnectionError>) -> Void
+    ) {
+        logger.info(
+            "Checking transaction status... transaction: " +
+            "\(redacting: transaction.serializedData.base64EncodedString())",
+            logFunction: false)
+        checkAcceptedStatus(transaction) {
+            completion($0.map { TransactionStatus($0) })
+        }
+    }
+
+    func checkAcceptedStatus(
+        _ transaction: Transaction,
+        completion: @escaping (Result<Transaction.AcceptedStatus, ConnectionError>) -> Void
+    ) {
+        fogUntrustedTxOutFetcher.getTxOut(
+            outputPublicKey: transaction.anyOutput.publicKey
+        ) {
+            completion($0.flatMap {
+                Self.acceptedStatus(
+                    of: transaction,
+                    outputResult: $0,
+                    outputBlockCount: $1)
+            })
+        }
+    }
+
+    private static func acceptedStatus(
+        of transaction: Transaction,
+        outputResult: FogLedger_TxOutResult,
+        outputBlockCount: UInt64
+    ) -> Result<Transaction.AcceptedStatus, ConnectionError> {
+        // We assume the output public key is unique, therefore checking the existence of the output
+        // is enough to confirm Tx was accepted.
+        switch outputResult.resultCode {
+        case .found:
+            let block = BlockMetadata(index: outputResult.blockIndex,
+                                      timestamp: outputResult.timestampDate)
+            return .success(.accepted(block: block))
+        case .notFound:
+            if outputBlockCount >= transaction.tombstoneBlockIndex {
+                return .success(.tombstoneBlockExceeded)
+            } else {
+                return .success(.notAccepted(knownToBeNotAcceptedTotalBlockCount: outputBlockCount))
+            }
+        case .malformedRequest, .databaseError, .UNRECOGNIZED:
+            return .failure(.invalidServerResponse("Fog UntrustedTxOut result error: " +
+                "\(outputResult.resultCode), response: \(outputResult)"))
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

It's not always necessary to check the keyImage when fetching transaction status because the `FogLedger_TxOutResult` has the same information. For backwards compatibility this was added as a new class `TransactionStatusTxOutChecker`.

### In this PR
* Add `TransactionStatusTxOutChecker` which just relies on UntrustedTxOut service.