### PR TITLE
Change @available rule to be compatible with Signals build process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2022-0829
+## [2.0.2] - 2022-08-29
+
+### Changed
+
+- `@available` Minimum version for async APIs
+
+## [2.0.1] - 2022-08-29
+
+### Changed
+
+- Access modifier for ChaCha RNG
+
+## [2.0.0] - 2022-08-29
 
 ### Added
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (2.0.1)
-  - MobileCoin/Core (2.0.1):
+  - MobileCoin (2.0.2)
+  - MobileCoin/Core (2.0.2):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 2.0.0)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (2.0.1):
+  - MobileCoin/Core/ProtocolUnitTests (2.0.2):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 2.0.0)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (2.0.1)
-  - MobileCoin/PerformanceTests (2.0.1)
-  - MobileCoin/Tests (2.0.1)
+  - MobileCoin/IntegrationTests (2.0.2)
+  - MobileCoin/PerformanceTests (2.0.2)
+  - MobileCoin/Tests (2.0.2)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: d1fbf7951d365e4fdc959ca3badc55261f756237
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 47e75054fe94367dda123796b8f5b3b908008f7f
+  MobileCoin: adf1c769d6fc07ac322fe49b8c9e6bed61976741
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (2.0.0):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (2.0.1)
-  - MobileCoin/CoreHTTP (2.0.1):
+  - MobileCoin (2.0.2)
+  - MobileCoin/CoreHTTP (2.0.2):
     - LibMobileCoin/CoreHTTP (= 2.0.0)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (2.0.1):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (2.0.2):
     - LibMobileCoin/CoreHTTP (= 2.0.0)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (2.0.1)
-  - MobileCoin/PerformanceTests (2.0.1)
-  - MobileCoin/Tests (2.0.1)
+  - MobileCoin/IntegrationTests (2.0.2)
+  - MobileCoin/PerformanceTests (2.0.2)
+  - MobileCoin/Tests (2.0.2)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: d1fbf7951d365e4fdc959ca3badc55261f756237
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 47e75054fe94367dda123796b8f5b3b908008f7f
+  MobileCoin: adf1c769d6fc07ac322fe49b8c9e6bed61976741
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -6,7 +6,7 @@ import Foundation
 
 #if swift(>=5.5)
 
-@available(iOSApplicationExtension 15.0.0, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension MobileCoinClient {
 
     @discardableResult

--- a/Sources/MobileCoinClient+Async.swift
+++ b/Sources/MobileCoinClient+Async.swift
@@ -6,7 +6,7 @@ import Foundation
 
 #if swift(>=5.5)
 
-@available(iOS 13.0, *)
+@available(iOSApplicationExtension 15.0.0, *)
 extension MobileCoinClient {
 
     @discardableResult

--- a/Sources/Utils/Async/AsyncUtils.swift
+++ b/Sources/Utils/Async/AsyncUtils.swift
@@ -48,7 +48,7 @@ func performAsync<Value1, Value2, Failure: Error>(
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable multiline_parameters
 
-@available(iOS 13.0, *)
+@available(iOS 15.0.0, *)
 public func withTimeout<T>(
     seconds: TimeInterval,
     block: @escaping @Sendable () async throws -> T

--- a/Sources/Utils/Async/AsyncUtils.swift
+++ b/Sources/Utils/Async/AsyncUtils.swift
@@ -48,7 +48,7 @@ func performAsync<Value1, Value2, Failure: Error>(
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable multiline_parameters
 
-@available(iOS 15.0.0, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public func withTimeout<T>(
     seconds: TimeInterval,
     block: @escaping @Sendable () async throws -> T


### PR DESCRIPTION
Soundtrack of this PR: [Yello - Oh Yeah](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjfoab82u_5AhU9ADQIHRY-C_YQyCl6BAgbEAM&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D6jJkdRaa04g&usg=AOvVaw0NvyoNJhkHOJNCcENbvLR4)

### Motivation

the `@available` tags need a higher version to be compatible with Signal's build process

### In this PR
* Change version and type of `@available` definitions
