### PR TITLE
Update configs with new allowed INTEL-SA-00615 hardening advisory.

### DIFF
--- a/Tests/Common/Fixtures/Network/Attestation/Attestation+Fixtures.swift
+++ b/Tests/Common/Fixtures/Network/Attestation/Attestation+Fixtures.swift
@@ -28,7 +28,7 @@ extension Attestation.Fixtures.Default {
             mrSigner: try XCTUnwrap(Data32(base64Encoded: Self.mrSignerB64)),
             productId: productId,
             minimumSecurityVersion: 0,
-            allowedHardeningAdvisories: ["INTEL-SA-00334"])
+            allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"])
     }
 
     private static let mrSignerB64 = "fuXinXRiP9vG+/FFS+bzuwuGwSNmt7R4rRM1PkTehBE="

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -494,7 +494,7 @@ extension NetworkPreset {
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
                 productId: McConstants.CONSENSUS_PRODUCT_ID,
                 minimumSecurityVersion: McConstants.CONSENSUS_SECURITY_VERSION,
-                allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+                allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"]))
         }
     }
 
@@ -511,7 +511,7 @@ extension NetworkPreset {
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
                 productId: McConstants.FOG_VIEW_PRODUCT_ID,
                 minimumSecurityVersion: McConstants.FOG_VIEW_SECURITY_VERSION,
-                allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+                allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"]))
         }
     }
 
@@ -528,7 +528,7 @@ extension NetworkPreset {
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
                 productId: McConstants.FOG_LEDGER_PRODUCT_ID,
                 minimumSecurityVersion: McConstants.FOG_LEDGER_SECURITY_VERSION,
-                allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+                allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"]))
         }
     }
 
@@ -545,7 +545,7 @@ extension NetworkPreset {
                 mrSigner: try XCTUnwrap(Data(hexEncoded: Self.devMrSignerHex)),
                 productId: McConstants.FOG_REPORT_PRODUCT_ID,
                 minimumSecurityVersion: McConstants.FOG_REPORT_SECURITY_VERSION,
-                allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+                allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"]))
         }
     }
 
@@ -554,7 +554,7 @@ extension NetworkPreset {
             try mrEnclaveHex.map({
                 try XCTUnwrapSuccess(Attestation.MrEnclave.make(
                         mrEnclave: try XCTUnwrap(Data(hexEncoded: $0)),
-                        allowedHardeningAdvisories: ["INTEL-SA-00334"]))
+                        allowedHardeningAdvisories: ["INTEL-SA-00334", "INTEL-SA-00615"]))
             })
         )
     }


### PR DESCRIPTION
### Motivation

The new 2.0.x Enclaves require the INTEL-SA-00615 to be allowed

### In this PR
* Update unit-test configs
