### PR TITLE
Fix Idempotence Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
       - install-example-gems
       - install-example-pods:
           xcode-version: << parameters.xcode-version >>
-      - run: make lint-locally-podspec
+      - run: make lint-podspec
       - store_artifacts: { path: output }
       - store_test_results: { path: output/scan }
       - store_artifacts: { path: ~/Library/Logs/DiagnosticReports }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
       - install-example-gems
       - install-example-pods:
           xcode-version: << parameters.xcode-version >>
-      - run: make lint-podspec
+      - run: make lint-locally-strict-podspec
       - store_artifacts: { path: output }
       - store_test_results: { path: output/scan }
       - store_artifacts: { path: ~/Library/Logs/DiagnosticReports }

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,11 @@ lint-locally-podspec:
 	cd Example; bundle exec pod repo update;
 	bundle exec pod lib lint MobileCoin.podspec --skip-tests --allow-warnings
 
+.PHONY: lint-locally-strict-podspec
+lint-locally-strict-podspec:
+	cd Example; bundle exec pod repo update;
+	bundle exec pod lib lint MobileCoin.podspec --skip-tests
+
 .PHONY: lint-podspec
 lint-podspec:
 	cd Example; bundle exec pod repo update;

--- a/Sources/Utils/Rng/MobileCoinChaCha20Rng.swift
+++ b/Sources/Utils/Rng/MobileCoinChaCha20Rng.swift
@@ -5,15 +5,14 @@
 import Foundation
 import LibMobileCoin
 
-@available(*, deprecated, message:
-    """
-    Full access to the RNG class is no longer neccessary for repeatable transaction creation.
-
-    Consumers that previously used MobileCoinChaCha20Rng should switch to public APIs that now only
-    require an `RngSeed`.
-
-    `RngSeed` is a wrapper around 32-bytes of Data which seeds the Transaction Builder's RNG.
-    """)
+//
+//    Full access to the RNG class is no longer neccessary for repeatable transaction creation.
+//
+//    Consumers that previously used MobileCoinChaCha20Rng should switch to public APIs that now
+//    only require an `RngSeed`.
+//
+//    `RngSeed` is a wrapper around 32-bytes of Data which seeds the Transaction Builder's RNG.
+//
 public final class MobileCoinChaCha20Rng: MobileCoinRng {
     // forcing early initialization so self can be captured in the
     // below init()...but I'm sure there's a better way to work around this


### PR DESCRIPTION
Soundtrack of this PR: [William DeVaughn - Be Thankful For What You Got](https://www.youtube.com/watch?v=Pvtlt-p7vB4)

### Motivation

Pod Release failed due to a deprecation warning, removing as its not entirely necc. because the public API that required the deprecated RNG is also now deprecated

### In this PR
* Remove deprecation warning
* Make CICD use "strict" pod lib lint (no warnings allowed)
