### PR TITLE
Update to support v1 and v2 of masked amounts and masked token ids

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Fog/View/FogView.swift
+++ b/Sources/Fog/View/FogView.swift
@@ -193,6 +193,14 @@ extension LedgerTxOut {
         -> Result<LedgerTxOut, ConnectionError>
     {
         guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
+            
+            guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
+                let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
+                    "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
+                logger.error(errorMessage)
+                return .failure(.invalidServerResponse(errorMessage))
+            }
+            
             let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
                 "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
             logger.error(errorMessage)

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -16,12 +16,12 @@ struct KnownTxOut: TxOutProtocol {
         guard let amount = ledgerTxOut.amount(accountKey: accountKey),
               let (subaddressIndex, keyImage) = ledgerTxOut.keyImage(accountKey: accountKey),
               let sharedSecret = TxOutUtils.sharedSecret(
-                                                viewPrivateKey: accountKey.viewPrivateKey,
-                                                publicKey: ledgerTxOut.publicKey),
+                                    viewPrivateKey: accountKey.viewPrivateKey,
+                                    publicKey: ledgerTxOut.publicKey),
               let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedValue: ledgerTxOut.maskedValue,
-                                                    publicKey: ledgerTxOut.publicKey,
-                                                    viewPrivateKey: accountKey.viewPrivateKey)
+                                    maskedAmount: ledgerTxOut.maskedAmount,
+                                    publicKey: ledgerTxOut.publicKey,
+                                    viewPrivateKey: accountKey.viewPrivateKey)
         else {
             return nil
         }
@@ -43,8 +43,7 @@ struct KnownTxOut: TxOutProtocol {
     var tokenId: TokenId { amount.tokenId }
     var encryptedMemo: Data66 { ledgerTxOut.encryptedMemo }
     var commitment: Data32
-    var maskedValue: UInt64 { ledgerTxOut.maskedValue }
-    var maskedTokenId: Data { ledgerTxOut.maskedTokenId }
+    var maskedAmount: MaskedAmount { ledgerTxOut.maskedAmount }
     var targetKey: RistrettoPublic { ledgerTxOut.targetKey }
     var publicKey: RistrettoPublic { ledgerTxOut.publicKey }
     var block: BlockMetadata { ledgerTxOut.block }

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -44,6 +44,9 @@ struct KnownTxOut: TxOutProtocol {
     var encryptedMemo: Data66 { ledgerTxOut.encryptedMemo }
     var commitment: Data32
     var maskedAmount: MaskedAmount { ledgerTxOut.maskedAmount }
+    var maskedValue: UInt64 { maskedAmount.maskedValue }
+    var maskedTokenId: Data { maskedAmount.maskedTokenId }
+    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
     var targetKey: RistrettoPublic { ledgerTxOut.targetKey }
     var publicKey: RistrettoPublic { ledgerTxOut.publicKey }
     var block: BlockMetadata { ledgerTxOut.block }

--- a/Sources/Ledger/LedgerTxOut.swift
+++ b/Sources/Ledger/LedgerTxOut.swift
@@ -18,8 +18,7 @@ struct LedgerTxOut: TxOutProtocol {
 
     var encryptedMemo: Data66 { txOut.encryptedMemo }
     var commitment: Data32 { txOut.commitment }
-    var maskedValue: UInt64 { txOut.maskedValue }
-    var maskedTokenId: Data { txOut.maskedTokenId }
+    var maskedAmount: MaskedAmount { txOut.maskedAmount }
     var targetKey: RistrettoPublic { txOut.targetKey }
     var publicKey: RistrettoPublic { txOut.publicKey }
 

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -14,6 +14,7 @@ struct TxOut: TxOutProtocol {
     let targetKey: RistrettoPublic
     let publicKey: RistrettoPublic
     let eMemo: Data66
+    public let maskedAmount: MaskedAmount
 
     /// - Returns: `nil` when the input is not deserializable.
     init?(serializedData: Data) {
@@ -41,8 +42,6 @@ struct TxOut: TxOutProtocol {
         proto.serializedDataInfallible
     }
 
-    var maskedValue: UInt64 { proto.maskedAmountV1.maskedValue }
-    var maskedTokenId: Data { proto.maskedAmountV1.maskedTokenID }
     var encryptedFogHint: Data { proto.eFogHint.data }
     var encryptedMemo: Data66 {
         guard proto.hasEMemo else {
@@ -57,10 +56,29 @@ extension TxOut: Hashable {}
 
 extension TxOut {
     static func make(_ proto: External_TxOut) -> Result<TxOut, InvalidInputError> {
-        guard let commitment = Data32(proto.maskedAmountV1.commitment.data) else {
+        
+        var commitment: Data32
+        var maskedAmount: MaskedAmount
+        switch proto.maskedAmount {
+        case .maskedAmountV1(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V1)
+            guard let commitmentV1 = Data32(proto.maskedAmountV1.commitment.data) else {
+                return .failure(
+                    InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+            }
+            commitment = commitmentV1
+        case .maskedAmountV2(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V2)
+            guard let commitmentV2 = Data32(proto.maskedAmountV2.commitment.data) else {
+                return .failure(
+                    InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+            }
+            commitment = commitmentV2
+        case .none:
             return .failure(
-                InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+                InvalidInputError("Failed parsing External_TxOut: invalid masked amount version"))
         }
+
         guard let targetKey = RistrettoPublic(proto.targetKey.data) else {
             return .failure(
                 InvalidInputError("Failed parsing External_TxOut: invalid target key format"))
@@ -69,7 +87,7 @@ extension TxOut {
             return .failure(
                 InvalidInputError("Failed parsing External_TxOut: invalid public key format"))
         }
-        guard [0, 4, 8].contains(proto.maskedAmountV1.maskedTokenID.count) else {
+        guard [0, 4, 8].contains(maskedAmount.maskedTokenId.count) else {
             return .failure(
                 InvalidInputError("Masked Token ID should be 0, 4, or 8 bytes"))
         }
@@ -86,6 +104,7 @@ extension TxOut {
             TxOut(
                 proto: proto,
                 commitment: commitment,
+                maskedAmount: maskedAmount,
                 targetKey: targetKey,
                 publicKey: publicKey,
                 eMemo: eMemo))
@@ -94,12 +113,14 @@ extension TxOut {
     private init(
         proto: External_TxOut,
         commitment: Data32,
+        maskedAmount: MaskedAmount,
         targetKey: RistrettoPublic,
         publicKey: RistrettoPublic,
         eMemo: Data66
     ) {
         self.proto = proto
         self.commitment = commitment
+        self.maskedAmount = maskedAmount
         self.targetKey = targetKey
         self.publicKey = publicKey
         self.eMemo = eMemo

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -1,6 +1,7 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
+// swiftlint:disable function_body_length
 
 import Foundation
 import LibMobileCoin
@@ -56,7 +57,7 @@ extension TxOut: Hashable {}
 
 extension TxOut {
     static func make(_ proto: External_TxOut) -> Result<TxOut, InvalidInputError> {
-        
+
         var commitment: Data32
         var maskedAmount: MaskedAmount
         switch proto.maskedAmount {

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -8,8 +8,7 @@ import LibMobileCoin
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }
     var commitment: Data32 { get }
-    var maskedValue: UInt64 { get }
-    var maskedTokenId: Data { get }
+    var maskedAmount: MaskedAmount { get }
     var targetKey: RistrettoPublic { get }
     var publicKey: RistrettoPublic { get }
 }
@@ -46,8 +45,7 @@ extension TxOutProtocol {
     ///     does not own `TxOut` or because ` TxOut` amounts are incongruent.
     func amount(accountKey: AccountKey) -> Amount? {
         TxOutUtils.amount(
-            maskedValue: maskedValue,
-            maskedTokenId: maskedTokenId,
+            maskedAmount: maskedAmount,
             publicKey: publicKey,
             viewPrivateKey: accountKey.viewPrivateKey)
     }
@@ -85,10 +83,18 @@ extension FogView_TxOutRecord {
     init(_ txOut: TxOutProtocol) {
         self.init()
         self.txOutAmountCommitmentData = txOut.commitment.data
-        self.txOutAmountMaskedValue = txOut.maskedValue
-        self.txOutAmountMaskedV1TokenID = txOut.maskedTokenId
+        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedAmount
         self.txOutTargetKeyData = txOut.targetKey.data
         self.txOutPublicKeyData = txOut.publicKey.data
         self.txOutEMemoData = txOut.encryptedMemo.data
+
+        switch txOut.maskedAmount.version {
+        case V1:
+            self.txOutAmountMaskedV1TokenID = txOut.maskedAmount.maskedTokenId
+        case V2:
+            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
+        default:
+            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
+        }
     }
 }

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -8,6 +8,9 @@ import LibMobileCoin
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }
     var commitment: Data32 { get }
+    var maskedValue: UInt64 { get }
+    var maskedTokenId: Data { get }
+    var maskedAmountVersion: MaskedAmount.Version { get } // TODO needed ?
     var maskedAmount: MaskedAmount { get }
     var targetKey: RistrettoPublic { get }
     var publicKey: RistrettoPublic { get }
@@ -44,6 +47,7 @@ extension TxOutProtocol {
     /// - Returns: `nil` when `accountKey` cannot unmask the amoount, either because `accountKey`
     ///     does not own `TxOut` or because ` TxOut` amounts are incongruent.
     func amount(accountKey: AccountKey) -> Amount? {
+        // TODO - needs changes
         TxOutUtils.amount(
             maskedAmount: maskedAmount,
             publicKey: publicKey,
@@ -83,17 +87,15 @@ extension FogView_TxOutRecord {
     init(_ txOut: TxOutProtocol) {
         self.init()
         self.txOutAmountCommitmentData = txOut.commitment.data
-        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedAmount
+        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedValue
         self.txOutTargetKeyData = txOut.targetKey.data
         self.txOutPublicKeyData = txOut.publicKey.data
         self.txOutEMemoData = txOut.encryptedMemo.data
 
         switch txOut.maskedAmount.version {
-        case V1:
+        case .v1:
             self.txOutAmountMaskedV1TokenID = txOut.maskedAmount.maskedTokenId
-        case V2:
-            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
-        default:
+        case .v2:
             self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
         }
     }

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -73,28 +73,28 @@ enum TxOutUtils {
         }
     }
 
-    static func reconstructCommitment(
-        maskedValue: UInt64,
-        publicKey: RistrettoPublic,
-        viewPrivateKey: RistrettoPrivate
-    ) -> Data32? {
-        reconstructCommitment(maskedValue: maskedValue,
-                              maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-                              publicKey: publicKey, viewPrivateKey: viewPrivateKey)
-    }
+//    static func reconstructCommitment(
+//        maskedValue: UInt64,
+//        publicKey: RistrettoPublic,
+//        viewPrivateKey: RistrettoPrivate
+//    ) -> Data32? {
+//        reconstructCommitment(maskedValue: maskedValue,
+//                              maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+//                              publicKey: publicKey, viewPrivateKey: viewPrivateKey)
+//    }
 
     static func reconstructCommitment(
-        maskedValue: UInt64,
-        maskedTokenId: Data,
+        maskedAmount: MaskedAmount,
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Data32? {
-        maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyBufferPtr in
                 viewPrivateKey.asMcBuffer { viewPrivateKeyPtr in
                     var mcAmount = McTxOutMaskedAmount(
-                        masked_value: maskedValue,
-                        masked_token_id: maskedTokenIdBufferPtr)
+                        masked_value: maskedAmount.maskedAmount,
+                        masked_token_id: maskedTokenIdBufferPtr,
+                        version: maskedAmount.version)
                     switch Data32.make(withMcMutableBuffer: { bufferPtr, errorPtr in
                         mc_tx_out_reconstruct_commitment(
                             &mcAmount,
@@ -241,34 +241,34 @@ enum TxOutUtils {
         }
     }
 
-    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
-    ///     does not own `TxOut` or because `TxOut` values are incongruent.
-    static func value(
-        maskedValue: UInt64,
-        publicKey: RistrettoPublic,
-        viewPrivateKey: RistrettoPrivate
-    ) -> UInt64? {
-        amount(maskedValue: maskedValue,
-               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-               publicKey: publicKey,
-               viewPrivateKey: viewPrivateKey)?.value
-    }
+//    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
+//    ///     does not own `TxOut` or because `TxOut` values are incongruent.
+//    static func value(
+//        maskedValue: UInt64,
+//        publicKey: RistrettoPublic,
+//        viewPrivateKey: RistrettoPrivate
+//    ) -> UInt64? {
+//        amount(maskedValue: maskedValue,
+//               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+//               publicKey: publicKey,
+//               viewPrivateKey: viewPrivateKey)?.value
+//    }
 
     /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
     ///     does not own `TxOut` or because `TxOut` values are incongruent.
     static func amount(
-        maskedValue: UInt64,
-        maskedTokenId: Data,
+        maskedAmount: MaskedAmount,
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Amount? {
         var mcTxOutAmount = McTxOutAmount()
-        return maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        return maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyPtr in
                 viewPrivateKey.asMcBuffer { viewKeyBufferPtr in
                     var mcMaskedAmount = McTxOutMaskedAmount(
-                        masked_value: maskedValue,
-                        masked_token_id: maskedTokenIdBufferPtr)
+                        masked_value: maskedAmount.maskedAmount,
+                        masked_token_id: maskedTokenIdBufferPtr,
+                        version: maskedAmount.version)
                     switch withMcError({ errorPtr in
                         mc_tx_out_get_amount(
                             &mcMaskedAmount,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -87,13 +87,28 @@ enum TxOutUtils {
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Data32? {
-        maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        reconstructCommitment(
+            maskedValue: maskedAmount.maskedValue,
+            maskedTokenId: maskedAmount.maskedTokenId,
+            maskedAmountVersion: maskedAmount.version,
+            publicKey: publicKey,
+            viewPrivateKey: viewPrivateKey)
+    }
+    
+    static func reconstructCommitment(
+        maskedValue: UInt64,
+        maskedTokenId: Data,
+        maskedAmountVersion: MaskedAmount.Version,
+        publicKey: RistrettoPublic,
+        viewPrivateKey: RistrettoPrivate
+    ) -> Data32? {
+        maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyBufferPtr in
                 viewPrivateKey.asMcBuffer { viewPrivateKeyPtr in
                     var mcAmount = McTxOutMaskedAmount(
-                        masked_value: maskedAmount.maskedAmount,
+                        masked_value: maskedValue,
                         masked_token_id: maskedTokenIdBufferPtr,
-                        version: maskedAmount.version)
+                        version: maskedAmountVersion.libmobilecoin_version)
                     switch Data32.make(withMcMutableBuffer: { bufferPtr, errorPtr in
                         mc_tx_out_reconstruct_commitment(
                             &mcAmount,
@@ -252,9 +267,9 @@ enum TxOutUtils {
             publicKey.asMcBuffer { publicKeyPtr in
                 viewPrivateKey.asMcBuffer { viewKeyBufferPtr in
                     var mcMaskedAmount = McTxOutMaskedAmount(
-                        masked_value: maskedAmount.maskedAmount,
+                        masked_value: maskedAmount.maskedValue,
                         masked_token_id: maskedTokenIdBufferPtr,
-                        version: maskedAmount.version)
+                        version: maskedAmount.libmobilecoin_version)
                     switch withMcError({ errorPtr in
                         mc_tx_out_get_amount(
                             &mcMaskedAmount,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -1,8 +1,7 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-
-// swiftlint:disable closure_body_length multiline_arguments
+// swiftlint:disable closure_body_length
 
 import Foundation
 import LibMobileCoin
@@ -240,19 +239,6 @@ enum TxOutUtils {
             }
         }
     }
-
-//    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
-//    ///     does not own `TxOut` or because `TxOut` values are incongruent.
-//    static func value(
-//        maskedValue: UInt64,
-//        publicKey: RistrettoPublic,
-//        viewPrivateKey: RistrettoPrivate
-//    ) -> UInt64? {
-//        amount(maskedValue: maskedValue,
-//               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-//               publicKey: publicKey,
-//               viewPrivateKey: viewPrivateKey)?.value
-//    }
 
     /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
     ///     does not own `TxOut` or because `TxOut` values are incongruent.

--- a/Sources/LibMobileCoin/McConstants.swift
+++ b/Sources/LibMobileCoin/McConstants.swift
@@ -23,7 +23,7 @@ extension McConstants {
     static let MAX_TOMBSTONE_BLOCKS: UInt64 = 100
 
     /// Minimum allowed fee, denominated in picoMOB.
-    static let DEFAULT_MINIMUM_FEE: UInt64 = 10_000_000_000
+    static let DEFAULT_MINIMUM_FEE: UInt64 = 4_000_000_000
 
     /// Transaction hash length, in bytes.
     static let TX_HASH_LEN = 32

--- a/Sources/LibMobileCoin/ProtoExtensions.swift
+++ b/Sources/LibMobileCoin/ProtoExtensions.swift
@@ -101,6 +101,19 @@ extension FogView_TxOutRecord {
     }
 }
 
+extension FogView_TxOutRecordLegacy {
+    var timestampDate: Date? {
+        get { timestamp != UInt64.max ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil }
+        set {
+            if let newValue = newValue {
+                timestamp = UInt64(newValue.timeIntervalSince1970)
+            } else {
+                timestamp = UInt64.max
+            }
+        }
+    }
+}
+
 // MARK: - Fog Ledger
 
 extension FogLedger_OutputResult {

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -6,37 +6,100 @@ import Foundation
 import LibMobileCoin
 
 struct MaskedAmount {
-    var maskedAmount: UInt64
-    var maskedTokenId: Data
-    var version: McMaskedAmountVersion
-
-    init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
-        self.maskedAmount = maskedAmount
-        self.maskedTokenId = maskedTokenId
-        self.version = version
+    enum Version {
+        case v1
+        case v2
+    }
+    
+    let maskedValue: UInt64
+    let maskedTokenId: Data
+    let commitment: Data32
+    let version: Version
+    
+    var libmobilecoin_version: McMaskedAmountVersion {
+        version.libmobilecoin_version
     }
 }
 
-extension MaskedAmount: CustomStringConvertible {
+extension MaskedAmount.Version {
+    var libmobilecoin_version: McMaskedAmountVersion {
+        switch self {
+        case .v1: return V1
+        case .v2: return V2
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: External_TxOut.OneOf_MaskedAmount) {
+        switch proto {
+        case .maskedAmountV1(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v1
+        case .maskedAmountV2(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v2
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: FogView_TxOutRecord) {
+        switch proto.txOutAmountMaskedTokenID {
+        case .txOutAmountMaskedV1TokenID(let maskedTokenID):
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = maskedTokenID
+            self.version = Version.v1
+        case .txOutAmountMaskedV2TokenID(let maskedTokenID):
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = maskedTokenID
+            self.version = Version.v2
+        case .none:
+            // Same as "empty"/"missing" which means its token_id 0 for MOB
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = Data()
+            self.version = Version.v1
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: External_Receipt.OneOf_MaskedAmount) {
+        switch proto {
+        case .maskedAmountV1(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v1
+        case .maskedAmountV2(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v2
+        }
+    }
+}
+
+extension MaskedAmount.Version: CustomStringConvertible {
     public var description: String {
-        "\(maskedAmount) \(maskedTokenId.description)"
+        switch self {
+        case .v1: return "Version 1"
+        case .v2: return "Version 2"
+        }
+    }
+}
+extension MaskedAmount: Hashable, Equatable, CustomStringConvertible {
+    public var description: String {
+        "maskedValue \(maskedValue) \n" +
+        "maskedTokenId \(maskedTokenId.hexEncodedString()) \n" +
+        "version \(version) \n"
     }
 }
 
-extension MaskedAmount: Equatable {
-    static func == (lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
-        lhs.maskedAmount == rhs.maskedAmount &&
-        lhs.maskedTokenId == rhs.maskedTokenId &&
-        lhs.version == rhs.version
-    }
-}
-
-extension McMaskedAmountVersion: Hashable {}
-
-extension MaskedAmount: Hashable {
-    func hash(into hasher: inout Hasher) {
-      hasher.combine(maskedAmount)
-      hasher.combine(maskedTokenId)
-      hasher.combine(version)
-    }
-}

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -5,12 +5,12 @@
 import Foundation
 import LibMobileCoin
 
-class MaskedAmount {
+struct MaskedAmount {
     var maskedAmount: UInt64
     var maskedTokenId: Data
     var version: McMaskedAmountVersion
 
-    public init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
+    init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
         self.maskedAmount = maskedAmount
         self.maskedTokenId = maskedTokenId
         self.version = version
@@ -24,10 +24,10 @@ extension MaskedAmount: CustomStringConvertible {
 }
 
 extension MaskedAmount: Equatable {
-    static func ==(lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
-        return lhs.maskedAmount == rhs.maskedAmount
-            && lhs.maskedTokenId == rhs.maskedTokenId
-            && lhs.version == rhs.version
+    static func == (lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
+        lhs.maskedAmount == rhs.maskedAmount &&
+        lhs.maskedTokenId == rhs.maskedTokenId &&
+        lhs.version == rhs.version
     }
 }
 

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import LibMobileCoin
+
+class MaskedAmount {
+    var maskedAmount: UInt64
+    var maskedTokenId: Data
+    var version: McMaskedAmountVersion
+
+    public init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
+        self.maskedAmount = maskedAmount
+        self.maskedTokenId = maskedTokenId
+        self.version = version
+    }
+}
+
+extension MaskedAmount: CustomStringConvertible {
+    public var description: String {
+        "\(maskedAmount) \(maskedTokenId.description)"
+    }
+}
+
+extension MaskedAmount: Equatable {
+    static func ==(lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
+        return lhs.maskedAmount == rhs.maskedAmount
+            && lhs.maskedTokenId == rhs.maskedTokenId
+            && lhs.version == rhs.version
+    }
+}
+
+extension McMaskedAmountVersion: Hashable {}
+
+extension MaskedAmount: Hashable {
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(maskedAmount)
+      hasher.combine(maskedTokenId)
+      hasher.combine(version)
+    }
+}

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -22,8 +22,7 @@ import LibMobileCoin
 public struct Receipt {
     let txOutPublicKeyTyped: RistrettoPublic
     let commitment: Data32
-    let maskedValue: UInt64
-    let maskedTokenId: Data
+    let maskedAmount: MaskedAmount
     let confirmationNumber: TxOutConfirmationNumber
 
     /// Block index at which the transaction that produced this `Receipt` will no longer be
@@ -37,8 +36,7 @@ public struct Receipt {
     ) {
         self.txOutPublicKeyTyped = txOut.publicKey
         self.commitment = txOut.commitment
-        self.maskedValue = txOut.maskedValue
-        self.maskedTokenId = txOut.maskedTokenId
+        self.maskedAmount = txOut.maskedAmount
         self.confirmationNumber = confirmationNumber
         self.txTombstoneBlockIndex = tombstoneBlockIndex
     }
@@ -68,8 +66,7 @@ public struct Receipt {
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
-            && maskedValue == txOut.maskedValue
-            && maskedTokenId == txOut.maskedTokenId
+            && maskedAmount == txOut.maskedAmount
     }
 
     func validateConfirmationNumber(accountKey: AccountKey) -> Bool {
@@ -87,8 +84,7 @@ public struct Receipt {
 
     func unmaskAmount(accountKey: AccountKey) -> Result<Amount, InvalidInputError> {
         guard let amount = TxOutUtils.amount(
-            maskedValue: maskedValue,
-            maskedTokenId: maskedTokenId,
+            maskedAmount: maskedAmount,
             publicKey: txOutPublicKeyTyped,
             viewPrivateKey: accountKey.viewPrivateKey)
         else {
@@ -124,8 +120,7 @@ public struct Receipt {
         }
 
         guard let amount = TxOutUtils.amount(
-                maskedValue: maskedValue,
-                maskedTokenId: maskedTokenId,
+                maskedAmount: maskedAmount,
                 publicKey: txOutPublicKeyTyped,
                 viewPrivateKey: accountKey.viewPrivateKey)
         else {
@@ -156,8 +151,25 @@ extension Receipt: Hashable {}
 
 extension Receipt {
     init?(_ proto: External_Receipt) {
+        let commitmentData: Data
+        let maskedAmount: MaskedAmount
+        switch proto.maskedAmount {
+        case .maskedAmountV1(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V1)
+            commitmentData = proto.maskedAmountV1.commitment.data
+        case .maskedAmountV2(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V2)
+            commitmentData = proto.maskedAmountV2.commitment.data
+        case .none:
+            logger.warning(
+                "Failed to initialize Receipt with External_Receipt. serialized proto: " +
+                    "\(redacting: proto.serializedDataInfallible.base64EncodedString())",
+                logFunction: false)
+            return nil
+        }
+
         guard let txOutPublicKey = RistrettoPublic(proto.publicKey.data),
-              let commitment = Data32(proto.maskedAmountV1.commitment.data),
+              let commitment = Data32(commitmentData),
               let confirmationNumber = TxOutConfirmationNumber(proto.confirmation)
         else {
             logger.warning(
@@ -169,8 +181,7 @@ extension Receipt {
 
         self.txOutPublicKeyTyped = txOutPublicKey
         self.commitment = commitment
-        self.maskedValue = proto.maskedAmountV1.maskedValue
-        self.maskedTokenId = proto.maskedAmountV1.maskedTokenID
+        self.maskedAmount = maskedAmount
         self.confirmationNumber = confirmationNumber
         self.txTombstoneBlockIndex = proto.tombstoneBlock
     }
@@ -180,10 +191,23 @@ extension External_Receipt {
     init(_ receipt: Receipt) {
         self.init()
         self.publicKey = External_CompressedRistretto(receipt.txOutPublicKey)
-        self.maskedAmountV1.commitment = External_CompressedRistretto(receipt.commitment)
-        self.maskedAmountV1.maskedValue = receipt.maskedValue
-        self.maskedAmountV1.maskedTokenID = receipt.maskedTokenId
         self.confirmation = External_TxOutConfirmationNumber(receipt.confirmationNumber)
         self.tombstoneBlock = receipt.txTombstoneBlockIndex
+
+        switch receipt.maskedAmount.version {
+        case V1:
+            self.maskedAmountV1.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV1.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV1.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        case V2:
+            self.maskedAmountV2.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV2.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV2.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        default:
+            self.maskedAmountV2.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV2.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV2.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        }
+
     }
 }

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -66,7 +66,7 @@ extension DynamicNetworkConfig {
 
     enum AlphaDevelopment {
         static let user = ""
-        static let namespace = "alpha"
+        static let namespace = "mc-sci-test"
         static let environment = "development"
         static let fogAuthoritySpkiB64Encoded = dynamicFogAuthoritySpki
 

--- a/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
@@ -93,8 +93,10 @@ extension Transaction.Fixtures.BuildTx {
                     encryptedMemo: Data66(),
                     commitment: Data32(base64Encoded:
                         "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
-                    maskedValue: 2886556578342610519,
-                    maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                    maskedAmount: MaskedAmount(
+                        2886556578342610519,
+                        maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                        version: V1),
                     targetKey: RistrettoPublic(base64Encoded:
                         "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!,
                     publicKey: RistrettoPublic(base64Encoded:

--- a/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
@@ -91,12 +91,12 @@ extension Transaction.Fixtures.BuildTx {
             LedgerTxOut(
                 PartialTxOut(
                     encryptedMemo: Data66(),
-                    commitment: Data32(base64Encoded:
-                        "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
                     maskedAmount: MaskedAmount(
-                        2886556578342610519,
+                        maskedValue: 2886556578342610519,
                         maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-                        version: V1),
+                        commitment: Data32(base64Encoded:
+                            "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
+                        version: .v1),
                     targetKey: RistrettoPublic(base64Encoded:
                         "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!,
                     publicKey: RistrettoPublic(base64Encoded:

--- a/Tests/Integration/Network/NetworkConfigFixtures.swift
+++ b/Tests/Integration/Network/NetworkConfigFixtures.swift
@@ -10,7 +10,7 @@ import XCTest
 
 enum NetworkConfigFixtures {
     static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
-    static let network: NetworkPreset = .testNet
+    static let network: NetworkPreset = .dynamic(alphaDev)
 }
 
 extension NetworkConfigFixtures {

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -2,6 +2,7 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
+import LibMobileCoin
 @testable import MobileCoin
 import XCTest
 
@@ -16,10 +17,14 @@ class ReconstructedCommitmentTests: XCTestCase {
     func testReconstructCommitment() throws {
         let fixture = try Transaction.Fixtures.Commitment()
         let txOutRecord = fixture.txOutRecord
+        let maskedAmount = MaskedAmount(
+            txOutRecord.txOutAmountMaskedValue,
+            maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+            version: V1)
         let viewKey = fixture.viewKey
         guard let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
               let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedValue: txOutRecord.txOutAmountMaskedValue,
+                                                    maskedAmount: maskedAmount,
                                                     publicKey: publicKey,
                                                     viewPrivateKey: viewKey) else {
             XCTFail("Unable to reconstruct commitment")

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -17,16 +17,17 @@ class ReconstructedCommitmentTests: XCTestCase {
     func testReconstructCommitment() throws {
         let fixture = try Transaction.Fixtures.Commitment()
         let txOutRecord = fixture.txOutRecord
-        let maskedAmount = MaskedAmount(
-            txOutRecord.txOutAmountMaskedValue,
-            maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-            version: V1)
         let viewKey = fixture.viewKey
-        guard let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
-              let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedAmount: maskedAmount,
-                                                    publicKey: publicKey,
-                                                    viewPrivateKey: viewKey) else {
+        
+        guard
+            let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
+            let commitment = TxOutUtils.reconstructCommitment(
+                maskedValue: txOutRecord.txOutAmountMaskedValue,
+                maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                maskedAmountVersion: .v1,
+                publicKey: publicKey,
+                viewPrivateKey: viewKey)
+        else {
             XCTFail("Unable to reconstruct commitment")
             return
         }


### PR DESCRIPTION
### Motivation

The mobilecoin lib was updated to have multiple versions of masked amount and masked token id.  This change is to update the Swift SDK to support the the masked amount version changes in mobilecion and libmobilecoin.

### In this PR
* support for masked amount and masked token id v1 and v2
