### PR TITLE
Masked Amount V1 & V2 Changes

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,32 +19,32 @@ PODS:
     - SwiftNIOTransportServices (< 2.0.0, >= 1.6.0)
     - SwiftProtobuf (< 2.0.0, >= 1.9.0)
   - Keys (1.0.1)
-  - LibMobileCoin/Core (4.0.0-pre1):
+  - LibMobileCoin/Core (4.0.0-pre2):
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre1)
-  - MobileCoin/Core (4.0.0-pre1):
+  - MobileCoin (4.0.0-pre2)
+  - MobileCoin/Core (4.0.0-pre2):
     - gRPC-Swift (= 1.0.0)
-    - LibMobileCoin/Core (~> 4.0.0-pre1)
+    - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.40.0)
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre1):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre2):
     - gRPC-Swift (= 1.0.0)
-    - LibMobileCoin/Core (~> 4.0.0-pre1)
+    - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
     - SwiftNIO (~> 2.40.0)
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0-pre1)
-  - MobileCoin/PerformanceTests (4.0.0-pre1)
-  - MobileCoin/Tests (4.0.0-pre1)
+  - MobileCoin/IntegrationTests (4.0.0-pre2)
+  - MobileCoin/PerformanceTests (4.0.0-pre2)
+  - MobileCoin/Tests (4.0.0-pre2)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -222,9 +222,9 @@ SPEC CHECKSUMS:
   CNIOWindows: 3047f2d8165848a3936a0a755fee27c6b5ee479b
   gRPC-Swift: 77154009a019e97f8c4bd8f2bb75fe9726801157
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  LibMobileCoin: cc737c98a2de72058bd1fbb1e2b9ec89b4fc3727
+  LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 096c73301250f95d8c8a08d78ab6ec26945edd01
+  MobileCoin: a9f23f2bd09eae7aed4ad810688ec45801f70a5e
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
   - Keys (1.0.1)
-  - LibMobileCoin/CoreHTTP (4.0.0-pre1):
+  - LibMobileCoin/CoreHTTP (4.0.0-pre2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre1)
-  - MobileCoin/CoreHTTP (4.0.0-pre1):
-    - LibMobileCoin/CoreHTTP (~> 4.0.0-pre1)
+  - MobileCoin (4.0.0-pre2)
+  - MobileCoin/CoreHTTP (4.0.0-pre2):
+    - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre1):
-    - LibMobileCoin/CoreHTTP (~> 4.0.0-pre1)
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre2):
+    - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0-pre1)
-  - MobileCoin/PerformanceTests (4.0.0-pre1)
-  - MobileCoin/Tests (4.0.0-pre1)
+  - MobileCoin/IntegrationTests (4.0.0-pre2)
+  - MobileCoin/PerformanceTests (4.0.0-pre2)
+  - MobileCoin/Tests (4.0.0-pre2)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  LibMobileCoin: cc737c98a2de72058bd1fbb1e2b9ec89b4fc3727
+  LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 096c73301250f95d8c8a08d78ab6ec26945edd01
+  MobileCoin: a9f23f2bd09eae7aed4ad810688ec45801f70a5e
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0-pre1"
+  s.version      = "4.0.0-pre2"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/Core", "~> 4.0.0-pre1"
+    subspec.dependency "LibMobileCoin/Core", "4.0.0-pre2"
 
     subspec.dependency "gRPC-Swift", "1.0.0"
     subspec.dependency "Logging", "~> 1.4"
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
       "Sources/Network/*.{h,m,swift}",
     ]
 
-    subspec.dependency "LibMobileCoin/CoreHTTP", "~> 4.0.0-pre1"
+    subspec.dependency "LibMobileCoin/CoreHTTP", "4.0.0-pre2"
 
     subspec.dependency "Logging", "~> 1.4"
 

--- a/Sources/Fog/View/FogView.swift
+++ b/Sources/Fog/View/FogView.swift
@@ -193,6 +193,14 @@ extension LedgerTxOut {
         -> Result<LedgerTxOut, ConnectionError>
     {
         guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
+            
+            guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
+                let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
+                    "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
+                logger.error(errorMessage)
+                return .failure(.invalidServerResponse(errorMessage))
+            }
+            
             let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
                 "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
             logger.error(errorMessage)

--- a/Sources/Fog/View/FogView.swift
+++ b/Sources/Fog/View/FogView.swift
@@ -193,14 +193,6 @@ extension LedgerTxOut {
         -> Result<LedgerTxOut, ConnectionError>
     {
         guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
-            
-            guard let ledgerTxOut = LedgerTxOut(txOutRecord, viewKey: viewKey) else {
-                let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
-                    "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
-                logger.error(errorMessage)
-                return .failure(.invalidServerResponse(errorMessage))
-            }
-            
             let errorMessage = "Invalid TxOut returned from Fog View. TxOutRecord: " +
                 "\(redacting: txOutRecord.serializedDataInfallible.base64EncodedString())"
             logger.error(errorMessage)

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -16,12 +16,12 @@ struct KnownTxOut: TxOutProtocol {
         guard let amount = ledgerTxOut.amount(accountKey: accountKey),
               let (subaddressIndex, keyImage) = ledgerTxOut.keyImage(accountKey: accountKey),
               let sharedSecret = TxOutUtils.sharedSecret(
-                                                viewPrivateKey: accountKey.viewPrivateKey,
-                                                publicKey: ledgerTxOut.publicKey),
+                                    viewPrivateKey: accountKey.viewPrivateKey,
+                                    publicKey: ledgerTxOut.publicKey),
               let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedValue: ledgerTxOut.maskedValue,
-                                                    publicKey: ledgerTxOut.publicKey,
-                                                    viewPrivateKey: accountKey.viewPrivateKey)
+                                    maskedAmount: ledgerTxOut.maskedAmount,
+                                    publicKey: ledgerTxOut.publicKey,
+                                    viewPrivateKey: accountKey.viewPrivateKey)
         else {
             return nil
         }
@@ -43,8 +43,7 @@ struct KnownTxOut: TxOutProtocol {
     var tokenId: TokenId { amount.tokenId }
     var encryptedMemo: Data66 { ledgerTxOut.encryptedMemo }
     var commitment: Data32
-    var maskedValue: UInt64 { ledgerTxOut.maskedValue }
-    var maskedTokenId: Data { ledgerTxOut.maskedTokenId }
+    var maskedAmount: MaskedAmount { ledgerTxOut.maskedAmount }
     var targetKey: RistrettoPublic { ledgerTxOut.targetKey }
     var publicKey: RistrettoPublic { ledgerTxOut.publicKey }
     var block: BlockMetadata { ledgerTxOut.block }

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -44,9 +44,6 @@ struct KnownTxOut: TxOutProtocol {
     var encryptedMemo: Data66 { ledgerTxOut.encryptedMemo }
     var commitment: Data32
     var maskedAmount: MaskedAmount { ledgerTxOut.maskedAmount }
-    var maskedValue: UInt64 { maskedAmount.maskedValue }
-    var maskedTokenId: Data { maskedAmount.maskedTokenId }
-    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
     var targetKey: RistrettoPublic { ledgerTxOut.targetKey }
     var publicKey: RistrettoPublic { ledgerTxOut.publicKey }
     var block: BlockMetadata { ledgerTxOut.block }

--- a/Sources/Ledger/KnownTxOut.swift
+++ b/Sources/Ledger/KnownTxOut.swift
@@ -44,6 +44,9 @@ struct KnownTxOut: TxOutProtocol {
     var encryptedMemo: Data66 { ledgerTxOut.encryptedMemo }
     var commitment: Data32
     var maskedAmount: MaskedAmount { ledgerTxOut.maskedAmount }
+    var maskedValue: UInt64 { maskedAmount.maskedValue }
+    var maskedTokenId: Data { maskedAmount.maskedTokenId }
+    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
     var targetKey: RistrettoPublic { ledgerTxOut.targetKey }
     var publicKey: RistrettoPublic { ledgerTxOut.publicKey }
     var block: BlockMetadata { ledgerTxOut.block }

--- a/Sources/Ledger/LedgerTxOut.swift
+++ b/Sources/Ledger/LedgerTxOut.swift
@@ -41,7 +41,7 @@ extension LedgerTxOut {
             timestamp: txOutRecord.timestampDate)
         self.init(partialTxOut, globalIndex: globalIndex, block: block)
     }
-    
+
     init?(_ txOutRecord: FogView_TxOutRecordLegacy, viewKey: RistrettoPrivate) {
         guard let partialTxOut = PartialTxOut(txOutRecord, viewKey: viewKey) else {
             return nil
@@ -58,7 +58,7 @@ extension LedgerTxOut {
     init?(_ fogTxOutRecordBytes: Data, viewKey: RistrettoPrivate) {
         let legacy_txOutRecord = try? FogView_TxOutRecordLegacy(contiguousBytes: fogTxOutRecordBytes)
         let txOutRecord = try? FogView_TxOutRecord(contiguousBytes: fogTxOutRecordBytes)
-        
+
         switch (legacy_txOutRecord, txOutRecord) {
         case (.some(let txOutRecord), nil):
             guard let partialTxOut = PartialTxOut(txOutRecord, viewKey: viewKey) else { return nil }

--- a/Sources/Ledger/LedgerTxOut.swift
+++ b/Sources/Ledger/LedgerTxOut.swift
@@ -19,9 +19,6 @@ struct LedgerTxOut: TxOutProtocol {
     var encryptedMemo: Data66 { txOut.encryptedMemo }
     var commitment: Data32 { txOut.commitment }
     var maskedAmount: MaskedAmount { txOut.maskedAmount }
-    var maskedValue: UInt64 { maskedAmount.maskedValue }
-    var maskedTokenId: Data { maskedAmount.maskedTokenId }
-    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
     var targetKey: RistrettoPublic { txOut.targetKey }
     var publicKey: RistrettoPublic { txOut.publicKey }
 

--- a/Sources/Ledger/LedgerTxOut.swift
+++ b/Sources/Ledger/LedgerTxOut.swift
@@ -54,20 +54,23 @@ extension LedgerTxOut {
     }
 }
 
+// swiftlint:disable todo
 extension LedgerTxOut {
     init?(_ fogTxOutRecordBytes: Data, viewKey: RistrettoPrivate) {
-        let legacy_txOutRecord = try? FogView_TxOutRecordLegacy(contiguousBytes: fogTxOutRecordBytes)
+        let legacy_txOutRecord = try? FogView_TxOutRecordLegacy(
+                contiguousBytes: fogTxOutRecordBytes)
         let txOutRecord = try? FogView_TxOutRecord(contiguousBytes: fogTxOutRecordBytes)
 
+        // TODO - Temporary fix for serialized data, find workaround and remove legacy proto
         switch (legacy_txOutRecord, txOutRecord) {
-        case (.some(let txOutRecord), nil):
+        case (.some(let txOutRecord), _):
             guard let partialTxOut = PartialTxOut(txOutRecord, viewKey: viewKey) else { return nil }
             let globalIndex = txOutRecord.txOutGlobalIndex
             let block = BlockMetadata(
                 index: txOutRecord.blockIndex,
                 timestamp: txOutRecord.timestampDate)
             self.init(partialTxOut, globalIndex: globalIndex, block: block)
-        case (nil, .some(let txOutRecord)):
+        case (_, .some(let txOutRecord)):
             guard let partialTxOut = PartialTxOut(txOutRecord, viewKey: viewKey) else { return nil }
             let globalIndex = txOutRecord.txOutGlobalIndex
             let block = BlockMetadata(
@@ -79,3 +82,4 @@ extension LedgerTxOut {
         }
     }
 }
+// swiftlint:enable todo

--- a/Sources/Ledger/LedgerTxOut.swift
+++ b/Sources/Ledger/LedgerTxOut.swift
@@ -18,8 +18,7 @@ struct LedgerTxOut: TxOutProtocol {
 
     var encryptedMemo: Data66 { txOut.encryptedMemo }
     var commitment: Data32 { txOut.commitment }
-    var maskedValue: UInt64 { txOut.maskedValue }
-    var maskedTokenId: Data { txOut.maskedTokenId }
+    var maskedAmount: MaskedAmount { txOut.maskedAmount }
     var targetKey: RistrettoPublic { txOut.targetKey }
     var publicKey: RistrettoPublic { txOut.publicKey }
 

--- a/Sources/Ledger/PartialTxOut.swift
+++ b/Sources/Ledger/PartialTxOut.swift
@@ -11,9 +11,6 @@ struct PartialTxOut: TxOutProtocol {
     let targetKey: RistrettoPublic
     let publicKey: RistrettoPublic
     var commitment: Data32 { maskedAmount.commitment }
-    var maskedValue: UInt64 { maskedAmount.maskedValue }
-    var maskedTokenId: Data { maskedAmount.maskedTokenId }
-    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
 }
 
 extension PartialTxOut: Equatable {}

--- a/Sources/Ledger/PartialTxOut.swift
+++ b/Sources/Ledger/PartialTxOut.swift
@@ -101,14 +101,20 @@ extension PartialTxOut {
             publicKey: publicKey)
     }
 
-    static func isCrc32Matching(_ reconstructed: Data32, txOutRecord: FogView_TxOutRecordLegacy) -> Bool {
+    static func isCrc32Matching(
+            _ reconstructed: Data32,
+            txOutRecord: FogView_TxOutRecordLegacy
+    ) -> Bool {
         isCrc32Matching(
             reconstructed,
             commitmentData: txOutRecord.txOutAmountCommitmentData,
             commitmentDataCrc32: txOutRecord.txOutAmountCommitmentDataCrc32)
     }
 
-    static func isCrc32Matching(_ reconstructed: Data32, txOutRecord: FogView_TxOutRecord) -> Bool {
+    static func isCrc32Matching(
+            _ reconstructed: Data32,
+            txOutRecord: FogView_TxOutRecord
+    ) -> Bool {
         isCrc32Matching(
             reconstructed,
             commitmentData: txOutRecord.txOutAmountCommitmentData,

--- a/Sources/Ledger/PartialTxOut.swift
+++ b/Sources/Ledger/PartialTxOut.swift
@@ -37,7 +37,7 @@ extension PartialTxOut {
         else {
             return nil
         }
-        
+
         guard
             let targetKey = RistrettoPublic(txOut.targetKey.data),
             let publicKey = RistrettoPublic(txOut.publicKey.data),
@@ -110,14 +110,14 @@ extension PartialTxOut {
             commitmentData: txOutRecord.txOutAmountCommitmentData,
             commitmentDataCrc32: txOutRecord.txOutAmountCommitmentDataCrc32)
     }
-    
+
     static func isCrc32Matching(_ reconstructed: Data32, txOutRecord: FogView_TxOutRecord) -> Bool {
         isCrc32Matching(
             reconstructed,
             commitmentData: txOutRecord.txOutAmountCommitmentData,
             commitmentDataCrc32: txOutRecord.txOutAmountCommitmentDataCrc32)
     }
-    
+
     static func isCrc32Matching(
         _ reconstructed: Data32,
         commitmentData: Data,

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -14,6 +14,7 @@ struct TxOut: TxOutProtocol {
     let targetKey: RistrettoPublic
     let publicKey: RistrettoPublic
     let eMemo: Data66
+    public let maskedAmount: MaskedAmount
 
     /// - Returns: `nil` when the input is not deserializable.
     init?(serializedData: Data) {
@@ -41,8 +42,6 @@ struct TxOut: TxOutProtocol {
         proto.serializedDataInfallible
     }
 
-    var maskedValue: UInt64 { proto.maskedAmountV1.maskedValue }
-    var maskedTokenId: Data { proto.maskedAmountV1.maskedTokenID }
     var encryptedFogHint: Data { proto.eFogHint.data }
     var encryptedMemo: Data66 {
         guard proto.hasEMemo else {
@@ -57,10 +56,29 @@ extension TxOut: Hashable {}
 
 extension TxOut {
     static func make(_ proto: External_TxOut) -> Result<TxOut, InvalidInputError> {
-        guard let commitment = Data32(proto.maskedAmountV1.commitment.data) else {
+        
+        var commitment: Data32
+        var maskedAmount: MaskedAmount
+        switch proto.maskedAmount {
+        case .maskedAmountV1(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V1)
+            guard let commitmentV1 = Data32(proto.maskedAmountV1.commitment.data) else {
+                return .failure(
+                    InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+            }
+            commitment = commitmentV1
+        case .maskedAmountV2(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V2)
+            guard let commitmentV2 = Data32(proto.maskedAmountV2.commitment.data) else {
+                return .failure(
+                    InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+            }
+            commitment = commitmentV2
+        case .none:
             return .failure(
-                InvalidInputError("Failed parsing External_TxOut: invalid commitment format"))
+                InvalidInputError("Failed parsing External_TxOut: invalid masked amount version"))
         }
+
         guard let targetKey = RistrettoPublic(proto.targetKey.data) else {
             return .failure(
                 InvalidInputError("Failed parsing External_TxOut: invalid target key format"))
@@ -69,7 +87,7 @@ extension TxOut {
             return .failure(
                 InvalidInputError("Failed parsing External_TxOut: invalid public key format"))
         }
-        guard [0, 4, 8].contains(proto.maskedAmountV1.maskedTokenID.count) else {
+        guard [0, 4, 8].contains(maskedAmount.maskedTokenId.count) else {
             return .failure(
                 InvalidInputError("Masked Token ID should be 0, 4, or 8 bytes"))
         }
@@ -86,6 +104,7 @@ extension TxOut {
             TxOut(
                 proto: proto,
                 commitment: commitment,
+                maskedAmount: maskedAmount,
                 targetKey: targetKey,
                 publicKey: publicKey,
                 eMemo: eMemo))
@@ -94,12 +113,14 @@ extension TxOut {
     private init(
         proto: External_TxOut,
         commitment: Data32,
+        maskedAmount: MaskedAmount,
         targetKey: RistrettoPublic,
         publicKey: RistrettoPublic,
         eMemo: Data66
     ) {
         self.proto = proto
         self.commitment = commitment
+        self.maskedAmount = maskedAmount
         self.targetKey = targetKey
         self.publicKey = publicKey
         self.eMemo = eMemo

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -1,6 +1,7 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
+// swiftlint:disable function_body_length
 
 import Foundation
 import LibMobileCoin
@@ -56,7 +57,7 @@ extension TxOut: Hashable {}
 
 extension TxOut {
     static func make(_ proto: External_TxOut) -> Result<TxOut, InvalidInputError> {
-        
+
         var commitment: Data32
         var maskedAmount: MaskedAmount
         switch proto.maskedAmount {

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -1,7 +1,6 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-// swiftlint:disable function_body_length
 
 import Foundation
 import LibMobileCoin

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -39,9 +39,6 @@ struct TxOut: TxOutProtocol {
     }
 
     var commitment: Data32 { maskedAmount.commitment }
-    var maskedValue: UInt64 { maskedAmount.maskedValue }
-    var maskedTokenId: Data { maskedAmount.maskedTokenId }
-    var maskedAmountVersion: MaskedAmount.Version { maskedAmount.version }
     
     var serializedData: Data {
         proto.serializedDataInfallible
@@ -61,7 +58,6 @@ extension TxOut: Hashable {}
 
 extension TxOut {
     static func make(_ proto: External_TxOut) -> Result<TxOut, InvalidInputError> {
-        // TODO - handle lack of V1 or V2 and revert to "legacy" ?
         guard
             let maskedAmountProto = proto.maskedAmount,
             let maskedAmount = MaskedAmount(maskedAmountProto) else {

--- a/Sources/Ledger/TxOut.swift
+++ b/Sources/Ledger/TxOut.swift
@@ -39,7 +39,7 @@ struct TxOut: TxOutProtocol {
     }
 
     var commitment: Data32 { maskedAmount.commitment }
-    
+
     var serializedData: Data {
         proto.serializedDataInfallible
     }

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -8,8 +8,7 @@ import LibMobileCoin
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }
     var commitment: Data32 { get }
-    var maskedValue: UInt64 { get }
-    var maskedTokenId: Data { get }
+    var maskedAmount: MaskedAmount { get }
     var targetKey: RistrettoPublic { get }
     var publicKey: RistrettoPublic { get }
 }
@@ -46,8 +45,7 @@ extension TxOutProtocol {
     ///     does not own `TxOut` or because ` TxOut` amounts are incongruent.
     func amount(accountKey: AccountKey) -> Amount? {
         TxOutUtils.amount(
-            maskedValue: maskedValue,
-            maskedTokenId: maskedTokenId,
+            maskedAmount: maskedAmount,
             publicKey: publicKey,
             viewPrivateKey: accountKey.viewPrivateKey)
     }
@@ -85,10 +83,18 @@ extension FogView_TxOutRecord {
     init(_ txOut: TxOutProtocol) {
         self.init()
         self.txOutAmountCommitmentData = txOut.commitment.data
-        self.txOutAmountMaskedValue = txOut.maskedValue
-        self.txOutAmountMaskedV1TokenID = txOut.maskedTokenId
+        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedAmount
         self.txOutTargetKeyData = txOut.targetKey.data
         self.txOutPublicKeyData = txOut.publicKey.data
         self.txOutEMemoData = txOut.encryptedMemo.data
+
+        switch txOut.maskedAmount.version {
+        case V1:
+            self.txOutAmountMaskedV1TokenID = txOut.maskedAmount.maskedTokenId
+        case V2:
+            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
+        default:
+            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
+        }
     }
 }

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -8,6 +8,9 @@ import LibMobileCoin
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }
     var commitment: Data32 { get }
+    var maskedValue: UInt64 { get }
+    var maskedTokenId: Data { get }
+    var maskedAmountVersion: MaskedAmount.Version { get } // TODO needed ?
     var maskedAmount: MaskedAmount { get }
     var targetKey: RistrettoPublic { get }
     var publicKey: RistrettoPublic { get }
@@ -44,6 +47,7 @@ extension TxOutProtocol {
     /// - Returns: `nil` when `accountKey` cannot unmask the amoount, either because `accountKey`
     ///     does not own `TxOut` or because ` TxOut` amounts are incongruent.
     func amount(accountKey: AccountKey) -> Amount? {
+        // TODO - needs changes
         TxOutUtils.amount(
             maskedAmount: maskedAmount,
             publicKey: publicKey,
@@ -83,17 +87,15 @@ extension FogView_TxOutRecord {
     init(_ txOut: TxOutProtocol) {
         self.init()
         self.txOutAmountCommitmentData = txOut.commitment.data
-        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedAmount
+        self.txOutAmountMaskedValue = txOut.maskedAmount.maskedValue
         self.txOutTargetKeyData = txOut.targetKey.data
         self.txOutPublicKeyData = txOut.publicKey.data
         self.txOutEMemoData = txOut.encryptedMemo.data
 
         switch txOut.maskedAmount.version {
-        case V1:
+        case .v1:
             self.txOutAmountMaskedV1TokenID = txOut.maskedAmount.maskedTokenId
-        case V2:
-            self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
-        default:
+        case .v2:
             self.txOutAmountMaskedV2TokenID = txOut.maskedAmount.maskedTokenId
         }
     }

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -44,7 +44,6 @@ extension TxOutProtocol {
     /// - Returns: `nil` when `accountKey` cannot unmask the amoount, either because `accountKey`
     ///     does not own `TxOut` or because ` TxOut` amounts are incongruent.
     func amount(accountKey: AccountKey) -> Amount? {
-        // TODO - needs changes
         TxOutUtils.amount(
             maskedAmount: maskedAmount,
             publicKey: publicKey,

--- a/Sources/Ledger/TxOutProtocol.swift
+++ b/Sources/Ledger/TxOutProtocol.swift
@@ -8,9 +8,6 @@ import LibMobileCoin
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }
     var commitment: Data32 { get }
-    var maskedValue: UInt64 { get }
-    var maskedTokenId: Data { get }
-    var maskedAmountVersion: MaskedAmount.Version { get } // TODO needed ?
     var maskedAmount: MaskedAmount { get }
     var targetKey: RistrettoPublic { get }
     var publicKey: RistrettoPublic { get }

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -94,7 +94,7 @@ enum TxOutUtils {
             publicKey: publicKey,
             viewPrivateKey: viewPrivateKey)
     }
-    
+
     static func reconstructCommitment(
         maskedValue: UInt64,
         maskedTokenId: Data,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -73,28 +73,28 @@ enum TxOutUtils {
         }
     }
 
-    static func reconstructCommitment(
-        maskedValue: UInt64,
-        publicKey: RistrettoPublic,
-        viewPrivateKey: RistrettoPrivate
-    ) -> Data32? {
-        reconstructCommitment(maskedValue: maskedValue,
-                              maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-                              publicKey: publicKey, viewPrivateKey: viewPrivateKey)
-    }
+//    static func reconstructCommitment(
+//        maskedValue: UInt64,
+//        publicKey: RistrettoPublic,
+//        viewPrivateKey: RistrettoPrivate
+//    ) -> Data32? {
+//        reconstructCommitment(maskedValue: maskedValue,
+//                              maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+//                              publicKey: publicKey, viewPrivateKey: viewPrivateKey)
+//    }
 
     static func reconstructCommitment(
-        maskedValue: UInt64,
-        maskedTokenId: Data,
+        maskedAmount: MaskedAmount,
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Data32? {
-        maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyBufferPtr in
                 viewPrivateKey.asMcBuffer { viewPrivateKeyPtr in
                     var mcAmount = McTxOutMaskedAmount(
-                        masked_value: maskedValue,
-                        masked_token_id: maskedTokenIdBufferPtr)
+                        masked_value: maskedAmount.maskedAmount,
+                        masked_token_id: maskedTokenIdBufferPtr,
+                        version: maskedAmount.version)
                     switch Data32.make(withMcMutableBuffer: { bufferPtr, errorPtr in
                         mc_tx_out_reconstruct_commitment(
                             &mcAmount,
@@ -241,34 +241,34 @@ enum TxOutUtils {
         }
     }
 
-    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
-    ///     does not own `TxOut` or because `TxOut` values are incongruent.
-    static func value(
-        maskedValue: UInt64,
-        publicKey: RistrettoPublic,
-        viewPrivateKey: RistrettoPrivate
-    ) -> UInt64? {
-        amount(maskedValue: maskedValue,
-               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-               publicKey: publicKey,
-               viewPrivateKey: viewPrivateKey)?.value
-    }
+//    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
+//    ///     does not own `TxOut` or because `TxOut` values are incongruent.
+//    static func value(
+//        maskedValue: UInt64,
+//        publicKey: RistrettoPublic,
+//        viewPrivateKey: RistrettoPrivate
+//    ) -> UInt64? {
+//        amount(maskedValue: maskedValue,
+//               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+//               publicKey: publicKey,
+//               viewPrivateKey: viewPrivateKey)?.value
+//    }
 
     /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
     ///     does not own `TxOut` or because `TxOut` values are incongruent.
     static func amount(
-        maskedValue: UInt64,
-        maskedTokenId: Data,
+        maskedAmount: MaskedAmount,
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Amount? {
         var mcTxOutAmount = McTxOutAmount()
-        return maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        return maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyPtr in
                 viewPrivateKey.asMcBuffer { viewKeyBufferPtr in
                     var mcMaskedAmount = McTxOutMaskedAmount(
-                        masked_value: maskedValue,
-                        masked_token_id: maskedTokenIdBufferPtr)
+                        masked_value: maskedAmount.maskedAmount,
+                        masked_token_id: maskedTokenIdBufferPtr,
+                        version: maskedAmount.version)
                     switch withMcError({ errorPtr in
                         mc_tx_out_get_amount(
                             &mcMaskedAmount,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -87,13 +87,28 @@ enum TxOutUtils {
         publicKey: RistrettoPublic,
         viewPrivateKey: RistrettoPrivate
     ) -> Data32? {
-        maskedAmount.maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
+        reconstructCommitment(
+            maskedValue: maskedAmount.maskedValue,
+            maskedTokenId: maskedAmount.maskedTokenId,
+            maskedAmountVersion: maskedAmount.version,
+            publicKey: publicKey,
+            viewPrivateKey: viewPrivateKey)
+    }
+    
+    static func reconstructCommitment(
+        maskedValue: UInt64,
+        maskedTokenId: Data,
+        maskedAmountVersion: MaskedAmount.Version,
+        publicKey: RistrettoPublic,
+        viewPrivateKey: RistrettoPrivate
+    ) -> Data32? {
+        maskedTokenId.asMcBuffer { maskedTokenIdBufferPtr in
             publicKey.asMcBuffer { publicKeyBufferPtr in
                 viewPrivateKey.asMcBuffer { viewPrivateKeyPtr in
                     var mcAmount = McTxOutMaskedAmount(
-                        masked_value: maskedAmount.maskedAmount,
+                        masked_value: maskedValue,
                         masked_token_id: maskedTokenIdBufferPtr,
-                        version: maskedAmount.version)
+                        version: maskedAmountVersion.libmobilecoin_version)
                     switch Data32.make(withMcMutableBuffer: { bufferPtr, errorPtr in
                         mc_tx_out_reconstruct_commitment(
                             &mcAmount,
@@ -252,9 +267,9 @@ enum TxOutUtils {
             publicKey.asMcBuffer { publicKeyPtr in
                 viewPrivateKey.asMcBuffer { viewKeyBufferPtr in
                     var mcMaskedAmount = McTxOutMaskedAmount(
-                        masked_value: maskedAmount.maskedAmount,
+                        masked_value: maskedAmount.maskedValue,
                         masked_token_id: maskedTokenIdBufferPtr,
-                        version: maskedAmount.version)
+                        version: maskedAmount.libmobilecoin_version)
                     switch withMcError({ errorPtr in
                         mc_tx_out_get_amount(
                             &mcMaskedAmount,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -72,16 +72,6 @@ enum TxOutUtils {
         }
     }
 
-//    static func reconstructCommitment(
-//        maskedValue: UInt64,
-//        publicKey: RistrettoPublic,
-//        viewPrivateKey: RistrettoPrivate
-//    ) -> Data32? {
-//        reconstructCommitment(maskedValue: maskedValue,
-//                              maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-//                              publicKey: publicKey, viewPrivateKey: viewPrivateKey)
-//    }
-
     static func reconstructCommitment(
         maskedAmount: MaskedAmount,
         publicKey: RistrettoPublic,

--- a/Sources/Ledger/TxOutUtils.swift
+++ b/Sources/Ledger/TxOutUtils.swift
@@ -1,8 +1,7 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-
-// swiftlint:disable closure_body_length multiline_arguments
+// swiftlint:disable closure_body_length
 
 import Foundation
 import LibMobileCoin
@@ -240,19 +239,6 @@ enum TxOutUtils {
             }
         }
     }
-
-//    /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
-//    ///     does not own `TxOut` or because `TxOut` values are incongruent.
-//    static func value(
-//        maskedValue: UInt64,
-//        publicKey: RistrettoPublic,
-//        viewPrivateKey: RistrettoPrivate
-//    ) -> UInt64? {
-//        amount(maskedValue: maskedValue,
-//               maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-//               publicKey: publicKey,
-//               viewPrivateKey: viewPrivateKey)?.value
-//    }
 
     /// - Returns: `nil` when `viewPrivateKey` cannot unmask value, either because `viewPrivateKey`
     ///     does not own `TxOut` or because `TxOut` values are incongruent.

--- a/Sources/LibMobileCoin/McConstants.swift
+++ b/Sources/LibMobileCoin/McConstants.swift
@@ -23,7 +23,7 @@ extension McConstants {
     static let MAX_TOMBSTONE_BLOCKS: UInt64 = 100
 
     /// Minimum allowed fee, denominated in picoMOB.
-    static let DEFAULT_MINIMUM_FEE: UInt64 = 10_000_000_000
+    static let DEFAULT_MINIMUM_FEE: UInt64 = 4_000_000_000
 
     /// Transaction hash length, in bytes.
     static let TX_HASH_LEN = 32

--- a/Sources/LibMobileCoin/ProtoExtensions.swift
+++ b/Sources/LibMobileCoin/ProtoExtensions.swift
@@ -101,6 +101,19 @@ extension FogView_TxOutRecord {
     }
 }
 
+extension FogView_TxOutRecordLegacy {
+    var timestampDate: Date? {
+        get { timestamp != UInt64.max ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil }
+        set {
+            if let newValue = newValue {
+                timestamp = UInt64(newValue.timeIntervalSince1970)
+            } else {
+                timestamp = UInt64.max
+            }
+        }
+    }
+}
+
 // MARK: - Fog Ledger
 
 extension FogLedger_OutputResult {

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -24,8 +24,10 @@ struct MaskedAmount {
 extension MaskedAmount.Version {
     var libmobilecoin_version: McMaskedAmountVersion {
         switch self {
-        case .v1: return V1
-        case .v2: return V2
+        case .v1:
+            return V1
+        case .v2:
+            return V2
         }
     }
 }

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -6,37 +6,100 @@ import Foundation
 import LibMobileCoin
 
 struct MaskedAmount {
-    var maskedAmount: UInt64
-    var maskedTokenId: Data
-    var version: McMaskedAmountVersion
-
-    init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
-        self.maskedAmount = maskedAmount
-        self.maskedTokenId = maskedTokenId
-        self.version = version
+    enum Version {
+        case v1
+        case v2
+    }
+    
+    let maskedValue: UInt64
+    let maskedTokenId: Data
+    let commitment: Data32
+    let version: Version
+    
+    var libmobilecoin_version: McMaskedAmountVersion {
+        version.libmobilecoin_version
     }
 }
 
-extension MaskedAmount: CustomStringConvertible {
+extension MaskedAmount.Version {
+    var libmobilecoin_version: McMaskedAmountVersion {
+        switch self {
+        case .v1: return V1
+        case .v2: return V2
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: External_TxOut.OneOf_MaskedAmount) {
+        switch proto {
+        case .maskedAmountV1(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v1
+        case .maskedAmountV2(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v2
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: FogView_TxOutRecord) {
+        switch proto.txOutAmountMaskedTokenID {
+        case .txOutAmountMaskedV1TokenID(let maskedTokenID):
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = maskedTokenID
+            self.version = Version.v1
+        case .txOutAmountMaskedV2TokenID(let maskedTokenID):
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = maskedTokenID
+            self.version = Version.v2
+        case .none:
+            // Same as "empty"/"missing" which means its token_id 0 for MOB
+            self.commitment = Data32(proto.txOutAmountCommitmentData) ?? Data32()
+            self.maskedValue = proto.txOutAmountMaskedValue
+            self.maskedTokenId = Data()
+            self.version = Version.v1
+        }
+    }
+}
+
+extension MaskedAmount {
+    init?(_ proto: External_Receipt.OneOf_MaskedAmount) {
+        switch proto {
+        case .maskedAmountV1(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v1
+        case .maskedAmountV2(let maskedAmount):
+            self.commitment = Data32(maskedAmount.commitment.data) ?? Data32()
+            self.maskedValue = maskedAmount.maskedValue
+            self.maskedTokenId = maskedAmount.maskedTokenID
+            self.version = Version.v2
+        }
+    }
+}
+
+extension MaskedAmount.Version: CustomStringConvertible {
     public var description: String {
-        "\(maskedAmount) \(maskedTokenId.description)"
+        switch self {
+        case .v1: return "Version 1"
+        case .v2: return "Version 2"
+        }
+    }
+}
+extension MaskedAmount: Hashable, Equatable, CustomStringConvertible {
+    public var description: String {
+        "maskedValue \(maskedValue) \n" +
+        "maskedTokenId \(maskedTokenId.hexEncodedString()) \n" +
+        "version \(version) \n"
     }
 }
 
-extension MaskedAmount: Equatable {
-    static func == (lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
-        lhs.maskedAmount == rhs.maskedAmount &&
-        lhs.maskedTokenId == rhs.maskedTokenId &&
-        lhs.version == rhs.version
-    }
-}
-
-extension McMaskedAmountVersion: Hashable {}
-
-extension MaskedAmount: Hashable {
-    func hash(into hasher: inout Hasher) {
-      hasher.combine(maskedAmount)
-      hasher.combine(maskedTokenId)
-      hasher.combine(version)
-    }
-}

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -10,12 +10,12 @@ struct MaskedAmount {
         case v1
         case v2
     }
-    
+
     let maskedValue: UInt64
     let maskedTokenId: Data
     let commitment: Data32
     let version: Version
-    
+
     var libmobilecoin_version: McMaskedAmountVersion {
         version.libmobilecoin_version
     }
@@ -102,4 +102,3 @@ extension MaskedAmount: Hashable, Equatable, CustomStringConvertible {
         "version \(version) \n"
     }
 }
-

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -5,12 +5,12 @@
 import Foundation
 import LibMobileCoin
 
-class MaskedAmount {
+struct MaskedAmount {
     var maskedAmount: UInt64
     var maskedTokenId: Data
     var version: McMaskedAmountVersion
 
-    public init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
+    init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
         self.maskedAmount = maskedAmount
         self.maskedTokenId = maskedTokenId
         self.version = version
@@ -24,10 +24,10 @@ extension MaskedAmount: CustomStringConvertible {
 }
 
 extension MaskedAmount: Equatable {
-    static func ==(lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
-        return lhs.maskedAmount == rhs.maskedAmount
-            && lhs.maskedTokenId == rhs.maskedTokenId
-            && lhs.version == rhs.version
+    static func == (lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
+        lhs.maskedAmount == rhs.maskedAmount &&
+        lhs.maskedTokenId == rhs.maskedTokenId &&
+        lhs.version == rhs.version
     }
 }
 

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+import LibMobileCoin
+
+class MaskedAmount {
+    var maskedAmount: UInt64
+    var maskedTokenId: Data
+    var version: McMaskedAmountVersion
+
+    public init(_ maskedAmount: UInt64, maskedTokenId: Data, version: McMaskedAmountVersion) {
+        self.maskedAmount = maskedAmount
+        self.maskedTokenId = maskedTokenId
+        self.version = version
+    }
+}
+
+extension MaskedAmount: CustomStringConvertible {
+    public var description: String {
+        "\(maskedAmount) \(maskedTokenId.description)"
+    }
+}
+
+extension MaskedAmount: Equatable {
+    static func ==(lhs: MaskedAmount, rhs: MaskedAmount) -> Bool {
+        return lhs.maskedAmount == rhs.maskedAmount
+            && lhs.maskedTokenId == rhs.maskedTokenId
+            && lhs.version == rhs.version
+    }
+}
+
+extension McMaskedAmountVersion: Hashable {}
+
+extension MaskedAmount: Hashable {
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(maskedAmount)
+      hasher.combine(maskedTokenId)
+      hasher.combine(version)
+    }
+}

--- a/Sources/Transaction/MaskedAmount.swift
+++ b/Sources/Transaction/MaskedAmount.swift
@@ -92,8 +92,10 @@ extension MaskedAmount {
 extension MaskedAmount.Version: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .v1: return "Version 1"
-        case .v2: return "Version 2"
+        case .v1:
+            return "Version 1"
+        case .v2:
+            return "Version 2"
         }
     }
 }

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -63,12 +63,14 @@ public struct Receipt {
         txOutPublicKeyTyped.data
     }
 
+    // swiftlint:disable todo
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
             // TODO - verify with core-eng that commitment is sufficient, 
             // remove after confirmation
     }
+    // swiftlint:enable todo
 
     func validateConfirmationNumber(accountKey: AccountKey) -> Bool {
         TxOutUtils.validateConfirmationNumber(

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -66,7 +66,7 @@ public struct Receipt {
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
-            && maskedAmount == txOut.maskedAmount
+            // TODO - verify with core-eng that commitment is sufficient
     }
 
     func validateConfirmationNumber(accountKey: AccountKey) -> Bool {

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -22,8 +22,7 @@ import LibMobileCoin
 public struct Receipt {
     let txOutPublicKeyTyped: RistrettoPublic
     let commitment: Data32
-    let maskedValue: UInt64
-    let maskedTokenId: Data
+    let maskedAmount: MaskedAmount
     let confirmationNumber: TxOutConfirmationNumber
 
     /// Block index at which the transaction that produced this `Receipt` will no longer be
@@ -37,8 +36,7 @@ public struct Receipt {
     ) {
         self.txOutPublicKeyTyped = txOut.publicKey
         self.commitment = txOut.commitment
-        self.maskedValue = txOut.maskedValue
-        self.maskedTokenId = txOut.maskedTokenId
+        self.maskedAmount = txOut.maskedAmount
         self.confirmationNumber = confirmationNumber
         self.txTombstoneBlockIndex = tombstoneBlockIndex
     }
@@ -68,8 +66,7 @@ public struct Receipt {
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
-            && maskedValue == txOut.maskedValue
-            && maskedTokenId == txOut.maskedTokenId
+            && maskedAmount == txOut.maskedAmount
     }
 
     func validateConfirmationNumber(accountKey: AccountKey) -> Bool {
@@ -87,8 +84,7 @@ public struct Receipt {
 
     func unmaskAmount(accountKey: AccountKey) -> Result<Amount, InvalidInputError> {
         guard let amount = TxOutUtils.amount(
-            maskedValue: maskedValue,
-            maskedTokenId: maskedTokenId,
+            maskedAmount: maskedAmount,
             publicKey: txOutPublicKeyTyped,
             viewPrivateKey: accountKey.viewPrivateKey)
         else {
@@ -124,8 +120,7 @@ public struct Receipt {
         }
 
         guard let amount = TxOutUtils.amount(
-                maskedValue: maskedValue,
-                maskedTokenId: maskedTokenId,
+                maskedAmount: maskedAmount,
                 publicKey: txOutPublicKeyTyped,
                 viewPrivateKey: accountKey.viewPrivateKey)
         else {
@@ -156,8 +151,25 @@ extension Receipt: Hashable {}
 
 extension Receipt {
     init?(_ proto: External_Receipt) {
+        let commitmentData: Data
+        let maskedAmount: MaskedAmount
+        switch proto.maskedAmount {
+        case .maskedAmountV1(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V1)
+            commitmentData = proto.maskedAmountV1.commitment.data
+        case .maskedAmountV2(let m):
+            maskedAmount = MaskedAmount(m.maskedValue, maskedTokenId: m.maskedTokenID, version: V2)
+            commitmentData = proto.maskedAmountV2.commitment.data
+        case .none:
+            logger.warning(
+                "Failed to initialize Receipt with External_Receipt. serialized proto: " +
+                    "\(redacting: proto.serializedDataInfallible.base64EncodedString())",
+                logFunction: false)
+            return nil
+        }
+
         guard let txOutPublicKey = RistrettoPublic(proto.publicKey.data),
-              let commitment = Data32(proto.maskedAmountV1.commitment.data),
+              let commitment = Data32(commitmentData),
               let confirmationNumber = TxOutConfirmationNumber(proto.confirmation)
         else {
             logger.warning(
@@ -169,8 +181,7 @@ extension Receipt {
 
         self.txOutPublicKeyTyped = txOutPublicKey
         self.commitment = commitment
-        self.maskedValue = proto.maskedAmountV1.maskedValue
-        self.maskedTokenId = proto.maskedAmountV1.maskedTokenID
+        self.maskedAmount = maskedAmount
         self.confirmationNumber = confirmationNumber
         self.txTombstoneBlockIndex = proto.tombstoneBlock
     }
@@ -180,10 +191,23 @@ extension External_Receipt {
     init(_ receipt: Receipt) {
         self.init()
         self.publicKey = External_CompressedRistretto(receipt.txOutPublicKey)
-        self.maskedAmountV1.commitment = External_CompressedRistretto(receipt.commitment)
-        self.maskedAmountV1.maskedValue = receipt.maskedValue
-        self.maskedAmountV1.maskedTokenID = receipt.maskedTokenId
         self.confirmation = External_TxOutConfirmationNumber(receipt.confirmationNumber)
         self.tombstoneBlock = receipt.txTombstoneBlockIndex
+
+        switch receipt.maskedAmount.version {
+        case V1:
+            self.maskedAmountV1.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV1.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV1.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        case V2:
+            self.maskedAmountV2.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV2.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV2.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        default:
+            self.maskedAmountV2.commitment = External_CompressedRistretto(receipt.commitment)
+            self.maskedAmountV2.maskedValue = receipt.maskedAmount.maskedAmount
+            self.maskedAmountV2.maskedTokenID = receipt.maskedAmount.maskedTokenId
+        }
+
     }
 }

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -66,7 +66,8 @@ public struct Receipt {
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
-            // TODO - verify with core-eng that commitment is sufficient
+            // TODO - verify with core-eng that commitment is sufficient, 
+            // remove after confirmation
     }
 
     func validateConfirmationNumber(accountKey: AccountKey) -> Bool {

--- a/Sources/Transaction/Receipt.swift
+++ b/Sources/Transaction/Receipt.swift
@@ -52,7 +52,7 @@ public struct Receipt {
     }
 
     var commitment: Data32 { maskedAmount.commitment }
-    
+
     public var serializedData: Data {
         let proto = External_Receipt(self)
         return proto.serializedDataInfallible

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -41,17 +41,20 @@ struct DynamicNetworkConfig {
     let namespace: String
     let environment: String
     let fogAuthoritySpkiB64Encoded: String
+    let trustRootsBytes: [Data]
 
     init(
         namespace: String,
         environment: String,
         fogAuthoritySpkiB64Encoded: String,
-        user: String = ""
+        user: String = "",
+        trustRootsBytes: [Data] = Self.trustRootsBytes()
     ) {
         self.user = user
         self.namespace = namespace
         self.environment = environment
         self.fogAuthoritySpkiB64Encoded = fogAuthoritySpkiB64Encoded
+        self.trustRootsBytes = trustRootsBytes
     }
 }
 
@@ -66,16 +69,73 @@ extension DynamicNetworkConfig {
 
     enum AlphaDevelopment {
         static let user = ""
-        static let namespace = "mc-sci-test"
+        static let namespace = "alpha"
         static let environment = "development"
         static let fogAuthoritySpkiB64Encoded = dynamicFogAuthoritySpki
+        static let trustRootsBytes: [Data] = DynamicNetworkConfig.trustRootsBytes()
 
         static func make() -> DynamicNetworkConfig {
             DynamicNetworkConfig(
                 namespace: Self.namespace,
                 environment: Self.environment,
                 fogAuthoritySpkiB64Encoded: Self.fogAuthoritySpkiB64Encoded,
-                user: Self.user)
+                user: Self.user,
+                trustRootsBytes: Self.trustRootsBytes)
+        }
+    }
+}
+
+extension DynamicNetworkConfig {
+    static var developmentNetworkTrustRootsB64 = [
+        """
+        MIIG1TCCBL2gAwIBAgIQbFWr29AHksedBwzYEZ7WvzANBgkqhkiG9w0BAQwFADCB\
+        iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl\
+        cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV\
+        BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMjAw\
+        MTMwMDAwMDAwWhcNMzAwMTI5MjM1OTU5WjBLMQswCQYDVQQGEwJBVDEQMA4GA1UE\
+        ChMHWmVyb1NTTDEqMCgGA1UEAxMhWmVyb1NTTCBSU0EgRG9tYWluIFNlY3VyZSBT\
+        aXRlIENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAhmlzfqO1Mdgj\
+        4W3dpBPTVBX1AuvcAyG1fl0dUnw/MeueCWzRWTheZ35LVo91kLI3DDVaZKW+TBAs\
+        JBjEbYmMwcWSTWYCg5334SF0+ctDAsFxsX+rTDh9kSrG/4mp6OShubLaEIUJiZo4\
+        t873TuSd0Wj5DWt3DtpAG8T35l/v+xrN8ub8PSSoX5Vkgw+jWf4KQtNvUFLDq8mF\
+        WhUnPL6jHAADXpvs4lTNYwOtx9yQtbpxwSt7QJY1+ICrmRJB6BuKRt/jfDJF9Jsc\
+        RQVlHIxQdKAJl7oaVnXgDkqtk2qddd3kCDXd74gv813G91z7CjsGyJ93oJIlNS3U\
+        gFbD6V54JMgZ3rSmotYbz98oZxX7MKbtCm1aJ/q+hTv2YK1yMxrnfcieKmOYBbFD\
+        hnW5O6RMA703dBK92j6XRN2EttLkQuujZgy+jXRKtaWMIlkNkWJmOiHmErQngHvt\
+        iNkIcjJumq1ddFX4iaTI40a6zgvIBtxFeDs2RfcaH73er7ctNUUqgQT5rFgJhMmF\
+        x76rQgB5OZUkodb5k2ex7P+Gu4J86bS15094UuYcV09hVeknmTh5Ex9CBKipLS2W\
+        2wKBakf+aVYnNCU6S0nASqt2xrZpGC1v7v6DhuepyyJtn3qSV2PoBiU5Sql+aARp\
+        wUibQMGm44gjyNDqDlVp+ShLQlUH9x8CAwEAAaOCAXUwggFxMB8GA1UdIwQYMBaA\
+        FFN5v1qqK0rPVIDh2JvAnfKyA2bLMB0GA1UdDgQWBBTI2XhootkZaNU9ct5fCj7c\
+        tYaGpjAOBgNVHQ8BAf8EBAMCAYYwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHSUE\
+        FjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwIgYDVR0gBBswGTANBgsrBgEEAbIxAQIC\
+        TjAIBgZngQwBAgEwUAYDVR0fBEkwRzBFoEOgQYY/aHR0cDovL2NybC51c2VydHJ1\
+        c3QuY29tL1VTRVJUcnVzdFJTQUNlcnRpZmljYXRpb25BdXRob3JpdHkuY3JsMHYG\
+        CCsGAQUFBwEBBGowaDA/BggrBgEFBQcwAoYzaHR0cDovL2NydC51c2VydHJ1c3Qu\
+        Y29tL1VTRVJUcnVzdFJTQUFkZFRydXN0Q0EuY3J0MCUGCCsGAQUFBzABhhlodHRw\
+        Oi8vb2NzcC51c2VydHJ1c3QuY29tMA0GCSqGSIb3DQEBDAUAA4ICAQAVDwoIzQDV\
+        ercT0eYqZjBNJ8VNWwVFlQOtZERqn5iWnEVaLZZdzxlbvz2Fx0ExUNuUEgYkIVM4\
+        YocKkCQ7hO5noicoq/DrEYH5IuNcuW1I8JJZ9DLuB1fYvIHlZ2JG46iNbVKA3ygA\
+        Ez86RvDQlt2C494qqPVItRjrz9YlJEGT0DrttyApq0YLFDzf+Z1pkMhh7c+7fXeJ\
+        qmIhfJpduKc8HEQkYQQShen426S3H0JrIAbKcBCiyYFuOhfyvuwVCFDfFvrjADjd\
+        4jX1uQXd161IyFRbm89s2Oj5oU1wDYz5sx+hoCuh6lSs+/uPuWomIq3y1GDFNafW\
+        +LsHBU16lQo5Q2yh25laQsKRgyPmMpHJ98edm6y2sHUabASmRHxvGiuwwE25aDU0\
+        2SAeepyImJ2CzB80YG7WxlynHqNhpE7xfC7PzQlLgmfEHdU+tHFeQazRQnrFkW2W\
+        kqRGIq7cKRnyypvjPMkjeiV9lRdAM9fSJvsB3svUuu1coIG1xxI1yegoGM4r5QP4\
+        RGIVvYaiI76C0djoSbQ/dkIUUXQuB8AL5jyH34g3BZaaXyvpmnV4ilppMXVAnAYG\
+        ON51WhJ6W0xNdNJwzYASZYH+tmCWI+N60Gv2NNMGHwMZ7e9bXgzUCZH5FaBFDGR5\
+        S9VWqHB73Q+OyIVvIbKYcSc2w/aSuFKGSA==
+        """,
+    ]
+    
+    static func trustRootsBytes() -> [Data] {
+        do {
+            return try Self.developmentNetworkTrustRootsB64.map {
+                try XCTUnwrap(Data(base64Encoded: $0))
+            }
+        } catch {
+            assertionFailure("Invalid development trust root bytes")
+            return []
         }
     }
 }
@@ -200,15 +260,6 @@ extension NetworkPreset {
         "89db0d1684fcc98258295c39f4ab68f7de5917ef30f0004d9a86f29930cebbbd"
     private static let mainNetFogReportMrEnclaveHex =
         "f3f7e9a674c55fb2af543513527b6a7872de305bac171783f6716a0bf6919499"
-
-//    private static let mainNetConsensusMrEnclaveHex =
-//        "e66db38b8a43a33f6c1610d335a361963bb2b31e056af0dc0a895ac6c857cab9"
-//    private static let mainNetFogViewMrEnclaveHex =
-//        "ddd59da874fdf3239d5edb1ef251df07a8728c9ef63057dd0b50ade5a9ddb041"
-//    private static let mainNetFogLedgerMrEnclaveHex =
-//        "511eab36de691ded50eb08b173304194da8b9d86bfdd7102001fe6bb279c3666"
-//    private static let mainNetFogReportMrEnclaveHex =
-//        "709ab90621e3a8d9eb26ed9e2830e091beceebd55fb01c5d7c31d27e83b9b0d1"
 
     // v1.1.0 Enclave Values
     private static let legacy_v1_1_0_testNetConsensusMrEnclaveHex =
@@ -445,8 +496,8 @@ extension NetworkPreset {
             transportProtocol: transportProtocol).get()
 
         networkConfig.httpRequester = DefaultHttpRequester()
-        try networkConfig.setConsensusTrustRoots(Self.trustRootsBytes())
-        try networkConfig.setFogTrustRoots(Self.trustRootsBytes())
+        try networkConfig.setConsensusTrustRoots(trustRootsBytes())
+        try networkConfig.setFogTrustRoots(trustRootsBytes())
         networkConfig.consensusAuthorization = consensusCredentials
         networkConfig.fogUserAuthorization = fogUserCredentials
 
@@ -575,6 +626,17 @@ extension NetworkPreset {
         )
     }
 
+    func trustRootsBytes() throws -> [Data] {
+        switch self {
+        case .mainNet, .testNet, .mobiledev, .master, .build, .demo, .diogenes, .drakeley, .eran:
+            return try Self.trustRootsB64.map { try XCTUnwrap(Data(base64Encoded: $0)) }
+        case .alpha:
+            return DynamicNetworkConfig.trustRootsBytes()
+        case .dynamic(let config):
+            return config.trustRootsBytes
+        }
+    }
+        
     static func trustRootsBytes() throws -> [Data] {
         try Self.trustRootsB64.map { try XCTUnwrap(Data(base64Encoded: $0)) }
     }
@@ -614,7 +676,8 @@ extension NetworkPreset {
         case .alpha, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return true
         case .dynamic:
-            return true
+            // TODO - Verify this is correct
+            return false
         }
     }
 

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -66,7 +66,7 @@ extension DynamicNetworkConfig {
 
     enum AlphaDevelopment {
         static let user = ""
-        static let namespace = "alpha"
+        static let namespace = "mc-sci-test"
         static let environment = "development"
         static let fogAuthoritySpkiB64Encoded = dynamicFogAuthoritySpki
 

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -127,7 +127,7 @@ extension DynamicNetworkConfig {
         S9VWqHB73Q+OyIVvIbKYcSc2w/aSuFKGSA==
         """,
     ]
-    
+
     static func trustRootsBytes() -> [Data] {
         do {
             return try Self.developmentNetworkTrustRootsB64.map {
@@ -636,7 +636,7 @@ extension NetworkPreset {
             return config.trustRootsBytes
         }
     }
-        
+
     static func trustRootsBytes() throws -> [Data] {
         try Self.trustRootsB64.map { try XCTUnwrap(Data(base64Encoded: $0)) }
     }
@@ -676,7 +676,6 @@ extension NetworkPreset {
         case .alpha, .master, .build, .demo, .diogenes, .drakeley, .eran:
             return true
         case .dynamic:
-            // TODO - Verify this is correct
             return false
         }
     }

--- a/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
@@ -93,8 +93,10 @@ extension Transaction.Fixtures.BuildTx {
                     encryptedMemo: Data66(),
                     commitment: Data32(base64Encoded:
                         "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
-                    maskedValue: 2886556578342610519,
-                    maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                    maskedAmount: MaskedAmount(
+                        2886556578342610519,
+                        maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                        version: V1),
                     targetKey: RistrettoPublic(base64Encoded:
                         "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!,
                     publicKey: RistrettoPublic(base64Encoded:

--- a/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
@@ -91,12 +91,12 @@ extension Transaction.Fixtures.BuildTx {
             LedgerTxOut(
                 PartialTxOut(
                     encryptedMemo: Data66(),
-                    commitment: Data32(base64Encoded:
-                        "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
                     maskedAmount: MaskedAmount(
-                        2886556578342610519,
+                        maskedValue: 2886556578342610519,
                         maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-                        version: V1),
+                        commitment: Data32(base64Encoded:
+                            "uImiYd/FgPnNUbRkBu5+F61QNO4DXF8NNCPIzKy/2UA=")!,
+                        version: .v1),
                     targetKey: RistrettoPublic(base64Encoded:
                         "VECBlIdhtmTFaXtlWphlqELpDL04EKMbbPWu3CoJ2UE=")!,
                     publicKey: RistrettoPublic(base64Encoded:

--- a/Tests/Integration/Network/NetworkConfigFixtures.swift
+++ b/Tests/Integration/Network/NetworkConfigFixtures.swift
@@ -10,7 +10,7 @@ import XCTest
 
 enum NetworkConfigFixtures {
     static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
-    static let network: NetworkPreset = .testNet
+    static let network: NetworkPreset = .dynamic(alphaDev)
 }
 
 extension NetworkConfigFixtures {

--- a/Tests/Unit/Transaction/Inputs/DefaultTxOutSelectionStrategyTests.swift
+++ b/Tests/Unit/Transaction/Inputs/DefaultTxOutSelectionStrategyTests.swift
@@ -9,7 +9,7 @@
 @testable import MobileCoin
 import XCTest
 
-private let minFee: UInt64 = 10_000_000_000
+private let minFee: UInt64 = 4_000_000_000
 
 class DefaultTxOutSelectionStrategyTests: XCTestCase {
 

--- a/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
+++ b/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
@@ -20,7 +20,7 @@ class BlockchainMetaFetcherTests: XCTestCase {
             guard let metaCache = $0.successOrFulfill(expectation: expect)
             else { return }
 
-            XCTAssertEqual(metaCache.minimumFees[.MOB], 10_000_000_000)
+            XCTAssertEqual(metaCache.minimumFees[.MOB], 4_000_000_000)
             expect.fulfill()
         }
         waitForExpectations(timeout: 1)

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -2,6 +2,7 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
+import LibMobileCoin
 @testable import MobileCoin
 import XCTest
 
@@ -16,10 +17,14 @@ class ReconstructedCommitmentTests: XCTestCase {
     func testReconstructCommitment() throws {
         let fixture = try Transaction.Fixtures.Commitment()
         let txOutRecord = fixture.txOutRecord
+        let maskedAmount = MaskedAmount(
+            txOutRecord.txOutAmountMaskedValue,
+            maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+            version: V1)
         let viewKey = fixture.viewKey
         guard let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
               let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedValue: txOutRecord.txOutAmountMaskedValue,
+                                                    maskedAmount: maskedAmount,
                                                     publicKey: publicKey,
                                                     viewPrivateKey: viewKey) else {
             XCTFail("Unable to reconstruct commitment")

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -17,16 +17,17 @@ class ReconstructedCommitmentTests: XCTestCase {
     func testReconstructCommitment() throws {
         let fixture = try Transaction.Fixtures.Commitment()
         let txOutRecord = fixture.txOutRecord
-        let maskedAmount = MaskedAmount(
-            txOutRecord.txOutAmountMaskedValue,
-            maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
-            version: V1)
         let viewKey = fixture.viewKey
-        guard let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
-              let commitment = TxOutUtils.reconstructCommitment(
-                                                    maskedAmount: maskedAmount,
-                                                    publicKey: publicKey,
-                                                    viewPrivateKey: viewKey) else {
+        
+        guard
+            let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
+            let commitment = TxOutUtils.reconstructCommitment(
+                maskedValue: txOutRecord.txOutAmountMaskedValue,
+                maskedTokenId: McConstants.LEGACY_MOB_MASKED_TOKEN_ID,
+                maskedAmountVersion: .v1,
+                publicKey: publicKey,
+                viewPrivateKey: viewKey)
+        else {
             XCTFail("Unable to reconstruct commitment")
             return
         }

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -18,7 +18,7 @@ class ReconstructedCommitmentTests: XCTestCase {
         let fixture = try Transaction.Fixtures.Commitment()
         let txOutRecord = fixture.txOutRecord
         let viewKey = fixture.viewKey
-        
+
         guard
             let publicKey = RistrettoPublic(txOutRecord.txOutPublicKeyData),
             let commitment = TxOutUtils.reconstructCommitment(


### PR DESCRIPTION
### Motivation

Support the MaskedAmount v1/v2 changes coming for v4.0.0 of the enclave.

### In this PR
* Refactor TxOut and related code to use and store `MaskedAmount` objects 
* Create a "legacy" view.proto file so we can re-use serialized data in some Swift unit-tests
* Version increment to trigger a release
* Add convenience initializers to create MaskedAmount objects from the relevant protobufs
* Update unit-tests
* Update bindings wrappers
* Update re-constructed commitment & crc32 checking code paths
* Remove maskedValue and maskedTokenId from the internal TxOutProtocol (use versioned MaskedAmount instead)
* Receipt checking uses commitment data & the txOutPublicKey
* Change mininum fee used in integration and unit tests to be the current minimum for MOB of 4_000_000_000

### Future Work
* Convert unit-tests to use new proto, remove "legacy" view.proto
* [x] Merge libmobilecoin PR - https://github.com/mobilecoinofficial/libmobilecoin/pull/52 
