### PR TITLE
Unauthenticated Sender Memos

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre2)
-  - MobileCoin/Core (4.0.0-pre2):
+  - MobileCoin (4.0.0-pre3)
+  - MobileCoin/Core (4.0.0-pre3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre2):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre3):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0-pre2)
-  - MobileCoin/PerformanceTests (4.0.0-pre2)
-  - MobileCoin/Tests (4.0.0-pre2)
+  - MobileCoin/IntegrationTests (4.0.0-pre3)
+  - MobileCoin/PerformanceTests (4.0.0-pre3)
+  - MobileCoin/Tests (4.0.0-pre3)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: a9f23f2bd09eae7aed4ad810688ec45801f70a5e
+  MobileCoin: 855e464ba6326e662f9d733ddf90a21aa4613ece
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (4.0.0-pre2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre2)
-  - MobileCoin/CoreHTTP (4.0.0-pre2):
+  - MobileCoin (4.0.0-pre3)
+  - MobileCoin/CoreHTTP (4.0.0-pre3):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre2):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre3):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0-pre2)
-  - MobileCoin/PerformanceTests (4.0.0-pre2)
-  - MobileCoin/Tests (4.0.0-pre2)
+  - MobileCoin/IntegrationTests (4.0.0-pre3)
+  - MobileCoin/PerformanceTests (4.0.0-pre3)
+  - MobileCoin/Tests (4.0.0-pre3)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: a9f23f2bd09eae7aed4ad810688ec45801f70a5e
+  MobileCoin: 855e464ba6326e662f9d733ddf90a21aa4613ece
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0-pre2"
+  s.version      = "4.0.0-pre3"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/MobileCoinClient+RTH.swift
+++ b/Sources/MobileCoinClient+RTH.swift
@@ -10,8 +10,12 @@ extension MobileCoinClient {
         txOut: OwnedTxOut,
         contacts: Set<Contact>
     ) -> HistoricalTransaction where Contact: Hashable {
-        let (memo, contact) = txOut.recoverableMemo.recover(contacts: contacts)
-        return HistoricalTransaction(memo: memo, txOut: txOut, contact: contact)
+        let (memo, unauthenticated, contact) = txOut.recoverableMemo.recover(contacts: contacts)
+        return HistoricalTransaction(
+            memo: memo,
+            unauthenticatedMemo: unauthenticated,
+            txOut: txOut,
+            contact: contact)
     }
 
     static public func recoverTransactions<Contact: PublicAddressProvider>(

--- a/Sources/Transaction/Memos/HistoricalTransaction.swift
+++ b/Sources/Transaction/Memos/HistoricalTransaction.swift
@@ -6,6 +6,7 @@ import Foundation
 
 public struct HistoricalTransaction {
     public let memo: RecoveredMemo?
+    public let unauthenticatedMemo: UnauthenticatedSenderMemo?
     public let txOut: OwnedTxOut
     public let contact: PublicAddressProvider?
 }
@@ -13,6 +14,7 @@ public struct HistoricalTransaction {
 extension HistoricalTransaction {
     init(txOut: OwnedTxOut) {
         self.memo = nil
+        self.unauthenticatedMemo = nil
         self.contact = nil
         self.txOut = txOut
     }

--- a/Sources/Transaction/Memos/RecoverableMemo.swift
+++ b/Sources/Transaction/Memos/RecoverableMemo.swift
@@ -228,7 +228,7 @@ extension RecoverableMemo {
         unauthenticated: UnauthenticatedSenderMemo?,
         contact: PublicAddressProvider?
     )
-    
+
     func recover<Contact: PublicAddressProvider>(
         contacts: Set<Contact>
     ) -> RecoverResult {
@@ -253,7 +253,7 @@ extension RecoverableMemo {
                 return (memo: memo, unauthenticated:nil, contact: contact)
             }
             .first
-            
+
             guard let recovered = recovered else {
                 guard let unauthenticated = self.unauthenticatedSenderMemo() else {
                     return (memo: nil, unauthenticated: nil, contact: nil)

--- a/Sources/Transaction/Memos/SenderMemo.swift
+++ b/Sources/Transaction/Memos/SenderMemo.swift
@@ -38,9 +38,9 @@ struct RecoverableSenderMemo {
         }
         return SenderMemo(memoData64: memoData, addressHash: addressHash)
     }
-    
+
     func unauthenticatedMemo() -> SenderMemo? {
-        return SenderMemo(memoData64: memoData, addressHash: addressHash)
+        SenderMemo(memoData64: memoData, addressHash: addressHash)
     }
 }
 

--- a/Sources/Transaction/Memos/SenderMemo.swift
+++ b/Sources/Transaction/Memos/SenderMemo.swift
@@ -38,6 +38,10 @@ struct RecoverableSenderMemo {
         }
         return SenderMemo(memoData64: memoData, addressHash: addressHash)
     }
+    
+    func unauthenticatedMemo() -> SenderMemo? {
+        return SenderMemo(memoData64: memoData, addressHash: addressHash)
+    }
 }
 
 extension RecoverableSenderMemo: Hashable { }

--- a/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
@@ -51,7 +51,7 @@ struct RecoverableSenderWithPaymentIntentMemo {
             addressHash: addressHash,
             paymentIntentId: paymentIntentId)
     }
-    
+
     func unauthenticatedMemo() -> SenderWithPaymentIntentMemo? {
         let paymentIntId = SenderWithPaymentIntentMemoUtils.getPaymentIntentId(memoData: memoData)
         guard let paymentIntentId = paymentIntId else {

--- a/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
@@ -51,6 +51,20 @@ struct RecoverableSenderWithPaymentIntentMemo {
             addressHash: addressHash,
             paymentIntentId: paymentIntentId)
     }
+    
+    func unauthenticatedMemo() -> SenderWithPaymentIntentMemo? {
+        let paymentIntId = SenderWithPaymentIntentMemoUtils.getPaymentIntentId(memoData: memoData)
+        guard let paymentIntentId = paymentIntId else {
+            logger.debug("Unable to get payment intent id")
+            return nil
+        }
+
+        let addressHash = SenderWithPaymentIntentMemoUtils.getAddressHash(memoData: memoData)
+        return SenderWithPaymentIntentMemo(
+            memoData64: memoData,
+            addressHash: addressHash,
+            paymentIntentId: paymentIntentId)
+    }
 }
 
 extension RecoverableSenderWithPaymentIntentMemo: Hashable { }

--- a/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
@@ -51,7 +51,7 @@ struct RecoverableSenderWithPaymentRequestMemo {
             addressHash: addressHash,
             paymentRequestId: paymentRequestId)
     }
-    
+
     func unauthenticatedMemo() -> SenderWithPaymentRequestMemo? {
         let paymentReqId = SenderWithPaymentRequestMemoUtils.getPaymentRequestId(memoData: memoData)
         guard let paymentRequestId = paymentReqId else {

--- a/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
@@ -51,6 +51,20 @@ struct RecoverableSenderWithPaymentRequestMemo {
             addressHash: addressHash,
             paymentRequestId: paymentRequestId)
     }
+    
+    func unauthenticatedMemo() -> SenderWithPaymentRequestMemo? {
+        let paymentReqId = SenderWithPaymentRequestMemoUtils.getPaymentRequestId(memoData: memoData)
+        guard let paymentRequestId = paymentReqId else {
+            logger.debug("Unable to get payment request id")
+            return nil
+        }
+
+        let addressHash = SenderWithPaymentRequestMemoUtils.getAddressHash(memoData: memoData)
+        return SenderWithPaymentRequestMemo(
+            memoData64: memoData,
+            addressHash: addressHash,
+            paymentRequestId: paymentRequestId)
+    }
 }
 
 extension RecoverableSenderWithPaymentRequestMemo: Hashable { }

--- a/Tests/Common/Fixtures/Transaction/Transaction+MemoFixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+MemoFixtures.swift
@@ -13,6 +13,8 @@ extension Transaction.Fixtures {
     struct TxOutMemo {
         let senderAccountKey: AccountKey
         let recipientAccountKey: AccountKey
+        let senderAccountKeyNoFog: AccountKey
+        let recipientAccountKeyNoFog: AccountKey
 
         let inputs: [PreparedTxInput]
         let txOuts: [TxOut]
@@ -36,6 +38,8 @@ extension Transaction.Fixtures {
             self.membershipProofs = try Self.txOutMembershipProofs()
             self.senderAccountKey = try Self.senderAccountKey()
             self.recipientAccountKey = try Self.recipientAccountKey()
+            self.senderAccountKeyNoFog = try Self.senderAccountKey()
+            self.recipientAccountKeyNoFog = try Self.recipientAccountKey()
             self.fogResolver = try Self.fogResolver()
             self.globalIndex = Self.globalIndex
             self.blockMetadata = Self.blockMetadata

--- a/Tests/Common/Fixtures/Transaction/Transaction+MemoFixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+MemoFixtures.swift
@@ -13,8 +13,6 @@ extension Transaction.Fixtures {
     struct TxOutMemo {
         let senderAccountKey: AccountKey
         let recipientAccountKey: AccountKey
-        let senderAccountKeyNoFog: AccountKey
-        let recipientAccountKeyNoFog: AccountKey
 
         let inputs: [PreparedTxInput]
         let txOuts: [TxOut]
@@ -38,8 +36,6 @@ extension Transaction.Fixtures {
             self.membershipProofs = try Self.txOutMembershipProofs()
             self.senderAccountKey = try Self.senderAccountKey()
             self.recipientAccountKey = try Self.recipientAccountKey()
-            self.senderAccountKeyNoFog = try Self.senderAccountKey()
-            self.recipientAccountKeyNoFog = try Self.recipientAccountKey()
             self.fogResolver = try Self.fogResolver()
             self.globalIndex = Self.globalIndex
             self.blockMetadata = Self.blockMetadata

--- a/Tests/Unit/Transaction/RecoverableMemoTests.swift
+++ b/Tests/Unit/Transaction/RecoverableMemoTests.swift
@@ -56,4 +56,21 @@ class RecoverableMemoTests: XCTestCase {
         XCTAssertEqual(authenticatedSenderMemoTxOuts.count, 0)
     }
 
+    func testUnauthenticatedSenderMemos() throws {
+        let fixture = try RecoverableMemo.Fixtures.Many()
+        let results = MobileCoinClient.recoverTransactions(
+            fixture.onesTxOuts,
+            contacts: fixture.badContacts)
+
+        // Check that all unauthenticated sender memos results were returned
+        let unauthenticatedSenderMemoTxOuts = results.filter {
+            $0.txOut.recoverableMemo.isAuthenticatedSenderMemo
+        }
+        .filter {
+            $0.unauthenticatedMemo != nil
+        }
+        
+        XCTAssertGreaterThan((unauthenticatedSenderMemoTxOuts.count), 0)
+    }
+
 }

--- a/Tests/Unit/Transaction/RecoverableMemoTests.swift
+++ b/Tests/Unit/Transaction/RecoverableMemoTests.swift
@@ -69,7 +69,7 @@ class RecoverableMemoTests: XCTestCase {
         .filter {
             $0.unauthenticatedMemo != nil
         }
-        
+
         XCTAssertGreaterThan((unauthenticatedSenderMemoTxOuts.count), 0)
     }
 

--- a/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
+++ b/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
@@ -91,7 +91,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(recovered.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.paymentRequestId, fixture.paymentRequestId)
-        
+
         guard
             case let .senderWithPaymentRequest(recoverable) = receivedTxOut.recoverableMemo,
             let unauthenticated = recoverable.unauthenticatedMemo()
@@ -99,7 +99,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
             XCTFail("Unable to get unauthenticated memo data")
             return
         }
-        
+
         XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(unauthenticated.paymentRequestId, fixture.paymentRequestId)
     }

--- a/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
+++ b/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
@@ -91,6 +91,17 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(recovered.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.paymentRequestId, fixture.paymentRequestId)
+        
+        guard
+            case let .senderWithPaymentRequest(recoverable) = receivedTxOut.recoverableMemo,
+            let unauthenticated = recoverable.unauthenticatedMemo()
+        else {
+            XCTFail("Unable to get unauthenticated memo data")
+            return
+        }
+        
+        XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
+        XCTAssertEqual(unauthenticated.paymentRequestId, fixture.paymentRequestId)
     }
 
     func testTransactionSenderWithPaymentRequestDestinationMemo() throws {
@@ -145,6 +156,17 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(recovered.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.paymentIntentId, fixture.paymentIntentId)
+
+        guard
+            case let .senderWithPaymentIntent(recoverable) = receivedTxOut.recoverableMemo,
+            let unauthenticated = recoverable.unauthenticatedMemo()
+        else {
+            XCTFail("Unable to recover memo data")
+            return
+        }
+
+        XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
+        XCTAssertEqual(unauthenticated.paymentIntentId, fixture.paymentIntentId)
     }
 
     func testTransactionSenderWithPaymentIntentDestinationMemo() throws {


### PR DESCRIPTION
### Motivation

Add a way to get "unauthenticated" sender memo data

### In this PR
* Add a field - `unauthenticatedMemo` to `HistoricalTransaction` which is the data type returned from the RTH `recover` API on the MobileCoinClient.

### Future Work
* Add more tests