### PR TITLE
`Encodable` Conformance

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -134,3 +134,6 @@ file_header:
 # Temporarily turn this into a warning until the code is fixed
 large_tuple:
   error: 6
+
+file_name:
+  excluded: ["DictionaryCodable.swift"]

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre3)
-  - MobileCoin/Core (4.0.0-pre3):
+  - MobileCoin (4.0.0-pre4)
+  - MobileCoin/Core (4.0.0-pre4):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre3):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre4):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0-pre3)
-  - MobileCoin/PerformanceTests (4.0.0-pre3)
-  - MobileCoin/Tests (4.0.0-pre3)
+  - MobileCoin/IntegrationTests (4.0.0-pre4)
+  - MobileCoin/PerformanceTests (4.0.0-pre4)
+  - MobileCoin/Tests (4.0.0-pre4)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 855e464ba6326e662f9d733ddf90a21aa4613ece
+  MobileCoin: 16b36e2645a3ed6b54518d3abec7fbca24273ef3
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (4.0.0-pre2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre3)
-  - MobileCoin/CoreHTTP (4.0.0-pre3):
+  - MobileCoin (4.0.0-pre4)
+  - MobileCoin/CoreHTTP (4.0.0-pre4):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre3):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre4):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0-pre3)
-  - MobileCoin/PerformanceTests (4.0.0-pre3)
-  - MobileCoin/Tests (4.0.0-pre3)
+  - MobileCoin/IntegrationTests (4.0.0-pre4)
+  - MobileCoin/PerformanceTests (4.0.0-pre4)
+  - MobileCoin/Tests (4.0.0-pre4)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 855e464ba6326e662f9d733ddf90a21aa4613ece
+  MobileCoin: 16b36e2645a3ed6b54518d3abec7fbca24273ef3
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0-pre3"
+  s.version      = "4.0.0-pre4"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Transaction/Memos/DestinationMemo.swift
+++ b/Sources/Transaction/Memos/DestinationMemo.swift
@@ -25,7 +25,7 @@ extension DestinationMemo: Encodable {
         case fee
         case totalOutlay
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)

--- a/Sources/Transaction/Memos/DestinationMemo.swift
+++ b/Sources/Transaction/Memos/DestinationMemo.swift
@@ -18,6 +18,23 @@ public struct DestinationMemo {
 
 extension DestinationMemo: Equatable, Hashable { }
 
+extension DestinationMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+        case numberOfRecipients
+        case fee
+        case totalOutlay
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
+        try container.encode(fee, forKey: .fee)
+        try container.encode(totalOutlay, forKey: .totalOutlay)
+    }
+}
+
 struct RecoverableDestinationMemo {
     let memoData: Data64
     let addressHash: AddressHash

--- a/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
@@ -28,7 +28,7 @@ extension DestinationWithPaymentIntentMemo: Encodable {
         case totalOutlay
         case paymentIntentId
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)

--- a/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
@@ -20,6 +20,25 @@ public struct DestinationWithPaymentIntentMemo {
 
 extension DestinationWithPaymentIntentMemo: Equatable, Hashable { }
 
+extension DestinationWithPaymentIntentMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+        case numberOfRecipients
+        case fee
+        case totalOutlay
+        case paymentIntentId
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
+        try container.encode(fee, forKey: .fee)
+        try container.encode(totalOutlay, forKey: .totalOutlay)
+        try container.encode(paymentIntentId, forKey: .paymentIntentId)
+    }
+}
+
 struct RecoverableDestinationWithPaymentIntentMemo {
     let memoData: Data64
     let addressHash: AddressHash

--- a/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
@@ -28,7 +28,7 @@ extension DestinationWithPaymentRequestMemo: Encodable {
         case totalOutlay
         case paymentRequestId
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)

--- a/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
@@ -20,6 +20,25 @@ public struct DestinationWithPaymentRequestMemo {
 
 extension DestinationWithPaymentRequestMemo: Equatable, Hashable { }
 
+extension DestinationWithPaymentRequestMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+        case numberOfRecipients
+        case fee
+        case totalOutlay
+        case paymentRequestId
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
+        try container.encode(fee, forKey: .fee)
+        try container.encode(totalOutlay, forKey: .totalOutlay)
+        try container.encode(paymentRequestId, forKey: .paymentRequestId)
+    }
+}
+
 struct RecoverableDestinationWithPaymentRequestMemo {
     let memoData: Data64
     let addressHash: AddressHash

--- a/Sources/Transaction/Memos/SenderMemo.swift
+++ b/Sources/Transaction/Memos/SenderMemo.swift
@@ -14,6 +14,17 @@ public struct SenderMemo {
 
 extension SenderMemo: Equatable, Hashable { }
 
+extension SenderMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+    }
+}
+
 struct RecoverableSenderMemo {
     let memoData: Data64
     let addressHash: AddressHash
@@ -42,6 +53,7 @@ struct RecoverableSenderMemo {
     func unauthenticatedMemo() -> SenderMemo? {
         SenderMemo(memoData64: memoData, addressHash: addressHash)
     }
+    
 }
 
 extension RecoverableSenderMemo: Hashable { }

--- a/Sources/Transaction/Memos/SenderMemo.swift
+++ b/Sources/Transaction/Memos/SenderMemo.swift
@@ -18,7 +18,7 @@ extension SenderMemo: Encodable {
     enum CodingKeys: String, CodingKey {
         case addressHashHex
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)
@@ -53,7 +53,7 @@ struct RecoverableSenderMemo {
     func unauthenticatedMemo() -> SenderMemo? {
         SenderMemo(memoData64: memoData, addressHash: addressHash)
     }
-    
+
 }
 
 extension RecoverableSenderMemo: Hashable { }

--- a/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
@@ -20,7 +20,7 @@ extension SenderWithPaymentIntentMemo: Encodable {
         case addressHashHex
         case paymentIntentId
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)

--- a/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
@@ -15,6 +15,19 @@ public struct SenderWithPaymentIntentMemo {
 
 extension SenderWithPaymentIntentMemo: Equatable, Hashable { }
 
+extension SenderWithPaymentIntentMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+        case paymentIntentId
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(paymentIntentId, forKey: .paymentIntentId)
+    }
+}
+
 struct RecoverableSenderWithPaymentIntentMemo {
     let memoData: Data64
     let addressHash: AddressHash

--- a/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
@@ -15,6 +15,19 @@ public struct SenderWithPaymentRequestMemo {
 
 extension SenderWithPaymentRequestMemo: Equatable, Hashable { }
 
+extension SenderWithPaymentRequestMemo: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case addressHashHex
+        case paymentRequestId
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(paymentRequestId, forKey: .paymentRequestId)
+    }
+}
+
 struct RecoverableSenderWithPaymentRequestMemo {
     let memoData: Data64
     let addressHash: AddressHash

--- a/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
@@ -20,7 +20,7 @@ extension SenderWithPaymentRequestMemo: Encodable {
         case addressHashHex
         case paymentRequestId
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(addressHashHex, forKey: .addressHashHex)

--- a/Tests/Common/Fixtures/Transaction/TransactionBuilder+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/TransactionBuilder+Fixtures.swift
@@ -19,6 +19,7 @@ extension TransactionBuilder.Fixtures {
         let memoType: MemoType
         let fee: Amount
         let totalOutlay: UInt64
+        let numberOfRecipients: UInt8 = 1
 
         static let Fixtures = TransactionBuilder.Fixtures.self
 
@@ -54,6 +55,7 @@ extension TransactionBuilder.Fixtures {
         let memoType: MemoType
         let fee: Amount
         let totalOutlay: UInt64
+        let numberOfRecipients: UInt8 = 1
 
         static let Fixtures = TransactionBuilder.Fixtures.self
 
@@ -94,6 +96,7 @@ extension TransactionBuilder.Fixtures {
         let memoType: MemoType
         let fee: Amount
         let totalOutlay: UInt64
+        let numberOfRecipients: UInt8 = 1
 
         static let Fixtures = TransactionBuilder.Fixtures.self
 

--- a/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
+++ b/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
@@ -29,13 +29,13 @@ final class RecoveredMemoEncodableTests: XCTestCase {
 
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
-            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+            let unauthEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
         else {
             XCTFail("Unable to get unauthenticated memo data for encodable testing")
             return
         }
 
-        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+        XCTAssertEqual(unauthEncoded as NSDictionary, expected as NSDictionary)
     }
 
     func testSenderWithPaymentRequestMemoEncodable() throws {
@@ -61,13 +61,13 @@ final class RecoveredMemoEncodableTests: XCTestCase {
 
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
-            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+            let unauthEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
         else {
             XCTFail("Unable to get unauthenticated memo data for encodable testing")
             return
         }
 
-        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+        XCTAssertEqual(unauthEncoded as NSDictionary, expected as NSDictionary)
     }
 
     func testSenderWithPaymentIntentMemoEncodable() throws {
@@ -93,13 +93,13 @@ final class RecoveredMemoEncodableTests: XCTestCase {
 
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
-            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+            let unauthEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
         else {
             XCTFail("Unable to get unauthenticated memo data for encodable testing")
             return
         }
 
-        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+        XCTAssertEqual(unauthEncoded as NSDictionary, expected as NSDictionary)
     }
 
     func testDestinationMemoEncodable() throws {

--- a/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
+++ b/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
@@ -24,9 +24,9 @@ final class RecoveredMemoEncodableTests: XCTestCase {
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
-        
+
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
             let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
@@ -54,11 +54,11 @@ final class RecoveredMemoEncodableTests: XCTestCase {
 
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "paymentRequestId": recovered.paymentRequestId
+            "paymentRequestId": recovered.paymentRequestId,
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
-        
+
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
             let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
@@ -66,7 +66,7 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             XCTFail("Unable to get unauthenticated memo data for encodable testing")
             return
         }
-        
+
         XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
     }
 
@@ -86,11 +86,11 @@ final class RecoveredMemoEncodableTests: XCTestCase {
 
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "paymentIntentId": recovered.paymentIntentId
+            "paymentIntentId": recovered.paymentIntentId,
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
-        
+
         guard
             let unauthenticated = recoverable.unauthenticatedMemo(),
             let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
@@ -98,10 +98,10 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             XCTFail("Unable to get unauthenticated memo data for encodable testing")
             return
         }
-        
+
         XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
     }
-    
+
     func testDestinationMemoEncodable() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress
@@ -115,14 +115,14 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             XCTFail("Unable to recover memo data")
             return
         }
-        
+
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
             "fee": recovered.fee,
             "totalOutlay": recovered.totalOutlay,
-            "numberOfRecipients": recovered.numberOfRecipients
+            "numberOfRecipients": recovered.numberOfRecipients,
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
     }
 
@@ -139,19 +139,19 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             XCTFail("Unable to recover memo data")
             return
         }
-        
+
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
             "fee": recovered.fee,
             "totalOutlay": recovered.totalOutlay,
             "numberOfRecipients": recovered.numberOfRecipients,
-            "paymentRequestId": recovered.paymentRequestId
-            
+            "paymentRequestId": recovered.paymentRequestId,
+
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
     }
-    
+
     func testDestinationWithPaymentIntentMemoEncodable() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentIntentAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress
@@ -165,16 +165,16 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             XCTFail("Unable to recover memo data")
             return
         }
-        
+
         let expected: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
             "fee": recovered.fee,
             "totalOutlay": recovered.totalOutlay,
             "numberOfRecipients": recovered.numberOfRecipients,
-            "paymentIntentId": recovered.paymentIntentId
-            
+            "paymentIntentId": recovered.paymentIntentId,
+
         ]
-        
+
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
     }
 

--- a/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
+++ b/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
@@ -1,0 +1,181 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+@testable import MobileCoin
+import XCTest
+
+final class RecoveredMemoEncodableTests: XCTestCase {
+
+    func testTransactionWithSenderMemo() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderAndDestination()
+        let senderPublicAddress = fixture.senderPublicAddress
+        let receivedTxOut = fixture.receivedTxOut
+
+        guard
+            case let .sender(recoverable) = receivedTxOut.recoverableMemo,
+            let recovered = recoverable.recover(senderPublicAddress: senderPublicAddress),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data")
+            return
+        }
+
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+        
+        guard
+            let unauthenticated = recoverable.unauthenticatedMemo(),
+            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+        else {
+            XCTFail("Unable to get unauthenticated memo data for encodable testing")
+            return
+        }
+
+        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+    }
+
+    func testSenderWithPaymentRequestMemoEncodable() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentRequestAndDestination()
+        let senderPublicAddress = fixture.senderPublicAddress
+        let receivedTxOut = fixture.receivedTxOut
+
+        guard
+            case let .senderWithPaymentRequest(recoverable) = receivedTxOut.recoverableMemo,
+            let recovered = recoverable.recover(senderPublicAddress: senderPublicAddress),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data for encodable testing")
+            return
+        }
+
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+            "paymentRequestId": recovered.paymentRequestId
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+        
+        guard
+            let unauthenticated = recoverable.unauthenticatedMemo(),
+            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+        else {
+            XCTFail("Unable to get unauthenticated memo data for encodable testing")
+            return
+        }
+        
+        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+    }
+
+    func testSenderWithPaymentIntentMemoEncodable() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentIntentAndDestination()
+        let senderPublicAddress = fixture.senderPublicAddress
+        let receivedTxOut = fixture.receivedTxOut
+
+        guard
+            case let .senderWithPaymentIntent(recoverable) = receivedTxOut.recoverableMemo,
+            let recovered = recoverable.recover(senderPublicAddress: senderPublicAddress),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data for encodable testing")
+            return
+        }
+
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+            "paymentIntentId": recovered.paymentIntentId
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+        
+        guard
+            let unauthenticated = recoverable.unauthenticatedMemo(),
+            let unauthenticatedEncoded = try? DictionaryEncoder().encode(unauthenticated) as? [String: Any]
+        else {
+            XCTFail("Unable to get unauthenticated memo data for encodable testing")
+            return
+        }
+        
+        XCTAssertEqual(unauthenticatedEncoded as NSDictionary, expected as NSDictionary)
+    }
+    
+    func testDestinationMemoEncodable() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderAndDestination()
+        let recipientPublicAddress = fixture.recipeintPublicAddress
+        let sentTxOut = fixture.sentTxOut
+
+        guard
+            case let .destination(recoverable) = sentTxOut.recoverableMemo,
+            let recovered = recoverable.recover(),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data")
+            return
+        }
+        
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+            "fee": recovered.fee,
+            "totalOutlay": recovered.totalOutlay,
+            "numberOfRecipients": recovered.numberOfRecipients
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+    }
+
+    func testDestinationWithPaymentRequestMemoEncodable() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentRequestAndDestination()
+        let recipientPublicAddress = fixture.recipeintPublicAddress
+        let sentTxOut = fixture.sentTxOut
+
+        guard
+            case let .destinationWithPaymentRequest(recoverable) = sentTxOut.recoverableMemo,
+            let recovered = recoverable.recover(),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data")
+            return
+        }
+        
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+            "fee": recovered.fee,
+            "totalOutlay": recovered.totalOutlay,
+            "numberOfRecipients": recovered.numberOfRecipients,
+            "paymentRequestId": recovered.paymentRequestId
+            
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+    }
+    
+    func testDestinationWithPaymentIntentMemoEncodable() throws {
+        let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentIntentAndDestination()
+        let recipientPublicAddress = fixture.recipeintPublicAddress
+        let sentTxOut = fixture.sentTxOut
+
+        guard
+            case let .destinationWithPaymentIntent(recoverable) = sentTxOut.recoverableMemo,
+            let recovered = recoverable.recover(),
+            let encoded = try? DictionaryEncoder().encode(recovered) as? [String: Any]
+        else {
+            XCTFail("Unable to recover memo data")
+            return
+        }
+        
+        let expected: [String: Any] = [
+            "addressHashHex": recovered.addressHashHex,
+            "fee": recovered.fee,
+            "totalOutlay": recovered.totalOutlay,
+            "numberOfRecipients": recovered.numberOfRecipients,
+            "paymentIntentId": recovered.paymentIntentId
+            
+        ]
+        
+        XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
+    }
+
+}

--- a/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
+++ b/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
@@ -92,7 +92,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(recovered.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.paymentRequestId, fixture.paymentRequestId)
-        
+
         guard
             case let .senderWithPaymentRequest(recoverable) = receivedTxOut.recoverableMemo,
             let unauthenticated = recoverable.unauthenticatedMemo()
@@ -103,9 +103,9 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(unauthenticated.paymentRequestId, fixture.paymentRequestId)
-        
+
     }
-    
+
     func testTransactionSenderWithPaymentRequestDestinationMemo() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentRequestAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress
@@ -171,7 +171,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
         XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(unauthenticated.paymentIntentId, fixture.paymentIntentId)
     }
-    
+
     func testTransactionSenderWithPaymentIntentDestinationMemo() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentIntentAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress

--- a/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
+++ b/Tests/Unit/Transaction/TxOutMemoIntegrationTests.swift
@@ -56,6 +56,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
         XCTAssertEqual(recovered.addressHash, recipientPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.fee, fixture.fee.value)
         XCTAssertEqual(recovered.totalOutlay, fixture.totalOutlay)
+        XCTAssertEqual(recovered.numberOfRecipients, fixture.numberOfRecipients)
     }
 
     func testBuildTransactionWithSenderWithPaymentRequest() throws {
@@ -91,7 +92,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(recovered.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(recovered.paymentRequestId, fixture.paymentRequestId)
-
+        
         guard
             case let .senderWithPaymentRequest(recoverable) = receivedTxOut.recoverableMemo,
             let unauthenticated = recoverable.unauthenticatedMemo()
@@ -102,8 +103,9 @@ class TxOutMemoIntegrationTests: XCTestCase {
 
         XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(unauthenticated.paymentRequestId, fixture.paymentRequestId)
+        
     }
-
+    
     func testTransactionSenderWithPaymentRequestDestinationMemo() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentRequestAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress
@@ -121,6 +123,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
         XCTAssertEqual(recovered.fee, fixture.fee.value)
         XCTAssertEqual(recovered.totalOutlay, fixture.totalOutlay)
         XCTAssertEqual(recovered.paymentRequestId, fixture.paymentRequestId)
+        XCTAssertEqual(recovered.numberOfRecipients, fixture.numberOfRecipients)
     }
 
     func testBuildTransactionWithSenderWithPaymentIntent() throws {
@@ -168,7 +171,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
         XCTAssertEqual(unauthenticated.addressHash, senderPublicAddress.calculateAddressHash())
         XCTAssertEqual(unauthenticated.paymentIntentId, fixture.paymentIntentId)
     }
-
+    
     func testTransactionSenderWithPaymentIntentDestinationMemo() throws {
         let fixture = try TransactionBuilder.Fixtures.SenderWithPaymentIntentAndDestination()
         let recipientPublicAddress = fixture.recipeintPublicAddress
@@ -186,6 +189,7 @@ class TxOutMemoIntegrationTests: XCTestCase {
         XCTAssertEqual(recovered.fee, fixture.fee.value)
         XCTAssertEqual(recovered.totalOutlay, fixture.totalOutlay)
         XCTAssertEqual(recovered.paymentIntentId, fixture.paymentIntentId)
+        XCTAssertEqual(recovered.numberOfRecipients, fixture.numberOfRecipients)
     }
 
     func testBlockVersionOneUnusedMemo() throws {

--- a/Tests/Unit/Utils/DictionaryCodable.swift
+++ b/Tests/Unit/Utils/DictionaryCodable.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+import Foundation
+
+class DictionaryEncoder {
+    private let jsonEncoder = JSONEncoder()
+
+    /// Encodes given Encodable value into an array or dictionary
+    func encode<T>(_ value: T) throws -> Any where T: Encodable {
+        let jsonData = try jsonEncoder.encode(value)
+        return try JSONSerialization.jsonObject(with: jsonData, options: .allowFragments)
+    }
+}
+
+class DictionaryDecoder {
+    private let jsonDecoder = JSONDecoder()
+
+    /// Decodes given Decodable type from given array or dictionary
+    func decode<T>(_ type: T.Type, from json: Any) throws -> T where T: Decodable {
+        let jsonData = try JSONSerialization.data(withJSONObject: json, options: [])
+        return try jsonDecoder.decode(type, from: jsonData)
+    }
+}


### PR DESCRIPTION
### Motivation

Add `Encodable` conformance to the `RecoveredMemo` structs. This will allow for simple and accurate encoding to JSON, or Dictionary `[String: Any]` by consumers.

### In this PR
* Add encodable conformance to RecoveredMemo's
* Update unit test with numberOfRecipients field
* Increment version number for a release
