### PR TITLE
Change Memo encoding to include typeBytes, typeName and "data"

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre4)
-  - MobileCoin/Core (4.0.0-pre4):
+  - MobileCoin (4.0.0-pre5)
+  - MobileCoin/Core (4.0.0-pre5):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre4):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre5):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre2)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0-pre4)
-  - MobileCoin/PerformanceTests (4.0.0-pre4)
-  - MobileCoin/Tests (4.0.0-pre4)
+  - MobileCoin/IntegrationTests (4.0.0-pre5)
+  - MobileCoin/PerformanceTests (4.0.0-pre5)
+  - MobileCoin/Tests (4.0.0-pre5)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 16b36e2645a3ed6b54518d3abec7fbca24273ef3
+  MobileCoin: 874161c7b3280bb1b899efd7a0b0fb9a5322f8d7
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (4.0.0-pre2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre4)
-  - MobileCoin/CoreHTTP (4.0.0-pre4):
+  - MobileCoin (4.0.0-pre5)
+  - MobileCoin/CoreHTTP (4.0.0-pre5):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre4):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre5):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre2)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0-pre4)
-  - MobileCoin/PerformanceTests (4.0.0-pre4)
-  - MobileCoin/Tests (4.0.0-pre4)
+  - MobileCoin/IntegrationTests (4.0.0-pre5)
+  - MobileCoin/PerformanceTests (4.0.0-pre5)
+  - MobileCoin/Tests (4.0.0-pre5)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 5fb5ecbc8eefb336a14b72830675eb997d7bc8d2
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 16b36e2645a3ed6b54518d3abec7fbca24273ef3
+  MobileCoin: 874161c7b3280bb1b899efd7a0b0fb9a5322f8d7
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0-pre4"
+  s.version      = "4.0.0-pre5"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Transaction/Memos/DestinationMemo.swift
+++ b/Sources/Transaction/Memos/DestinationMemo.swift
@@ -20,6 +20,12 @@ extension DestinationMemo: Equatable, Hashable { }
 
 extension DestinationMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
         case numberOfRecipients
         case fee
@@ -28,10 +34,14 @@ extension DestinationMemo: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
-        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
-        try container.encode(fee, forKey: .fee)
-        try container.encode(totalOutlay, forKey: .totalOutlay)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
+        try data.encode(String(numberOfRecipients), forKey: .numberOfRecipients)
+        try data.encode(String(fee), forKey: .fee)
+        try data.encode(String(totalOutlay), forKey: .totalOutlay)
     }
 }
 

--- a/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentIntentMemo.swift
@@ -22,6 +22,12 @@ extension DestinationWithPaymentIntentMemo: Equatable, Hashable { }
 
 extension DestinationWithPaymentIntentMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
         case numberOfRecipients
         case fee
@@ -31,11 +37,15 @@ extension DestinationWithPaymentIntentMemo: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
-        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
-        try container.encode(fee, forKey: .fee)
-        try container.encode(totalOutlay, forKey: .totalOutlay)
-        try container.encode(paymentIntentId, forKey: .paymentIntentId)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
+        try data.encode(String(numberOfRecipients), forKey: .numberOfRecipients)
+        try data.encode(String(fee), forKey: .fee)
+        try data.encode(String(totalOutlay), forKey: .totalOutlay)
+        try data.encode(String(paymentIntentId), forKey: .paymentIntentId)
     }
 }
 

--- a/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/DestinationWithPaymentRequestMemo.swift
@@ -22,6 +22,12 @@ extension DestinationWithPaymentRequestMemo: Equatable, Hashable { }
 
 extension DestinationWithPaymentRequestMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
         case numberOfRecipients
         case fee
@@ -31,11 +37,15 @@ extension DestinationWithPaymentRequestMemo: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
-        try container.encode(numberOfRecipients, forKey: .numberOfRecipients)
-        try container.encode(fee, forKey: .fee)
-        try container.encode(totalOutlay, forKey: .totalOutlay)
-        try container.encode(paymentRequestId, forKey: .paymentRequestId)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
+        try data.encode(String(numberOfRecipients), forKey: .numberOfRecipients)
+        try data.encode(String(fee), forKey: .fee)
+        try data.encode(String(totalOutlay), forKey: .totalOutlay)
+        try data.encode(String(paymentRequestId), forKey: .paymentRequestId)
     }
 }
 

--- a/Sources/Transaction/Memos/RecoverableMemo.swift
+++ b/Sources/Transaction/Memos/RecoverableMemo.swift
@@ -55,7 +55,6 @@ extension UnauthenticatedSenderMemo {
     }
 }
 
-
 // swiftlint:disable function_body_length
 enum RecoverableMemo {
     case notset

--- a/Sources/Transaction/Memos/RecoverableMemo.swift
+++ b/Sources/Transaction/Memos/RecoverableMemo.swift
@@ -55,6 +55,7 @@ extension UnauthenticatedSenderMemo {
     }
 }
 
+
 // swiftlint:disable function_body_length
 enum RecoverableMemo {
     case notset
@@ -73,43 +74,43 @@ enum RecoverableMemo {
         let typeBytes = data[..<2]
 
         switch typeBytes.hexEncodedString() {
-        case Types.SENDER_WITH_PAYMENT_REQUEST:
+        case SenderWithPaymentRequestMemo.type:
             let memo = RecoverableSenderWithPaymentRequestMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutPublicKey: txOutKeys.publicKey)
             self = .senderWithPaymentRequest(memo)
-        case Types.SENDER_WITH_PAYMENT_INTENT:
+        case SenderWithPaymentIntentMemo.type:
             let memo = RecoverableSenderWithPaymentIntentMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutPublicKey: txOutKeys.publicKey)
             self = .senderWithPaymentIntent(memo)
-        case Types.SENDER:
+        case SenderMemo.type:
             let memo = RecoverableSenderMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutPublicKey: txOutKeys.publicKey)
             self = .sender(memo)
-        case Types.DESTINATION:
+        case DestinationMemo.type:
             let memo = RecoverableDestinationMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutKeys: txOutKeys)
             self = .destination(memo)
-        case Types.DESTINATION_WITH_PAYMENT_INTENT:
+        case DestinationWithPaymentIntentMemo.type:
             let memo = RecoverableDestinationWithPaymentIntentMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutKeys: txOutKeys)
             self = .destinationWithPaymentIntent(memo)
-        case Types.DESTINATION_WITH_PAYMENT_REQUEST:
+        case DestinationWithPaymentRequestMemo.type:
             let memo = RecoverableDestinationWithPaymentRequestMemo(
                 memoData,
                 accountKey: accountKey,
                 txOutKeys: txOutKeys)
             self = .destinationWithPaymentRequest(memo)
-        case Types.UNUSED:
+        case Self.UNUSED_TYPE:
             self = .unused
         default:
             logger.warning("Memo data type unknown")
@@ -117,15 +118,7 @@ enum RecoverableMemo {
         }
     }
 
-    enum Types {
-        static let SENDER = "0100"
-        static let SENDER_WITH_PAYMENT_REQUEST = "0101"
-        static let SENDER_WITH_PAYMENT_INTENT = "0102"
-        static let DESTINATION = "0200"
-        static let DESTINATION_WITH_PAYMENT_REQUEST = "0203"
-        static let DESTINATION_WITH_PAYMENT_INTENT = "0204"
-        static let UNUSED = "0000"
-    }
+    static let UNUSED_TYPE = "0000"
 
     var isAuthenticatedSenderMemo: Bool {
         switch self {
@@ -139,6 +132,37 @@ enum RecoverableMemo {
 
 }
 // swiftlint:enable function_body_length
+
+/// Memo Type "binary" header/prefixes and readable names
+extension SenderMemo {
+    public static let type = "0100"
+    public static let typeName = "SenderMemo"
+}
+
+extension SenderWithPaymentRequestMemo {
+    public static let type = "0101"
+    public static let typeName = "SenderWithPaymentRequestIdMemo"
+}
+
+extension SenderWithPaymentIntentMemo {
+    public static let type = "0102"
+    public static let typeName = "SenderWithPaymentIntentIdMemo"
+}
+
+extension DestinationMemo {
+    public static let type = "0200"
+    public static let typeName = "DestinationMemo"
+}
+
+extension DestinationWithPaymentRequestMemo {
+    public static let type = "0203"
+    public static let typeName = "DestinationWithPaymentRequestIdMemo"
+}
+
+extension DestinationWithPaymentIntentMemo {
+    public static let type = "0204"
+    public static let typeName = "DestinationWithPaymentIntentIdMemo"
+}
 
 // swiftlint:disable cyclomatic_complexity
 extension RecoverableMemo {

--- a/Sources/Transaction/Memos/SenderMemo.swift
+++ b/Sources/Transaction/Memos/SenderMemo.swift
@@ -16,12 +16,22 @@ extension SenderMemo: Equatable, Hashable { }
 
 extension SenderMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
     }
 }
 

--- a/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentIntentMemo.swift
@@ -17,14 +17,24 @@ extension SenderWithPaymentIntentMemo: Equatable, Hashable { }
 
 extension SenderWithPaymentIntentMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
         case paymentIntentId
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
-        try container.encode(paymentIntentId, forKey: .paymentIntentId)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
+        try data.encode(String(paymentIntentId), forKey: .paymentIntentId)
     }
 }
 

--- a/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
+++ b/Sources/Transaction/Memos/SenderWithPaymentRequestMemo.swift
@@ -17,14 +17,24 @@ extension SenderWithPaymentRequestMemo: Equatable, Hashable { }
 
 extension SenderWithPaymentRequestMemo: Encodable {
     enum CodingKeys: String, CodingKey {
+        case typeBytes
+        case typeName
+        case data
+    }
+
+    enum DataCodingKeys: String, CodingKey {
         case addressHashHex
         case paymentRequestId
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(addressHashHex, forKey: .addressHashHex)
-        try container.encode(paymentRequestId, forKey: .paymentRequestId)
+        try container.encode(Self.type, forKey: .typeBytes)
+        try container.encode(Self.typeName, forKey: .typeName)
+
+        var data = container.nestedContainer(keyedBy: DataCodingKeys.self, forKey: .data)
+        try data.encode(addressHashHex, forKey: .addressHashHex)
+        try data.encode(String(paymentRequestId), forKey: .paymentRequestId)
     }
 }
 

--- a/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
+++ b/Tests/Unit/Transaction/RecoveredMemoEncodableTests.swift
@@ -21,8 +21,15 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
+        ]
+
+        let type = SenderMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
@@ -52,9 +59,16 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "paymentRequestId": recovered.paymentRequestId,
+            "paymentRequestId": String(recovered.paymentRequestId),
+        ]
+
+        let type = SenderWithPaymentRequestMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
@@ -84,9 +98,16 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "paymentIntentId": recovered.paymentIntentId,
+            "paymentIntentId": String(recovered.paymentIntentId),
+        ]
+
+        let type = SenderWithPaymentIntentMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
@@ -116,11 +137,18 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "fee": recovered.fee,
-            "totalOutlay": recovered.totalOutlay,
-            "numberOfRecipients": recovered.numberOfRecipients,
+            "fee": String(recovered.fee),
+            "totalOutlay": String(recovered.totalOutlay),
+            "numberOfRecipients": String(recovered.numberOfRecipients),
+        ]
+
+        let type = DestinationMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
@@ -140,13 +168,20 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "fee": recovered.fee,
-            "totalOutlay": recovered.totalOutlay,
-            "numberOfRecipients": recovered.numberOfRecipients,
-            "paymentRequestId": recovered.paymentRequestId,
+            "fee": String(recovered.fee),
+            "totalOutlay": String(recovered.totalOutlay),
+            "numberOfRecipients": String(recovered.numberOfRecipients),
+            "paymentRequestId": String(recovered.paymentRequestId),
 
+        ]
+
+        let type = DestinationWithPaymentRequestMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)
@@ -166,13 +201,20 @@ final class RecoveredMemoEncodableTests: XCTestCase {
             return
         }
 
-        let expected: [String: Any] = [
+        let data: [String: Any] = [
             "addressHashHex": recovered.addressHashHex,
-            "fee": recovered.fee,
-            "totalOutlay": recovered.totalOutlay,
-            "numberOfRecipients": recovered.numberOfRecipients,
-            "paymentIntentId": recovered.paymentIntentId,
+            "fee": String(recovered.fee),
+            "totalOutlay": String(recovered.totalOutlay),
+            "numberOfRecipients": String(recovered.numberOfRecipients),
+            "paymentIntentId": String(recovered.paymentIntentId),
 
+        ]
+
+        let type = DestinationWithPaymentIntentMemo.self
+        let expected: [String: Any] = [
+            "typeBytes": type.type,
+            "typeName": type.typeName,
+            "data": data,
         ]
 
         XCTAssertEqual(encoded as NSDictionary, expected as NSDictionary)


### PR DESCRIPTION
### Motivation

Change encoding format, update unit tests, remove typeBytes enum add as static vars to memo types.

### In this PR
* Update encoding format

### Future Work
* make protobuf interface layer for all APIs so they can be consistent between android and iOS
