### PR TITLE
Update `printBalances`, change "wait for expectations" behavior 

### DIFF
--- a/Sources/LibMobileCoin/McConstants.swift
+++ b/Sources/LibMobileCoin/McConstants.swift
@@ -23,7 +23,7 @@ extension McConstants {
     static let MAX_TOMBSTONE_BLOCKS: UInt64 = 100
 
     /// Minimum allowed fee, denominated in picoMOB.
-    static let DEFAULT_MINIMUM_FEE: UInt64 = 4_000_000_000
+    static let DEFAULT_MINIMUM_FEE: UInt64 = 400_000_000
 
     /// Transaction hash length, in bytes.
     static let TX_HASH_LEN = 32

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
             let description = "[\(transportProtocol.description)]:\(description)"
             print("Testing ... \(description)")
             let expect = expectation(description: description)
-            try testCase(transportProtocol, expect) 
+            try testCase(transportProtocol, expect)
             XCTWaiter().wait(for: [expect], timeout: timeout)
 
             // Without the sleep here, we were occasionally seeing 'insufficientFunds' errors

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -16,12 +16,17 @@ extension XCTestCase {
     ) rethrows {
         let supportedProtocols = TransportProtocol.supportedProtocols
 
+        let last = supportedProtocols.last
         try supportedProtocols.forEach { transportProtocol in
             let description = "[\(transportProtocol.description)]:\(description)"
             print("Testing ... \(description)")
             let expect = expectation(description: description)
             try testCase(transportProtocol, expect)
             XCTWaiter().wait(for: [expect], timeout: timeout)
+
+            // Without the sleep here, we were occasionally seeing 'insufficientFunds' errors
+            // caused by tests that transact, where the change txo has not come back yet
+            sleep(transportProtocol == last ? 0 : interval)
         }
     }
 

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -15,14 +15,13 @@ extension XCTestCase {
                 _ testCase: (TransportProtocol, XCTestExpectation) throws -> Void
     ) rethrows {
         let supportedProtocols = TransportProtocol.supportedProtocols
-        let last = supportedProtocols.last
+
         try supportedProtocols.forEach { transportProtocol in
             let description = "[\(transportProtocol.description)]:\(description)"
             print("Testing ... \(description)")
             let expect = expectation(description: description)
             try testCase(transportProtocol, expect)
-            waitForExpectations(timeout: timeout)
-            sleep(transportProtocol == last ? 0 : interval)
+            XCTWaiter().wait(for: [expect], timeout: timeout)
         }
     }
 

--- a/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
+++ b/Tests/Common/Utils/XCTestCase+SupportedProtocols.swift
@@ -21,7 +21,7 @@ extension XCTestCase {
             let description = "[\(transportProtocol.description)]:\(description)"
             print("Testing ... \(description)")
             let expect = expectation(description: description)
-            try testCase(transportProtocol, expect)
+            try testCase(transportProtocol, expect) 
             XCTWaiter().wait(for: [expect], timeout: timeout)
 
             // Without the sleep here, we were occasionally seeing 'insufficientFunds' errors

--- a/Tests/Integration/IntegrationTestFixtures.swift
+++ b/Tests/Integration/IntegrationTestFixtures.swift
@@ -21,6 +21,16 @@ extension IntegrationTestFixtures {
         try FogUrl.make(string: network.fogReportUrl).get()
     }
 
+    static var testAccountCount: Int {
+        switch network {
+        case .dynamic:
+            return network.testAccountRootEntropies.count
+        default:
+            // the createAccountKey method will first try mnemonics, then private keys
+            return max(network.testAccountsMnemonics.count, network.testAccountsPrivateKeys.count)
+        }
+    }
+
     static func createAccountKey(accountIndex: Int = 0) throws -> AccountKey {
         let fogAuthoritySpki = try network.fogAuthoritySpki()
 

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -54,7 +54,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 accountKey: key,
                 transportProtocol: transportProtocol)
 
-            let expect = XCTestExpectation(description: "Retrieving balance for acct index \(index)")
+            let expect = XCTestExpectation(description: "Retrieving balance for acct idx \(index)")
             client.updateBalance {
                 guard $0.successOrFulfill(expectation: expect) != nil else { return }
 

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -45,27 +45,28 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol,
         expectation expect: XCTestExpectation
     ) throws {
-        try Array(0...9).forEach({ index in
+        let numAccounts = IntegrationTestFixtures.testAccountCount
+        try Array(0..<numAccounts).forEach({ index in
             let key = try IntegrationTestFixtures.createAccountKey(accountIndex: index)
 
             let client = try IntegrationTestFixtures.createMobileCoinClient(
                 accountKey: key,
                 transportProtocol: transportProtocol)
 
+            let balExpect = expectation(description: "Retrieving balance for acct index \(index)")
             client.updateBalance {
-                guard $0.successOrFulfill(expectation: expect) != nil else { return }
+                guard $0.successOrFulfill(expectation: balExpect) != nil else { return }
 
                 if let amountPicoMob = try? XCTUnwrap(client.balance.amountPicoMob()) {
                     print("account index \(index) public address \(key.publicAddress)")
                     print("account index \(index) balance: \(amountPicoMob)")
                 }
-
-                if index == 9 {
-                    expect.fulfill()
-                }
             }
+
+            XCTWaiter().wait(for: [balExpect], timeout: 40)
         })
 
+        expect.fulfill()
     }
 
     func testBalances() throws {

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -46,6 +46,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         expectation expect: XCTestExpectation
     ) throws {
         let numAccounts = IntegrationTestFixtures.testAccountCount
+        var balanceExpects: [XCTestExpectation] = []
         try Array(0..<numAccounts).forEach({ index in
             let key = try IntegrationTestFixtures.createAccountKey(accountIndex: index)
 
@@ -53,9 +54,9 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 accountKey: key,
                 transportProtocol: transportProtocol)
 
-            let balExpect = expectation(description: "Retrieving balance for acct index \(index)")
+            let expect = XCTestExpectation(description: "Retrieving balance for acct index \(index)")
             client.updateBalance {
-                guard $0.successOrFulfill(expectation: balExpect) != nil else { return }
+                guard $0.successOrFulfill(expectation: expect) != nil else { return }
 
                 if let amountPicoMob = try? XCTUnwrap(client.balance.amountPicoMob()) {
                     print("account index \(index) public address \(key.publicAddress)")
@@ -63,9 +64,10 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
                 }
             }
 
-            XCTWaiter().wait(for: [balExpect], timeout: 40)
+            balanceExpects.append(expect)
         })
 
+        XCTWaiter().wait(for: balanceExpects, timeout: 40)
         expect.fulfill()
     }
 

--- a/Tests/Integration/Network/NetworkConfigFixtures.swift
+++ b/Tests/Integration/Network/NetworkConfigFixtures.swift
@@ -9,8 +9,9 @@ import Foundation
 import XCTest
 
 enum NetworkConfigFixtures {
-    static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
-    static let network: NetworkPreset = .dynamic(alphaDev)
+//    static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
+//    static let network: NetworkPreset = .dynamic(alphaDev)
+    static let network: NetworkPreset = .testNet
 }
 
 extension NetworkConfigFixtures {

--- a/Tests/Unit/Transaction/Inputs/DefaultTxOutSelectionStrategyTests.swift
+++ b/Tests/Unit/Transaction/Inputs/DefaultTxOutSelectionStrategyTests.swift
@@ -9,7 +9,7 @@
 @testable import MobileCoin
 import XCTest
 
-private let minFee: UInt64 = 4_000_000_000
+private let minFee: UInt64 = 400_000_000
 
 class DefaultTxOutSelectionStrategyTests: XCTestCase {
 

--- a/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
+++ b/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
@@ -20,14 +20,14 @@ class BlockchainMetaFetcherTests: XCTestCase {
             guard let metaCache = $0.successOrFulfill(expectation: expect)
             else { return }
 
-            XCTAssertEqual(metaCache.minimumFees[.MOB], 4_000_000_000)
+            XCTAssertEqual(metaCache.minimumFees[.MOB], 400_000_000)
             expect.fulfill()
         }
         waitForExpectations(timeout: 1)
     }
 
     func testFetchMinimumFeeWorksWithNewService() throws {
-        let blockchainService = TestBlockchainService(successWithMinimumFee: 3_000_000_000)
+        let blockchainService = TestBlockchainService(successWithMinimumFee: 300_000_000)
         let fetcher = BlockchainMetaFetcher(
             blockchainService: blockchainService,
             metaCacheTTL: 60,
@@ -38,7 +38,7 @@ class BlockchainMetaFetcherTests: XCTestCase {
             guard let metaCache = $0.successOrFulfill(expectation: expect)
             else { return }
 
-            XCTAssertEqual(metaCache.minimumFees[.MOB], 3_000_000_000)
+            XCTAssertEqual(metaCache.minimumFees[.MOB], 300_000_000)
             expect.fulfill()
         }
         waitForExpectations(timeout: 1)


### PR DESCRIPTION
### Motivation

Protocol tests were having issues where the waitForExpectation for one protocol test was being fulfilled incorrectly by a prior protocol test.  Also, the protocol tests seemed to include a sleep between testing the protocols, presumably to try to prevent this issue?  These changes also remove the need to sleep, which will reduce each test execution by 10s.

### In this PR
    
     * Previously, when an expect would time out, the code would sleep for
       10s and attempt to test the subsequent protocol.  However when the
       previous protocol eventually fulfills the expectation, it will
       confuse the next test as the current code waits for any expectation
    
     * This fix updates the protocol test loop to wait for the specific
       expectation for the protocol to prevent the multiple expectation
       fullfillment error.
    
     * Additionally, this update speeds up the protocol tests as there
       should no longer be any need to sleep for 10s between protocols
       (I believe this was an attempt to prevent the above noted error from
       happening by giving time for the prior protocol to fulfill the
       expectation after timeout possibly?  not sure)### Future Work

     * Includes another small fix to remove magic number around number
       test accounts when printing balances

