### PR TITLE
Increment Version for `4.0.0-pre8` release 

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre7)
-  - MobileCoin/Core (4.0.0-pre7):
+  - MobileCoin (4.0.0-pre8)
+  - MobileCoin/Core (4.0.0-pre8):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre3)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre7):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.0-pre8):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (= 4.0.0-pre3)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0-pre7)
-  - MobileCoin/PerformanceTests (4.0.0-pre7)
-  - MobileCoin/Tests (4.0.0-pre7)
+  - MobileCoin/IntegrationTests (4.0.0-pre8)
+  - MobileCoin/PerformanceTests (4.0.0-pre8)
+  - MobileCoin/Tests (4.0.0-pre8)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: af8d6580227c14b787370209f5ed4c4a4fc90b9f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 1cc5ff311c2772ba96da3ac071a1c3ba43567a9c
+  MobileCoin: f4b274ba03e8e0dc2332e7f9072468ca60482bec
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (4.0.0-pre3):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0-pre7)
-  - MobileCoin/CoreHTTP (4.0.0-pre7):
+  - MobileCoin (4.0.0-pre8)
+  - MobileCoin/CoreHTTP (4.0.0-pre8):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre3)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre7):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0-pre8):
     - LibMobileCoin/CoreHTTP (= 4.0.0-pre3)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0-pre7)
-  - MobileCoin/PerformanceTests (4.0.0-pre7)
-  - MobileCoin/Tests (4.0.0-pre7)
+  - MobileCoin/IntegrationTests (4.0.0-pre8)
+  - MobileCoin/PerformanceTests (4.0.0-pre8)
+  - MobileCoin/Tests (4.0.0-pre8)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: af8d6580227c14b787370209f5ed4c4a4fc90b9f
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 1cc5ff311c2772ba96da3ac071a1c3ba43567a9c
+  MobileCoin: f4b274ba03e8e0dc2332e7f9072468ca60482bec
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0-pre7"
+  s.version      = "4.0.0-pre8"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"


### PR DESCRIPTION
### Motivation

Forgot to increment version for a `4.0.0-pre8` release with the updated libmobilecoin and new testnet measurements

### In this PR
* Increment version

### Future Work
* Update changelog
