### PR TITLE
Fix SCI input tx selection, and update SCI test accts for cur balances

### DIFF
--- a/Sources/Transaction/SignedContingentInputBuilder.swift
+++ b/Sources/Transaction/SignedContingentInputBuilder.swift
@@ -1,10 +1,8 @@
 //
 //  Copyright (c) 2020-2022 MobileCoin. All rights reserved.
 //
-
 // swiftlint:disable function_parameter_count function_default_parameter_at_end
 // swiftlint:disable closure_body_length
-
 import Foundation
 import LibMobileCoin
 
@@ -115,8 +113,16 @@ extension SignedContingentInputBuilder {
         rng: MobileCoinRng
     ) -> Result<SignedContingentInput, TransactionBuilderError> {
         let builder: SignedContingentInputBuilder
-        guard let input: PreparedTxInput = inputs.first else {
-            return .failure(.invalidInput("Insufficient funds"))
+
+        let possibleInputs = inputs.filter { $0.knownTxOut.amount.value >= amountToSend.value }
+        guard possibleInputs.count > 0 else {
+            return .failure(.invalidInput("Defragmentation Required"))
+        }
+
+        let input = possibleInputs.min { $0.knownTxOut.amount.value < $1.knownTxOut.amount.value }
+
+        guard let input = input else {
+            return .failure(.invalidInput("Unexpected error - unable to find valid input"))
         }
 
         let subaddressIndex = input.subaddressIndex

--- a/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
+++ b/Tests/Integration/MobileCoinClientPublicApiIntTests.swift
@@ -384,9 +384,9 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
 
     func cancelSignedContingentInput(transportProtocol: TransportProtocol) async throws {
         let amountToSend = Amount(100 + IntegrationTestFixtures.fee, in: .MOB)
-        let amountToReceive = Amount(10, in: .TestToken)
+        let amountToReceive = Amount(10, in: .MOBUSD)
 
-        let creatorIdx = 4
+        let creatorIdx = 1
         let creatorAddr = try IntegrationTestFixtures.createPublicAddress(accountIndex: creatorIdx)
         let creatorAcctKey = try IntegrationTestFixtures.createAccountKey(accountIndex: creatorIdx)
         let creator = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
@@ -395,12 +395,12 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             transportProtocol: transportProtocol
         )
 
-        let consumerIdx = 5
+        let consumerIdx = 0
         let consumerAcctKey =
             try IntegrationTestFixtures.createAccountKey(accountIndex: consumerIdx)
         let consumer = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
             accountKey: consumerAcctKey,
-            tokenId: .TestToken,
+            tokenId: .MOBUSD,
             transportProtocol: transportProtocol
         )
 
@@ -445,7 +445,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
         transportProtocol: TransportProtocol
     ) async throws {
         let amountToSend = Amount(100 + IntegrationTestFixtures.fee, in: .MOB)
-        let amountToReceive = Amount(10, in: .TestToken)
+        let amountToReceive = Amount(10, in: .MOBUSD)
 
         func checkBlockVersionAndFee(
             _ client: MobileCoinClient
@@ -511,7 +511,7 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             try await checkBalanceChange()
         }
 
-        let creatorIdx = 4
+        let creatorIdx = 1
         let creatorAddr = try IntegrationTestFixtures.createPublicAddress(accountIndex: creatorIdx)
         let creatorAcctKey = try IntegrationTestFixtures.createAccountKey(accountIndex: creatorIdx)
         let creator = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
@@ -520,12 +520,12 @@ class MobileCoinClientPublicApiIntTests: XCTestCase {
             transportProtocol: transportProtocol
         )
 
-        let consumerIdx = 5
+        let consumerIdx = 0
         let consumerAcctKey =
             try IntegrationTestFixtures.createAccountKey(accountIndex: consumerIdx)
         let consumer = try await IntegrationTestFixtures.createMobileCoinClientWithBalance(
             accountKey: consumerAcctKey,
-            tokenId: .TestToken,
+            tokenId: .MOBUSD,
             transportProtocol: transportProtocol
         )
 


### PR DESCRIPTION
Soundtrack of this PR: [Signed, Sealed, Delivered](https://www.youtube.com/watch?v=pUj9frKY46E)

### Motivation

Fix SCI Input selection 

### In this PR
* Updated input tx selection for SCI to pick the smallest single tx with enough balance for the SCI
* Updated test account indexes and SCI token types to match available balances in TestNet