### PR TITLE
Make Ristretto structs Public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2023-03-02
+
+### Added
+
+- Public access to Ristretto structs with a wrapper
+
 ## [4.0.0] - 2023-02-07
 
 ### Added
@@ -264,3 +270,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/mobilecoinofficial/MobileCoin-Swift/compare/1.1.0-pre2...1.1.0
 [1.1.0-pre2]: https://github.com/mobilecoinofficial/MobileCoin-Swift/compare/1.0.0...1.1.0-pre2
 [1.0.0]: https://github.com/mobilecoinofficial/MobileCoin-Swift/compare/1.0.0-rc1...1.0.0
+

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: debf975ac1b9099f8bd4fe6b64898e6230743c30
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 0d8de693f4ed2891eec12a06e3fe6e79940e8f65
+  MobileCoin: 6d801c8aac46c77624d1a55c98cdf0061ad42847
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
     - gRPC-Swift
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0)
-  - MobileCoin/Core (4.0.0):
+  - MobileCoin (4.0.1)
+  - MobileCoin/Core (4.0.1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (~> 4.0.0-pre3)
     - Logging (~> 1.4)
@@ -33,7 +33,7 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/Core/ProtocolUnitTests (4.0.0):
+  - MobileCoin/Core/ProtocolUnitTests (4.0.1):
     - gRPC-Swift (= 1.0.0)
     - LibMobileCoin/Core (~> 4.0.0-pre3)
     - Logging (~> 1.4)
@@ -42,9 +42,9 @@ PODS:
     - SwiftNIOHPACK (~> 1.16.3)
     - SwiftNIOHTTP1 (~> 2.40.0)
     - SwiftProtobuf
-  - MobileCoin/IntegrationTests (4.0.0)
-  - MobileCoin/PerformanceTests (4.0.0)
-  - MobileCoin/Tests (4.0.0)
+  - MobileCoin/IntegrationTests (4.0.1)
+  - MobileCoin/PerformanceTests (4.0.1)
+  - MobileCoin/Tests (4.0.1)
   - SwiftLint (0.47.1)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -3,18 +3,18 @@ PODS:
   - LibMobileCoin/CoreHTTP (4.0.0):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
-  - MobileCoin (4.0.0)
-  - MobileCoin/CoreHTTP (4.0.0):
+  - MobileCoin (4.0.1)
+  - MobileCoin/CoreHTTP (4.0.1):
     - LibMobileCoin/CoreHTTP (~> 4.0.0-pre3)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.0):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (4.0.1):
     - LibMobileCoin/CoreHTTP (~> 4.0.0-pre3)
     - Logging (~> 1.4)
     - SwiftLint
-  - MobileCoin/IntegrationTests (4.0.0)
-  - MobileCoin/PerformanceTests (4.0.0)
-  - MobileCoin/Tests (4.0.0)
+  - MobileCoin/IntegrationTests (4.0.1)
+  - MobileCoin/PerformanceTests (4.0.1)
+  - MobileCoin/Tests (4.0.1)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.19.0)
 

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: debf975ac1b9099f8bd4fe6b64898e6230743c30
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MobileCoin: 0d8de693f4ed2891eec12a06e3fe6e79940e8f65
+  MobileCoin: 6d801c8aac46c77624d1a55c98cdf0061ad42847
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Sources/Crypto/DefaultCryptoBox.swift
+++ b/Sources/Crypto/DefaultCryptoBox.swift
@@ -22,7 +22,7 @@ public enum DefaultCryptoBox {
         VersionedCryptoBox.decrypt(ciphertext: ciphertext,
                                    privateKey: accountKey.subaddressSpendPrivateKey)
     }
-    
+
     public static func encrypt(
         plaintext: Data,
         publicKey: WrappedRistrettoPublic

--- a/Sources/Crypto/DefaultCryptoBox.swift
+++ b/Sources/Crypto/DefaultCryptoBox.swift
@@ -22,4 +22,22 @@ public enum DefaultCryptoBox {
         VersionedCryptoBox.decrypt(ciphertext: ciphertext,
                                    privateKey: accountKey.subaddressSpendPrivateKey)
     }
+    
+    public static func encrypt(
+        plaintext: Data,
+        publicKey: WrappedRistrettoPublic
+    ) -> Result<Data, InvalidInputError> {
+        VersionedCryptoBox.encrypt(plaintext: plaintext,
+                                   publicKey: publicKey.ristretto,
+                                   rng: rngCallback,
+                                   rngContext: MobileCoinXoshiroRng())
+    }
+
+    public static func decrypt(
+        ciphertext: Data,
+        privateKey: WrappedRistrettoPrivate
+    ) -> Result<Data, VersionedCryptoBoxError> {
+        VersionedCryptoBox.decrypt(ciphertext: ciphertext,
+                                   privateKey: privateKey.ristretto)
+    }
 }

--- a/Sources/Crypto/RistrettoPrivate.swift
+++ b/Sources/Crypto/RistrettoPrivate.swift
@@ -46,7 +46,7 @@ extension External_RistrettoPrivate {
     }
 }
 
-public struct WrappedRistrettoPrivate {
+public struct WrappedRistrettoPrivate: Hashable {
     let ristretto: RistrettoPrivate
     
     public init?(_ data: Data) {

--- a/Sources/Crypto/RistrettoPrivate.swift
+++ b/Sources/Crypto/RistrettoPrivate.swift
@@ -45,3 +45,19 @@ extension External_RistrettoPrivate {
         self.data = ristrettoPrivate.data
     }
 }
+
+public struct WrappedRistrettoPrivate {
+    let ristretto: RistrettoPrivate
+    
+    public init?(_ data: Data) {
+        guard
+            let data32 = Data32(data.data),
+            let ristretto = RistrettoPrivate(data32)
+        else {
+            return nil
+        }
+        self.ristretto = ristretto
+    }
+
+    var data: Data { ristretto.data }
+}

--- a/Sources/Crypto/RistrettoPrivate.swift
+++ b/Sources/Crypto/RistrettoPrivate.swift
@@ -48,7 +48,7 @@ extension External_RistrettoPrivate {
 
 public struct WrappedRistrettoPrivate: Hashable {
     let ristretto: RistrettoPrivate
-    
+
     public init?(_ data: Data) {
         guard
             let data32 = Data32(data.data),

--- a/Sources/Crypto/RistrettoPrivate.swift
+++ b/Sources/Crypto/RistrettoPrivate.swift
@@ -59,5 +59,5 @@ public struct WrappedRistrettoPrivate: Hashable {
         self.ristretto = ristretto
     }
 
-    var data: Data { ristretto.data }
+    public var data: Data { ristretto.data }
 }

--- a/Sources/Crypto/RistrettoPublic.swift
+++ b/Sources/Crypto/RistrettoPublic.swift
@@ -46,7 +46,7 @@ extension External_CompressedRistretto {
     }
 }
 
-public struct WrappedRistrettoPublic {
+public struct WrappedRistrettoPublic: Hashable {
     let ristretto: RistrettoPublic
     
     public init?(_ data: Data) {
@@ -61,3 +61,4 @@ public struct WrappedRistrettoPublic {
 
     var data: Data { ristretto.data }
 }
+

--- a/Sources/Crypto/RistrettoPublic.swift
+++ b/Sources/Crypto/RistrettoPublic.swift
@@ -45,3 +45,19 @@ extension External_CompressedRistretto {
         self.data = ristrettoPublic.data
     }
 }
+
+public struct WrappedRistrettoPublic {
+    let ristretto: RistrettoPublic
+    
+    public init?(_ data: Data) {
+        guard
+            let data32 = Data32(data.data),
+            let ristretto = RistrettoPublic(data32)
+        else {
+            return nil
+        }
+        self.ristretto = ristretto
+    }
+
+    var data: Data { ristretto.data }
+}

--- a/Sources/Crypto/RistrettoPublic.swift
+++ b/Sources/Crypto/RistrettoPublic.swift
@@ -48,7 +48,7 @@ extension External_CompressedRistretto {
 
 public struct WrappedRistrettoPublic: Hashable {
     let ristretto: RistrettoPublic
-    
+
     public init?(_ data: Data) {
         guard
             let data32 = Data32(data.data),
@@ -61,4 +61,3 @@ public struct WrappedRistrettoPublic: Hashable {
 
     public var data: Data { ristretto.data }
 }
-

--- a/Sources/Crypto/RistrettoPublic.swift
+++ b/Sources/Crypto/RistrettoPublic.swift
@@ -59,6 +59,6 @@ public struct WrappedRistrettoPublic: Hashable {
         self.ristretto = ristretto
     }
 
-    var data: Data { ristretto.data }
+    public var data: Data { ristretto.data }
 }
 

--- a/Tests/Unit/MobileCoinClientPublicApiTests.swift
+++ b/Tests/Unit/MobileCoinClientPublicApiTests.swift
@@ -84,7 +84,7 @@ class MobileCoinClientPublicApiTests: XCTestCase {
         let validRistretto = "3379daf11c7d26bde2be0ab557e79285f868a1e58058ab47063950435fc7670a"
         let validRistrettoData = try XCTUnwrap(Data(hexEncoded: validRistretto))
         let validKey = WrappedRistrettoPrivate(validRistrettoData)
-        XCTAssertNotNil(validKey, "Init should succeed")
+        XCTAssertNotNil(validKey?.data, "Init should succeed")
     }
 
     func testWrappedRistrettoPrivateFailure() throws {
@@ -98,7 +98,7 @@ class MobileCoinClientPublicApiTests: XCTestCase {
         let validRistretto = "c235c13c4dedd808e95f428036716d52561fad7f51ce675f4d4c9c1fa1ea2165"
         let validRistrettoData = try XCTUnwrap(Data(hexEncoded: validRistretto))
         let validKey = WrappedRistrettoPublic(validRistrettoData)
-        XCTAssertNotNil(validKey, "Init should succeed")
+        XCTAssertNotNil(validKey?.data, "Init should succeed")
     }
 
     func testWrappedRistrettoPublicFailure() throws {

--- a/Tests/Unit/MobileCoinClientPublicApiTests.swift
+++ b/Tests/Unit/MobileCoinClientPublicApiTests.swift
@@ -102,7 +102,7 @@ class MobileCoinClientPublicApiTests: XCTestCase {
     }
 
     func testWrappedRistrettoPublicFailure() throws {
-        let invalidRistretto = "0e61ca061876b651e6981ad9a74fd5fe8d4af2f6981283bafe4c1ba40c3d0803"
+        let invalidRistretto = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         let invalidRistrettoData = try XCTUnwrap(Data(hexEncoded: invalidRistretto))
         let invalidKey = WrappedRistrettoPublic(invalidRistrettoData)
         XCTAssertNil(invalidKey, "Init should fail")

--- a/Tests/Unit/MobileCoinClientPublicApiTests.swift
+++ b/Tests/Unit/MobileCoinClientPublicApiTests.swift
@@ -80,4 +80,31 @@ class MobileCoinClientPublicApiTests: XCTestCase {
         _ = MobileCoinClient.make(accountKey: fixture.accountKey, config: fixture.config)
     }
 
+    func testWrappedRistrettoPrivate() throws {
+        let validRistretto = "3379daf11c7d26bde2be0ab557e79285f868a1e58058ab47063950435fc7670a"
+        let validRistrettoData = try XCTUnwrap(Data(hexEncoded: validRistretto))
+        let validKey = WrappedRistrettoPrivate(validRistrettoData)
+        XCTAssertNotNil(validKey, "Init should succeed")
+    }
+
+    func testWrappedRistrettoPrivateFailure() throws {
+        let invalidRistretto = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        let invalidRistrettoData = try XCTUnwrap(Data(hexEncoded: invalidRistretto))
+        let invalidKey = WrappedRistrettoPrivate(invalidRistrettoData)
+        XCTAssertNil(invalidKey, "Init should fail")
+    }
+    
+    func testWrappedRistrettoPublic() throws {
+        let validRistretto = "c235c13c4dedd808e95f428036716d52561fad7f51ce675f4d4c9c1fa1ea2165"
+        let validRistrettoData = try XCTUnwrap(Data(hexEncoded: validRistretto))
+        let validKey = WrappedRistrettoPublic(validRistrettoData)
+        XCTAssertNotNil(validKey, "Init should succeed")
+    }
+
+    func testWrappedRistrettoPublicFailure() throws {
+        let invalidRistretto = "0e61ca061876b651e6981ad9a74fd5fe8d4af2f6981283bafe4c1ba40c3d0803"
+        let invalidRistrettoData = try XCTUnwrap(Data(hexEncoded: invalidRistretto))
+        let invalidKey = WrappedRistrettoPublic(invalidRistrettoData)
+        XCTAssertNil(invalidKey, "Init should fail")
+    }
 }

--- a/Tests/Unit/MobileCoinClientPublicApiTests.swift
+++ b/Tests/Unit/MobileCoinClientPublicApiTests.swift
@@ -93,7 +93,7 @@ class MobileCoinClientPublicApiTests: XCTestCase {
         let invalidKey = WrappedRistrettoPrivate(invalidRistrettoData)
         XCTAssertNil(invalidKey, "Init should fail")
     }
-    
+
     func testWrappedRistrettoPublic() throws {
         let validRistretto = "c235c13c4dedd808e95f428036716d52561fad7f51ce675f4d4c9c1fa1ea2165"
         let validRistrettoData = try XCTUnwrap(Data(hexEncoded: validRistretto))


### PR DESCRIPTION
### Motivation

We need to make RistrettoPrivate & RistrettoPublic available through the SDK, and add a lower-level API into the DefaultCryptoBox.

### In this PR
* Provide public access to "Wrapped" RistrettoPrivate and RistrettoPublic
* Lower level access to the DefaultCryptoBox

### Notes

Making the internal type RistrettoPrivate & RistrettoPublic `public` would be a higher-impact change that doesn't make sense right now. 
