### PR TITLE
Set up integration tests to run at midnight and for PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,9 @@
 name: integration-tests
 
 on:
+  pull_request:
+  schedule:
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       network:
@@ -53,7 +56,8 @@ jobs:
 
       - name: Set the Network
         env:
-          NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
+          DEFAULT_NETWORK: 'testNet'
+          NETWORK_UNDER_TEST: ${{ github.event.inputs.network || env.DEFAULT_NETWORK }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account
@@ -156,7 +160,8 @@ jobs:
 
       - name: Set the Network
         env:
-          NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
+          DEFAULT_NETWORK: 'testNet'
+          NETWORK_UNDER_TEST: ${{ github.event.inputs.network || env.DEFAULT_NETWORK }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,9 +55,9 @@ jobs:
           bundle check || bundle install
 
       - name: Set the Network
+        if: ${{ github.event.inputs.network }}
         env:
           NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
-        if: ${{ $NETWORK_UNDER_TEST }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account
@@ -159,9 +159,9 @@ jobs:
           bundle check || bundle install
 
       - name: Set the Network
+        if: ${{ github.event.inputs.network }}
         env:
           NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
-        if: ${{ $NETWORK_UNDER_TEST }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Set the Network
         env:
-          DEFAULT_NETWORK: 'testNet'
-          NETWORK_UNDER_TEST: ${{ github.event.inputs.network || env.DEFAULT_NETWORK }}
+          NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
+        if: ${{ $NETWORK_UNDER_TEST }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account
@@ -160,8 +160,8 @@ jobs:
 
       - name: Set the Network
         env:
-          DEFAULT_NETWORK: 'testNet'
-          NETWORK_UNDER_TEST: ${{ github.event.inputs.network || env.DEFAULT_NETWORK }}
+          NETWORK_UNDER_TEST: ${{ github.event.inputs.network }}
+        if: ${{ $NETWORK_UNDER_TEST }}
         run: sed -i '' "s/NetworkPreset = \..*/NetworkPreset = .${NETWORK_UNDER_TEST}/" ./Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
 
       - name: GCP Service Account

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: integration-tests
 on:
   pull_request:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       network:


### PR DESCRIPTION
### Motivation

Early awareness of integration test env data issues, and code errors

### In this PR
* Configure GHA integration tests to run at midnight
* Configure GHA integration tests to run for PRs
