### PR TITLE
Uncomment declaration of alphaDev so GHA can run against alpha

### DIFF
--- a/Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
+++ b/Tests/Integration/Common/Fixtures/NetworkConfigFixtures.swift
@@ -9,8 +9,7 @@ import Foundation
 import XCTest
 
 enum NetworkConfigFixtures {
-//    static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
-//    static let network: NetworkPreset = .dynamic(alphaDev)
+    static let alphaDev = DynamicNetworkConfig.AlphaDevelopment.make()
     static let network: NetworkPreset = .testNet
 }
 


### PR DESCRIPTION
Trivial fix for GHA integration test workflow to be able to run against alpha