### PR TITLE
Fix fee calc bug caused by 0 bal transactions in unspent list

### DIFF
--- a/Sources/Account/Account.swift
+++ b/Sources/Account/Account.swift
@@ -127,6 +127,7 @@ final class Account {
         let txOuts = allTxOutTrackers
             .filter { $0.receivedAndUnspent(asOfBlockCount: knowableBlockCount) }
             .filter { $0.knownTxOut.tokenId == tokenId }
+            .filter { $0.knownTxOut.value > 0 }
             .map { $0.knownTxOut }
         return (txOuts: txOuts, blockCount: knowableBlockCount)
     }


### PR DESCRIPTION
### In this PR
 * Defrag integration test was unexpectedly failing with insufficient funds
 * Funds were available - so test should not have failed
 * Inspection revealed the 0-bal transactions inflating the defrag fee cost
 * Proposed fix here is to filter out 0-bal transactions from unspent txos
 * Alternate fix could be to leave the 0-bal transactions  in the list, and update fee calc logic to exclude

fixes #184740756