### PR TITLE
 Add API for creating a Proof of Reserve SCI

### DIFF
--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Keys (1.0.1)
-  - LibMobileCoin/CoreHTTP (6.0.0-pre1):
+  - LibMobileCoin/CoreHTTP (6.0.2):
     - SwiftProtobuf (~> 1.5)
   - Logging (1.4.0)
   - MobileCoin (6.0.3)
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  LibMobileCoin: 4b89263fc8280242da38ecaf8cbcfa473822c260
+  LibMobileCoin: 8503f567fa32184a5be7bc038fbd727747dd9991
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
   MobileCoin: c64e04cf7eaa17d83efb2f8d69c02d1d53889ffa
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519

--- a/Sources/Common/Account/Account+SCIOperations.swift
+++ b/Sources/Common/Account/Account+SCIOperations.swift
@@ -100,11 +100,12 @@ extension Account {
         }
 
         func createProofOfReserveSignedContingentInput(
-            for txOutPubKeyBytes: Data,
+            txOutPubKeyBytes: Data,
             completion: @escaping (
                 Result<SignedContingentInput, SignedContingentInputCreationError>
             ) -> Void
         ) {
+
             guard let txOutPubKey = RistrettoPublic(txOutPubKeyBytes) else {
                 serialQueue.async {
                     completion(.failure(.invalidInput("Invalid TxOutPubKey")))
@@ -129,7 +130,7 @@ extension Account {
 
                     proofOfReserveSignedContingentInputCreator.createSignedContingentInput(
                         input: txOut,
-                        tombstoneBlockIndex: ledgerBlockCount + 50,
+                        fogTombstoneBlockIndex: ledgerBlockCount + 50,
                         blockVersion: blockVersion) { result in
                         serialQueue.async {
                             completion(result)

--- a/Sources/Common/Account/Account.swift
+++ b/Sources/Common/Account/Account.swift
@@ -195,7 +195,7 @@ final class Account {
         return .success(ownedTxOut)
     }
 
-    private func ownedTxOut(for txOutPublicKey: RistrettoPublic) -> KnownTxOut? {
+    func ownedTxOut(for txOutPublicKey: RistrettoPublic) -> KnownTxOut? {
         ownedTxOuts.first(where: { $0.publicKey == txOutPublicKey })
     }
 }

--- a/Sources/Common/Account/AccountKey.swift
+++ b/Sources/Common/Account/AccountKey.swift
@@ -78,7 +78,7 @@ public struct AccountKey {
 
     /// - Returns: `nil` when the input is not deserializable.
     public init?(serializedData: Data) {
-        guard let proto = try? External_AccountKey(serializedBytes: serializedData) else {
+        guard let proto = try? External_AccountKey(serializedData: serializedData) else {
             logger.error("External_AccountKey deserialization failed.", logFunction: false)
             return nil
         }

--- a/Sources/Common/Account/PublicAddress.swift
+++ b/Sources/Common/Account/PublicAddress.swift
@@ -40,7 +40,7 @@ public struct PublicAddress {
 
     /// - Returns: `nil` when the input is not deserializable.
     public init?(serializedData: Data) {
-        guard let proto = try? External_PublicAddress(serializedBytes: serializedData) else {
+        guard let proto = try? External_PublicAddress(serializedData: serializedData) else {
             logger.warning("External_PublicAddress deserialization failed. serializedData: " +
                 "\(redacting: serializedData.base64EncodedString())")
             return nil

--- a/Sources/Common/Encodings/PrintableWrapper+Base58.swift
+++ b/Sources/Common/Encodings/PrintableWrapper+Base58.swift
@@ -21,7 +21,7 @@ extension Printable_PrintableWrapper {
             return nil
         }
 
-        guard let printableWrapper = try? Self(serializedBytes: decodedData) else {
+        guard let printableWrapper = try? Self(serializedData: decodedData) else {
             logger.warning("Printable_PrintableWrapper deserialization failed.")
             return nil
         }

--- a/Sources/Common/Fog/View/FogViewUtils.swift
+++ b/Sources/Common/Fog/View/FogViewUtils.swift
@@ -32,7 +32,7 @@ enum FogViewUtils {
             ciphertext: ciphertext,
             privateKey: accountKey.subaddressViewPrivateKey
         ).flatMap { decrypted in
-            guard let txOutRecord = try? FogView_TxOutRecord(serializedBytes: decrypted) else {
+            guard let txOutRecord = try? FogView_TxOutRecord(serializedData: decrypted) else {
                 return .failure(.invalidInput("FogView_TxOutRecord deserialization failed. " +
                     "serializedData: \(redacting: decrypted.base64EncodedString())"))
             }

--- a/Sources/Common/Ledger/LedgerTxOut.swift
+++ b/Sources/Common/Ledger/LedgerTxOut.swift
@@ -61,8 +61,8 @@ extension LedgerTxOut {
 extension LedgerTxOut {
     init?(_ fogTxOutRecordBytes: Data, viewKey: RistrettoPrivate) {
         let legacy_txOutRecord = try? FogView_TxOutRecordLegacy(
-            serializedBytes: fogTxOutRecordBytes)
-        let txOutRecord = try? FogView_TxOutRecord(serializedBytes: fogTxOutRecordBytes)
+            serializedData: fogTxOutRecordBytes)
+        let txOutRecord = try? FogView_TxOutRecord(serializedData: fogTxOutRecordBytes)
 
         // TODO - Temporary fix for serialized data, find workaround and remove legacy proto
         switch (legacy_txOutRecord, txOutRecord) {

--- a/Sources/Common/Ledger/TxOut.swift
+++ b/Sources/Common/Ledger/TxOut.swift
@@ -20,7 +20,7 @@ struct TxOut: TxOutProtocol {
 
     /// - Returns: `nil` when the input is not deserializable.
     init?(serializedData: Data) {
-        guard let proto = try? External_TxOut(serializedBytes: serializedData) else {
+        guard let proto = try? External_TxOut(serializedData: serializedData) else {
             logger.warning(
                 "External_TxOut deserialization failed. serializedData: " +
                     "\(redacting: serializedData.base64EncodedString())",

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -195,6 +195,33 @@ public final class MobileCoinClient {
         ).requiresDefragmentation(toSendAmount: amount, feeLevel: feeLevel, completion: completion)
     }
 
+    public func createProofOfReserveSignedContingentInput(
+        txOutPubKeyBytes: Data,
+        completion: @escaping (
+            Result<SignedContingentInput, SignedContingentInputCreationError>
+        ) -> Void
+    ) {
+        guard let rngSeed = defaultRng.generateRngSeed() else {
+            completion(.failure(
+                SignedContingentInputCreationError.invalidInput("Couldn't create 32byte RNG seed")))
+            return
+        }
+
+        Account.SCIOperations(
+            account: accountLock,
+            fogMerkleProofService: serviceProvider.fogMerkleProofService,
+            fogResolverManager: fogResolverManager,
+            metaFetcher: metaFetcher,
+            txOutSelectionStrategy: txOutSelectionStrategy,
+            mixinSelectionStrategy: mixinSelectionStrategy,
+            rngSeed: rngSeed,
+            targetQueue: serialQueue
+        ).createProofOfReserveSignedContingentInput(
+            txOutPubKeyBytes: txOutPubKeyBytes,
+            completion: completion
+        )
+    }
+
     public func createSignedContingentInput(
         recipient: PublicAddress,
         amountToSend: Amount,

--- a/Sources/Common/Transaction/ProofOfReserveSignedContingentInputCreator.swift
+++ b/Sources/Common/Transaction/ProofOfReserveSignedContingentInputCreator.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//  Copyright (c) 2020-2025 MobileCoin. All rights reserved.
 //
 
 // swiftlint:disable function_parameter_count multiline_function_chains function_body_length
@@ -36,7 +36,7 @@ struct ProofOfReserveSignedContingentInputCreator {
 
     func createSignedContingentInput(
         input: KnownTxOut,
-        tombstoneBlockIndex: UInt64,
+        fogTombstoneBlockIndex: UInt64,
         blockVersion: BlockVersion,
         completion: @escaping (
             Result<SignedContingentInput, SignedContingentInputCreationError>
@@ -45,7 +45,7 @@ struct ProofOfReserveSignedContingentInputCreator {
         performAsync(body1: { callback in
             fogResolverManager.fogResolver(
                 addresses: [selfPaymentAddress],
-                desiredMinPubkeyExpiry: tombstoneBlockIndex,
+                desiredMinPubkeyExpiry: fogTombstoneBlockIndex,
                 completion: callback)
         }, body2: { callback in
             prepareInput(input: input, completion: callback)
@@ -57,7 +57,9 @@ struct ProofOfReserveSignedContingentInputCreator {
                         accountKey: self.accountKey,
                         memoType: .recoverable,
                         amountToSend: input.amount,
+                        // UInt64.max to make this SCI not spendable
                         amountToReceive: Amount(value: UInt64.max, tokenId: input.tokenId),
+                        // Block index in the past to make this SCI not spendable
                         tombstoneBlockIndex: 1,
                         fogResolver: fogResolver,
                         blockVersion: blockVersion,

--- a/Sources/Common/Transaction/ProofOfReserveSignedContingentInputCreator.swift
+++ b/Sources/Common/Transaction/ProofOfReserveSignedContingentInputCreator.swift
@@ -1,0 +1,126 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+
+// swiftlint:disable function_parameter_count multiline_function_chains function_body_length
+// swiftlint:disable array_init
+
+import Foundation
+
+struct ProofOfReserveSignedContingentInputCreator {
+    private let serialQueue: DispatchQueue
+    private let accountKey: AccountKey
+    private let selfPaymentAddress: PublicAddress
+    private let fogResolverManager: FogResolverManager
+    private let fogMerkleProofFetcher: FogMerkleProofFetcher
+    private let rng: MobileCoinRng
+
+    init(
+        accountKey: AccountKey,
+        fogMerkleProofService: FogMerkleProofService,
+        fogResolverManager: FogResolverManager,
+        rngSeed: RngSeed,
+        targetQueue: DispatchQueue?
+    ) {
+        self.serialQueue = DispatchQueue(
+            label: "com.mobilecoin.\(Account.self).\(Self.self)",
+            target: targetQueue)
+        self.accountKey = accountKey
+        self.selfPaymentAddress = accountKey.publicAddress
+        self.fogResolverManager = fogResolverManager
+        self.fogMerkleProofFetcher = FogMerkleProofFetcher(
+            fogMerkleProofService: fogMerkleProofService,
+            targetQueue: targetQueue)
+        self.rng = MobileCoinChaCha20Rng(rngSeed: rngSeed)
+    }
+
+    func createSignedContingentInput(
+        input: KnownTxOut,
+        tombstoneBlockIndex: UInt64,
+        blockVersion: BlockVersion,
+        completion: @escaping (
+            Result<SignedContingentInput, SignedContingentInputCreationError>
+        ) -> Void
+    ) {
+        performAsync(body1: { callback in
+            fogResolverManager.fogResolver(
+                addresses: [selfPaymentAddress],
+                desiredMinPubkeyExpiry: tombstoneBlockIndex,
+                completion: callback)
+        }, body2: { callback in
+            prepareInput(input: input, completion: callback)
+        }, completion: {
+            completion($0.mapError { .connectionError($0) }
+                .flatMap { fogResolver, preparedInput in
+                    SignedContingentInputBuilder.build(
+                        inputs: [preparedInput],
+                        accountKey: self.accountKey,
+                        memoType: .recoverable,
+                        amountToSend: input.amount,
+                        amountToReceive: Amount(value: UInt64.max, tokenId: input.tokenId),
+                        tombstoneBlockIndex: 1,
+                        fogResolver: fogResolver,
+                        blockVersion: blockVersion,
+                        rng: self.rng
+                    ).mapError { .invalidInput(String(describing: $0)) }
+                })
+        })
+    }
+
+    private func prepareInput(
+        input: KnownTxOut,
+        ledgerTxOutCount: UInt64? = nil,
+        merkleRootBlock: UInt64? = nil,
+        completion: @escaping (Result<PreparedTxInput, ConnectionError>) -> Void
+    ) {
+        fogMerkleProofFetcher.getOutputs(
+            globalIndicesArray: [[input.globalIndex]],
+            merkleRootBlock: input.block.index,
+            maxNumIndicesPerQuery: 100
+        ) {
+            self.processFetchResults(
+                $0,
+                input: input,
+                ledgerTxOutCount: ledgerTxOutCount,
+                completion: completion)
+        }
+    }
+
+    private func processFetchResults(
+        _ results: Result<[[(TxOut, TxOutMembershipProof)]], FogMerkleProofFetcherError>,
+        input: KnownTxOut,
+        ledgerTxOutCount: UInt64?,
+        completion: @escaping (Result<PreparedTxInput, ConnectionError>) -> Void
+    ) {
+        switch results {
+        case .success(let inputsMixinOutputs):
+            completion(PreparedTxInput.make(knownTxOut: input, ring: inputsMixinOutputs[0])
+                .mapError { .invalidServerResponse(String(describing: $0)) })
+        case .failure(let error):
+            switch error {
+            case .connectionError(let connectionError):
+                logger.error("FetchMerkleProofs error: \(connectionError)", logFunction: false)
+                completion(.failure(connectionError))
+            case let .outOfBounds(blockCount: blockCount, ledgerTxOutCount: responseTxOutCount):
+                if let ledgerTxOutCount = ledgerTxOutCount {
+                    let errorMessage = "Fog GetMerkleProof returned doesNotExist, even though " +
+                        "txo indices were limited by globalTxoCount returned by previous call to " +
+                        "GetMerkleProof. Previously returned globalTxoCount: " +
+                        "\(ledgerTxOutCount), response globalTxoCount: " +
+                        "\(responseTxOutCount), response blockCount: \(blockCount)"
+                    logger.error(errorMessage, logFunction: false)
+                    completion(.failure(.invalidServerResponse(errorMessage)))
+                } else {
+                    // Retry, making sure we limit mixin indices to txo count
+                    // returned by the server. Uses blockCount returned by server for
+                    // merkleRootBlock.
+                    prepareInput(
+                        input: input,
+                        ledgerTxOutCount: responseTxOutCount,
+                        merkleRootBlock: blockCount,
+                        completion: completion)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Common/Transaction/Receipt.swift
+++ b/Sources/Common/Transaction/Receipt.swift
@@ -44,7 +44,7 @@ public struct Receipt {
 
     /// - Returns: `nil` when the input is not deserializable.
     public init?(serializedData: Data) {
-        guard let proto = try? External_Receipt(serializedBytes: serializedData) else {
+        guard let proto = try? External_Receipt(serializedData: serializedData) else {
             logger.warning(
                 "External_Receipt deserialization failed. serializedData: " +
                     "\(redacting: serializedData.base64EncodedString())",
@@ -70,7 +70,7 @@ public struct Receipt {
     func matchesTxOut(_ txOut: TxOutProtocol) -> Bool {
         txOutPublicKeyTyped == txOut.publicKey
             && commitment == txOut.commitment
-            // TODO - verify with core-eng that commitment is sufficient, 
+            // TODO - verify with core-eng that commitment is sufficient,
             // remove after confirmation
     }
     // swiftlint:enable todo

--- a/Sources/Common/Transaction/SignedContingentInput.swift
+++ b/Sources/Common/Transaction/SignedContingentInput.swift
@@ -19,7 +19,7 @@ public struct SignedContingentInput {
 
     /// - Returns: `nil` when the input is not deserializable.
     public init?(serializedData: Data) {
-        guard let proto = try? External_SignedContingentInput(serializedBytes: serializedData) else {
+        guard let proto = try? External_SignedContingentInput(serializedData: serializedData) else {
             logger.warning("External_SignedContingentInput deserialization failed. " +
                 "serializedData: \(redacting: serializedData.base64EncodedString())")
             return nil

--- a/Sources/Common/Transaction/SignedContingentInput.swift
+++ b/Sources/Common/Transaction/SignedContingentInput.swift
@@ -89,7 +89,7 @@ extension SignedContingentInput {
         // Generally the amount we are getting from the SCI (pseudoOutputAmount) will be greater than the change
         // amount, otherwise there is no point in using it.
         // However, there is one special case where that is not the case: Proof of Reserve SCIs.
-        // For proof of reserve SCIs the change amount ends up being set to u64::MAX so make them unspendable,
+        // For proof of reserve SCIs the change amount ends up being set to u64::MAX to make them unspendable,
         // and that would make the change amount greater than the pseudo output amount and we would end up with
         // an overflow when calculating the reward amount, so we have a conditional here to protect against that.
         self.rewardAmount = pseudoOutputAmount.value > changeAmount.value ?

--- a/Sources/Common/Transaction/SignedContingentInput.swift
+++ b/Sources/Common/Transaction/SignedContingentInput.swift
@@ -86,7 +86,15 @@ extension SignedContingentInput {
         self.changeAmount = requiredOutputAmounts.first(where: { $0.tokenId == changeTokenId }) ??
             Amount(0, in: changeTokenId )
 
-        self.rewardAmount = Amount(pseudoOutputAmount.value - changeAmount.value, in: changeTokenId)
+        // Generally the amount we are getting from the SCI (pseudoOutputAmount) will be greater than the change
+        // amount, otherwise there is no point in using it.
+        // However, there is one special case where that is not the case: Proof of Reserve SCIs.
+        // For proof of reserve SCIs the change amount ends up being set to u64::MAX so make them unspendable,
+        // and that would make the change amount greater than the pseudo output amount and we would end up with
+        // an overflow when calculating the reward amount, so we have a conditional here to protect against that.
+        self.rewardAmount = pseudoOutputAmount.value > changeAmount.value ?
+            Amount(pseudoOutputAmount.value - changeAmount.value, in: changeTokenId) :
+            Amount(0, in: changeTokenId)
 
         self.requiredAmount = requiredOutputAmounts.first(where: { $0.tokenId != changeTokenId }) ??
         Amount(0, in: changeTokenId)

--- a/Sources/Common/Transaction/Transaction.swift
+++ b/Sources/Common/Transaction/Transaction.swift
@@ -15,7 +15,7 @@ public struct Transaction {
 
     /// - Returns: `nil` when the input is not deserializable.
     public init?(serializedData: Data) {
-        guard let proto = try? External_Tx(serializedBytes: serializedData) else {
+        guard let proto = try? External_Tx(serializedData: serializedData) else {
             logger.warning("External_Tx deserialization failed. serializedData: " +
                 "\(redacting: serializedData.base64EncodedString())")
             return nil

--- a/Sources/GRPC/GRPC/GrpcConnection/GrpcCallable/AttestedGrpcCallable.swift
+++ b/Sources/GRPC/GRPC/GrpcConnection/GrpcCallable/AttestedGrpcCallable.swift
@@ -86,7 +86,7 @@ extension AttestedGrpcCallable
         return attestAkeCipher.decryptMessage(response)
             .mapError { _ in .attestationFailure() }
             .flatMap { plaintext in
-                guard let response = try? InnerResponse(serializedBytes: plaintext) else {
+                guard let response = try? InnerResponse(serializedData: plaintext) else {
                     return .failure(.connectionError(.invalidServerResponse(
                         "Failed to deserialized attested message plaintext into " +
                             "\(InnerResponse.self). plaintext: " +
@@ -126,7 +126,7 @@ extension AttestedGrpcCallable
     ) -> Result < (responseAad: InnerResponseAad, response: InnerResponse),
                 AttestedGrpcConnectionError>
     {
-        guard let responseAad = try? InnerResponseAad(serializedBytes: response.aad) else {
+        guard let responseAad = try? InnerResponseAad(serializedData: response.aad) else {
             return .failure(.connectionError(.invalidServerResponse(
                 "Failed to deserialized attested message aad into \(InnerResponseAad.self). aad: " +
                     "\(redacting: response.aad.base64EncodedString())")))
@@ -135,7 +135,7 @@ extension AttestedGrpcCallable
         return attestAkeCipher.decryptMessage(response)
             .mapError { _ in .attestationFailure() }
             .flatMap { plaintext in
-                guard let plaintextResponse = try? InnerResponse(serializedBytes: plaintext) else {
+                guard let plaintextResponse = try? InnerResponse(serializedData: plaintext) else {
                     return .failure(.connectionError(.invalidServerResponse(
                         "Failed to deserialized attested message plaintext into " +
                             "\(InnerResponse.self). plaintext: " +

--- a/Sources/HTTPS/HttpConnection/HttpCallable/AttestedHttpCallable.swift
+++ b/Sources/HTTPS/HttpConnection/HttpCallable/AttestedHttpCallable.swift
@@ -86,7 +86,7 @@ extension AttestedHttpCallable
         return attestAkeCipher.decryptMessage(response)
             .mapError { _ in .attestationFailure() }
             .flatMap { plaintext in
-                guard let response = try? InnerResponse(serializedBytes: plaintext) else {
+                guard let response = try? InnerResponse(serializedData: plaintext) else {
                     return .failure(.connectionError(.invalidServerResponse(
                         "Failed to deserialized attested message plaintext into " +
                             "\(InnerResponse.self). plaintext: " +
@@ -126,7 +126,7 @@ extension AttestedHttpCallable
     ) -> Result < (responseAad: InnerResponseAad, response: InnerResponse),
                 AttestedHttpConnectionError>
     {
-        guard let responseAad = try? InnerResponseAad(serializedBytes: response.aad) else {
+        guard let responseAad = try? InnerResponseAad(serializedData: response.aad) else {
             return .failure(.connectionError(.invalidServerResponse(
                 "Failed to deserialized attested message aad into \(InnerResponseAad.self). aad: " +
                     "\(redacting: response.aad.base64EncodedString())")))
@@ -135,7 +135,7 @@ extension AttestedHttpCallable
         return attestAkeCipher.decryptMessage(response)
             .mapError { _ in .attestationFailure() }
             .flatMap { plaintext in
-                guard let plaintextResponse = try? InnerResponse(serializedBytes: plaintext) else {
+                guard let plaintextResponse = try? InnerResponse(serializedData: plaintext) else {
                     return .failure(.connectionError(.invalidServerResponse(
                         "Failed to deserialized attested message plaintext into " +
                             "\(InnerResponse.self). plaintext: " +

--- a/Sources/HTTPS/RestApiRequester.swift
+++ b/Sources/HTTPS/RestApiRequester.swift
@@ -72,7 +72,7 @@ extension RestApiRequester: Requester {
 
                 let responsePayload: T.ResponsePayload? = {
                     guard let data = httpResponse.responseData,
-                          let responsePayload = try? T.ResponsePayload(serializedBytes: data)
+                          let responsePayload = try? T.ResponsePayload(serializedData: data)
                     else {
                         return nil
                     }


### PR DESCRIPTION
### Motivation

We want Sentz to be able to generate Proof of Reserve SCIs. In order to do that, the `mobilecoin_flutter_plugin` needs to support that, and in order for it to support it, the underlying `MobileCoin-Swift` (and [`android-sdk`](https://github.com/mobilecoinofficial/android-sdk/pull/144)) components need to support that.

### In this PR
* A helper method for creating a Proof of Reserve SCI
* I had to rename a bunch of `serializedBytes: ` instances to `serializedData: ` since the code wouldn't build without this.