### PR TITLE
chore(SENTZ-5436): bump pod version to 6.0.6

### DIFF
--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - Keys (1.0.1)
   - LibMobileCoin/CoreHTTP (6.0.2):
     - SwiftProtobuf (~> 1.5)
-  - MobileCoin (6.0.5)
-  - MobileCoin/CoreHTTP (6.0.5):
+  - MobileCoin (6.0.6)
+  - MobileCoin/CoreHTTP (6.0.6):
     - LibMobileCoin/CoreHTTP (~> 6.0.0-pre1)
     - SwiftLint
     - SwiftProtobuf (~> 1.28)
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (6.0.5):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (6.0.6):
     - LibMobileCoin/CoreHTTP (~> 6.0.0-pre1)
     - SwiftLint
     - SwiftProtobuf (~> 1.28)
-  - MobileCoin/IntegrationNonTransactingTests (6.0.5)
-  - MobileCoin/IntegrationTransactingTests (6.0.5)
-  - MobileCoin/PerformanceTests (6.0.5)
-  - MobileCoin/Tests (6.0.5)
+  - MobileCoin/IntegrationNonTransactingTests (6.0.6)
+  - MobileCoin/IntegrationTransactingTests (6.0.6)
+  - MobileCoin/PerformanceTests (6.0.6)
+  - MobileCoin/Tests (6.0.6)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.38.1)
 
@@ -47,7 +47,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8503f567fa32184a5be7bc038fbd727747dd9991
-  MobileCoin: 5ac0adf5e856e2f50392c8c6a3d4993d351bbadd
+  MobileCoin: c7c510515736c9b56fa6a7386097e2cbb0eae5b7
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 409d3aaec90e51b1705b1dd8065b56893450e77c
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "6.0.5"
+  s.version      = "6.0.6"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"


### PR DESCRIPTION
* Bump s.version in MobileCoin.podspec to 6.0.6.
* Regenerate ExampleHTTP/Podfile.lock in lockstep, since CI installs pods in deployment mode and fails on a stale lock.