### PR TITLE
ci(SENTZ-5434): Keep generated test credentials out of the Actions cache

### DIFF
--- a/.github/actions/setup-macos-ci/action.yml
+++ b/.github/actions/setup-macos-ci/action.yml
@@ -91,14 +91,8 @@ runs:
         bundle config set --local clean 'true'
         bundle check || bundle install --jobs 4 --retry 3
 
-    - name: Restore CocoaPods cache
-      if: inputs.install-pods == 'true'
-      uses: actions/cache@v4
-      with:
-        path: ExampleHTTP/Pods
-        key: v1-example-http-pods-${{ hashFiles('ExampleHTTP/Podfile.lock') }}
-        restore-keys: |
-          v1-example-http-pods-
+    # `Pods/CocoaPodsKeys` holds the generated test credentials, so no cache may
+    # carry it: a cache saved on master is restorable by a fork pull request.
 
     # cocoapods-keys resolves each key from ENV before falling back to the
     # keychain, so the caller only needs to export the key names as job env.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,25 @@ jobs:
           submodules: recursive
           lfs: true
 
+      # A blank secret reaches the build as an empty key rather than an error,
+      # so this runs ahead of everything that consumes one.
+      - name: Report test credential availability
+        run: |
+          set -euo pipefail
+          missing=""
+          for key in devNetworkAuthUsername devNetworkAuthPassword \
+                     testNetTestAccountMnemonicsCommaSeparated \
+                     mobileDevTestAccountMnemonicsCommaSeparated \
+                     dynamicTestAccountSeedEntropiesCommaSeparated \
+                     dynamicFogAuthoritySpki; do
+            if [[ -z "${!key:-}" ]]; then
+              missing="${missing:+${missing}, }${key}"
+            fi
+          done
+          if [[ -n "${missing}" ]]; then
+            echo "::notice title=Blank test credentials::${missing}"
+          fi
+
       - name: Setup
         uses: ./.github/actions/setup-macos-ci
 


### PR DESCRIPTION
cocoapods-keys writes the six test credentials into `ExampleHTTP/Pods/CocoaPodsKeys/MobileCoinKeys.m` on every run. The setup action cached that whole tree under a key derived from the committed `Podfile.lock`, with a bare prefix restore-key. A pull request from a fork could restore the entry master saved and read the file. This drops the Pods cache rather than trying to exclude a path from it. The plugin regenerates the keys on every run, so nothing downstream needs them restored. A second step names any blank credential before the build starts, so a fork run says what it is missing instead of failing opaquely later.

Notes:

- Every cache entry holding the generated keys has been deleted. Master still runs the cache step, so the next master build whose `ExampleHTTP/Podfile.lock` hash has no exact key hit saves a fresh one, and one final deletion is needed once this merges. The credentials themselves are not rotated.
- The tree could be cached safely by restoring it, deleting the generated keys and saving after the build. Rejected on cost: three moving parts to keep a warm setup that already runs in under twenty seconds.
- No fork pull request has ever run this workflow. The change rests on GitHub exporting an unavailable secret as an empty variable rather than omitting it, which is what `cocoapods-keys` needs to skip its keychain lookup. Static reading says every required job still passes, and the first real fork run is what settles it.
- Evidence for all of the above is on SENTZ-5434.
