### PR TITLE
Derive pub key from rng seed

### DIFF
--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -395,6 +395,90 @@ public final class MobileCoinClient {
         }
     }
 
+    /// Derives the payload and change TxOut public keys a transaction built
+    /// with `rng` would produce, without building one.
+    ///
+    /// Intended for learning a TxOut public key before the transaction exists
+    /// — for instance to tell a third party which output to expect. Passing
+    /// the same `rng` to `prepareTransaction` later produces the same keys.
+    ///
+    /// No balance is required: inputs are what need funds, and none are added.
+    /// Fog reports and the block version are fetched, so this makes network
+    /// calls and can fail like any other fog operation.
+    ///
+    /// `amount` and `fee` are what the eventual transaction will carry. They
+    /// do not affect the keys, but the recipient does, and so does `memoType`
+    /// insofar as it must match what the transaction is built with.
+    public func txOutContexts(
+        to recipient: PublicAddress,
+        memoType: MemoType = .recoverable,
+        amount: Amount,
+        fee: UInt64,
+        rng: MobileCoinRng,
+        completion: @escaping (
+            Result<(payload: TxOutContext, change: TxOutContext), TransactionPreparationError>
+        ) -> Void
+    ) {
+        guard let rngSeed = rng.generateRngSeed() else {
+            completion(.failure(
+                TransactionPreparationError.invalidInput("Could not create 32-byte RNG seed")))
+            return
+        }
+
+        let (accountKey, ledgerBlockCount) = accountLock.readSync {
+            ($0.accountKey, $0.knowableBlockCount)
+        }
+
+        // Same overload and arguments the real path uses in
+        // TransactionPreparer: the expiry decides which fog pubkeys resolve,
+        // and that decides whether each output draws a real hint or a fake
+        // one, which are different numbers of draws.
+        let tombstoneBlockIndex = ledgerBlockCount + 50
+
+        fogResolverManager.fogResolver(
+            addresses: [recipient, accountKey.publicAddress],
+            desiredMinPubkeyExpiry: tombstoneBlockIndex
+        ) { fogResolverResult in
+            switch fogResolverResult {
+            case .failure(let error):
+                self.callbackQueue.async {
+                    completion(.failure(.connectionError(error)))
+                }
+            case .success(let fogResolver):
+                self.metaFetcher.blockVersion { blockVersionResult in
+                    switch blockVersionResult {
+                    case .failure(let error):
+                        self.callbackQueue.async {
+                            completion(.failure(.connectionError(error)))
+                        }
+                    case .success(let blockVersion):
+                        let context = TransactionBuilder.Context(
+                            accountKey: accountKey,
+                            blockVersion: blockVersion,
+                            fogResolver: fogResolver,
+                            memoType: memoType,
+                            tombstoneBlockIndex: tombstoneBlockIndex,
+                            fee: Amount(fee, in: amount.tokenId),
+                            rngSeed: rngSeed)
+
+                        let result = TransactionBuilder.txOutContexts(
+                            context: context,
+                            recipient: recipient,
+                            amount: amount
+                        ).mapError { error in
+                            TransactionPreparationError.invalidInput(
+                                error.localizedDescription)
+                        }
+
+                        self.callbackQueue.async {
+                            completion(result)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public func prepareDefragmentationStepTransactions(
         toSendAmount amount: Amount,
         recoverableMemo: Bool = false,

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -444,7 +444,6 @@ public final class MobileCoinClient {
             case .success(let fogResolver):
                 self.deriveTxOutContexts(
                     to: recipient,
-                    accountKey: accountKey,
                     fogResolver: fogResolver,
                     tombstoneBlockIndex: tombstoneBlockIndex,
                     rngSeed: rngSeed,
@@ -455,7 +454,6 @@ public final class MobileCoinClient {
 
     private func deriveTxOutContexts(
         to recipient: PublicAddress,
-        accountKey: AccountKey,
         fogResolver: FogResolver,
         tombstoneBlockIndex: UInt64,
         rngSeed: RngSeed,
@@ -469,7 +467,7 @@ public final class MobileCoinClient {
                 self.finish(.failure(.connectionError(error)), completion)
             case .success(let blockVersion):
                 let context = TransactionBuilder.Context(
-                    accountKey: accountKey,
+                    accountKey: self.accountLock.readSync { $0.accountKey },
                     blockVersion: blockVersion,
                     fogResolver: fogResolver,
                     memoType: .recoverable,

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -500,7 +500,10 @@ public final class MobileCoinClient {
                 self.finish(
                     TransactionBuilder.txOutContexts(context: context, recipient: recipient)
                         .mapError {
-                            TransactionPreparationError.invalidInput($0.localizedDescription)
+                            // TransactionBuilderError is CustomStringConvertible
+                            // and not LocalizedError, so localizedDescription
+                            // would drop the reason for a Foundation default.
+                            TransactionPreparationError.invalidInput(String(describing: $0))
                         },
                     completion)
             }

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -437,10 +437,21 @@ public final class MobileCoinClient {
             ($0.accountKey, $0.knowableBlockCount)
         }
 
-        // Same overload and arguments the real path uses in
-        // TransactionPreparer: the expiry decides which fog pubkeys resolve,
-        // and that decides whether each output draws a real hint or a fake
-        // one, which are different numbers of draws.
+        // An expiry is needed to resolve fog and to fill the builder context,
+        // but it does not reach the keys, so it does not have to match the one
+        // the send later computes from a higher block count.
+        //
+        // add_output draws exactly twice: create_fog_hint, then `r`, with only
+        // a token-id check between them. create_fog_hint branches on whether
+        // the recipient has a fog report url rather than on the expiry, and
+        // returns the pubkey expiry as a value rather than spending it on the
+        // rng. So a different pubkey resolving changes what the hint encrypts
+        // to and nothing else — `r`, and the key built from it, are the same.
+        // An expiry nothing can satisfy fails resolution outright rather than
+        // quietly moving a draw.
+        //
+        // This uses the same overload the real path does so resolution behaves
+        // the same way, not because the keys depend on it.
         let tombstoneBlockIndex = ledgerBlockCount + 50
 
         fogResolverManager.fogResolver(

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -406,14 +406,13 @@ public final class MobileCoinClient {
     /// Fog reports and the block version are fetched, so this makes network
     /// calls and can fail like any other fog operation.
     ///
-    /// `amount` and `fee` are what the eventual transaction will carry. They
-    /// do not affect the keys, but the recipient does, and so does `memoType`
-    /// insofar as it must match what the transaction is built with.
+    /// Takes only what a key depends on. A TxOut public key is `r * D`: `r`
+    /// comes from `rng` and the order of the builder's draws, `D` from the
+    /// recipient's subaddress. Amounts, fees and memos reach neither, so they
+    /// are not parameters — passing the ones the eventual transaction carries
+    /// would not change the answer.
     public func txOutContexts(
         to recipient: PublicAddress,
-        memoType: MemoType = .recoverable,
-        amount: Amount,
-        fee: UInt64,
         rng: MobileCoinRng,
         completion: @escaping (
             Result<(payload: TxOutContext, change: TxOutContext), TransactionPreparationError>
@@ -456,15 +455,16 @@ public final class MobileCoinClient {
                             accountKey: accountKey,
                             blockVersion: blockVersion,
                             fogResolver: fogResolver,
-                            memoType: memoType,
+                            memoType: .recoverable,
                             tombstoneBlockIndex: tombstoneBlockIndex,
-                            fee: Amount(fee, in: amount.tokenId),
+                            // No amount reaches a draw, so any fee gives the
+                            // same keys; zero avoids implying otherwise.
+                            fee: Amount(0, in: .MOB),
                             rngSeed: rngSeed)
 
                         let result = TransactionBuilder.txOutContexts(
                             context: context,
-                            recipient: recipient,
-                            amount: amount
+                            recipient: recipient
                         ).mapError { error in
                             TransactionPreparationError.invalidInput(
                                 error.localizedDescription)

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -395,30 +395,39 @@ public final class MobileCoinClient {
         }
     }
 
-    /// Derives the payload and change TxOut public keys a transaction built
-    /// with `rng` would produce, without building one.
+    /// Derives the payload and change TxOut public keys the transaction built
+    /// from `rngSeed` will produce, without building one.
     ///
     /// Intended for learning a TxOut public key before the transaction exists
-    /// — for instance to tell a third party which output to expect. Passing
-    /// the same `rng` to `prepareTransaction` later produces the same keys.
+    /// — for instance to tell a third party which output to expect.
+    ///
+    /// Takes the seed rather than an rng on purpose. `prepareTransaction`
+    /// derives its builder seed by consuming four draws from the rng it is
+    /// given, so handing one instance to both calls would advance it in
+    /// between and derive two different seeds — the transaction would carry
+    /// keys other than the ones reported here, with nothing failing on either
+    /// side. Send with `prepareTransaction(rng: MobileCoinChaCha20Rng(rngSeed:
+    /// seed))` on this same seed and the keys match.
     ///
     /// No balance is required: inputs are what need funds, and none are added.
     /// Fog reports and the block version are fetched, so this makes network
     /// calls and can fail like any other fog operation.
     ///
     /// Takes only what a key depends on. A TxOut public key is `r * D`: `r`
-    /// comes from `rng` and the order of the builder's draws, `D` from the
+    /// comes from the seed and the order of the builder's draws, `D` from the
     /// recipient's subaddress. Amounts, fees and memos reach neither, so they
     /// are not parameters — passing the ones the eventual transaction carries
     /// would not change the answer.
     public func txOutContexts(
         to recipient: PublicAddress,
-        rng: MobileCoinRng,
+        rngSeed: RngSeed,
         completion: @escaping (
             Result<(payload: TxOutContext, change: TxOutContext), TransactionPreparationError>
         ) -> Void
     ) {
-        guard let rngSeed = rng.generateRngSeed() else {
+        // The same hop prepareTransaction makes, on a fresh rng, so the two
+        // reach the same builder seed from the same caller seed.
+        guard let builderSeed = MobileCoinChaCha20Rng(rngSeed: rngSeed).generateRngSeed() else {
             completion(.failure(
                 TransactionPreparationError.invalidInput("Could not create 32-byte RNG seed")))
             return
@@ -446,7 +455,7 @@ public final class MobileCoinClient {
                     to: recipient,
                     fogResolver: fogResolver,
                     tombstoneBlockIndex: tombstoneBlockIndex,
-                    rngSeed: rngSeed,
+                    rngSeed: builderSeed,
                     completion: completion)
             }
         }

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -440,43 +440,60 @@ public final class MobileCoinClient {
         ) { fogResolverResult in
             switch fogResolverResult {
             case .failure(let error):
-                self.callbackQueue.async {
-                    completion(.failure(.connectionError(error)))
-                }
+                self.finish(.failure(.connectionError(error)), completion)
             case .success(let fogResolver):
-                self.metaFetcher.blockVersion { blockVersionResult in
-                    switch blockVersionResult {
-                    case .failure(let error):
-                        self.callbackQueue.async {
-                            completion(.failure(.connectionError(error)))
-                        }
-                    case .success(let blockVersion):
-                        let context = TransactionBuilder.Context(
-                            accountKey: accountKey,
-                            blockVersion: blockVersion,
-                            fogResolver: fogResolver,
-                            memoType: .recoverable,
-                            tombstoneBlockIndex: tombstoneBlockIndex,
-                            // No amount reaches a draw, so any fee gives the
-                            // same keys; zero avoids implying otherwise.
-                            fee: Amount(0, in: .MOB),
-                            rngSeed: rngSeed)
-
-                        let result = TransactionBuilder.txOutContexts(
-                            context: context,
-                            recipient: recipient
-                        ).mapError { error in
-                            TransactionPreparationError.invalidInput(
-                                error.localizedDescription)
-                        }
-
-                        self.callbackQueue.async {
-                            completion(result)
-                        }
-                    }
-                }
+                self.deriveTxOutContexts(
+                    to: recipient,
+                    accountKey: accountKey,
+                    fogResolver: fogResolver,
+                    tombstoneBlockIndex: tombstoneBlockIndex,
+                    rngSeed: rngSeed,
+                    completion: completion)
             }
         }
+    }
+
+    private func deriveTxOutContexts(
+        to recipient: PublicAddress,
+        accountKey: AccountKey,
+        fogResolver: FogResolver,
+        tombstoneBlockIndex: UInt64,
+        rngSeed: RngSeed,
+        completion: @escaping (
+            Result<(payload: TxOutContext, change: TxOutContext), TransactionPreparationError>
+        ) -> Void
+    ) {
+        metaFetcher.blockVersion { blockVersionResult in
+            switch blockVersionResult {
+            case .failure(let error):
+                self.finish(.failure(.connectionError(error)), completion)
+            case .success(let blockVersion):
+                let context = TransactionBuilder.Context(
+                    accountKey: accountKey,
+                    blockVersion: blockVersion,
+                    fogResolver: fogResolver,
+                    memoType: .recoverable,
+                    tombstoneBlockIndex: tombstoneBlockIndex,
+                    // No amount reaches a draw, so any fee gives the same
+                    // keys; zero avoids implying otherwise.
+                    fee: Amount(0, in: .MOB),
+                    rngSeed: rngSeed)
+
+                self.finish(
+                    TransactionBuilder.txOutContexts(context: context, recipient: recipient)
+                        .mapError {
+                            TransactionPreparationError.invalidInput($0.localizedDescription)
+                        },
+                    completion)
+            }
+        }
+    }
+
+    private func finish<T>(
+        _ result: Result<T, TransactionPreparationError>,
+        _ completion: @escaping (Result<T, TransactionPreparationError>) -> Void
+    ) {
+        callbackQueue.async { completion(result) }
     }
 
     public func prepareDefragmentationStepTransactions(

--- a/Sources/Common/Transaction/TransactionBuilder+TxOutContexts.swift
+++ b/Sources/Common/Transaction/TransactionBuilder+TxOutContexts.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright (c) 2020-2026 MobileCoin. All rights reserved.
+//
+
+import Foundation
+
+extension TransactionBuilder {
+
+    /// Derives the payload and change outputs a transaction built with
+    /// `context` would produce, without adding inputs or building one.
+    ///
+    /// Building the same transaction later with the same `context.rngSeed`
+    /// yields the same keys: inputs are added before the seeded RNG exists and
+    /// consume none of it, so they cannot move the outputs. That is also why
+    /// no balance is required here — inputs are what need funds.
+    ///
+    /// Takes only what a key depends on. A TxOut public key is `r * D`: `r`
+    /// comes from the seed and the order of the builder's draws, `D` from the
+    /// recipient's subaddress. Nothing else reaches either — the builder draws
+    /// exactly twice per output, for the fog hint and for `r`, and everything
+    /// after that is handed the key rather than the RNG. Amounts, fees and
+    /// memos are therefore not parameters; the zeros and defaults used here
+    /// produce the same keys as any real transaction, which
+    /// `TxOutContextsDerivationTests` pins.
+    static func txOutContexts(
+        context: TransactionBuilder.Context,
+        recipient: PublicAddress
+    ) -> Result<(payload: TxOutContext, change: TxOutContext), TransactionBuilderError> {
+        let builder: TransactionBuilder
+        switch makeBuilder(context: context) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let made):
+            builder = made
+        }
+
+        // Zero, because no amount reaches a draw. Both outputs use the fee's
+        // token id so the builder's mixed-token check cannot trip on values
+        // that do not describe a real transaction anyway.
+        let zero = Amount(0, in: context.fee.tokenId)
+        let possibleTransaction = PossibleTransaction(
+            [TransactionOutput(recipient: recipient, amount: zero)],
+            zero)
+
+        let (payloadContexts, changeContext) = addOutputs(
+            context: context,
+            builder: builder,
+            possibleTransaction: possibleTransaction,
+            rng: MobileCoinChaCha20Rng(rngSeed: context.rngSeed))
+
+        return payloadContexts.collectResult().flatMap { payloads in
+            guard let payload = payloads.first else {
+                return .failure(.invalidInput("No payload output produced"))
+            }
+            return changeContext.map { change in (payload: payload, change: change) }
+        }
+    }
+
+}

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -258,21 +258,18 @@ extension TransactionBuilder {
     /// consume none of it, so they cannot move the outputs. That is also why
     /// no balance is required here — inputs are what need funds.
     ///
-    /// `amount` is what the eventual transaction will send. It does not affect
-    /// the keys, and neither does the change amount, which is zero here
-    /// because with no inputs there is no remainder to return.
+    /// Takes only what a key depends on. A TxOut public key is `r * D`: `r`
+    /// comes from the seed and the order of the builder's draws, `D` from the
+    /// recipient's subaddress. Nothing else reaches either — the builder draws
+    /// exactly twice per output, for the fog hint and for `r`, and everything
+    /// after that is handed the key rather than the RNG. Amounts, fees and
+    /// memos are therefore not parameters; the zeros and defaults used here
+    /// produce the same keys as any real transaction, which
+    /// `TxOutContextsDerivationTests` pins.
     static func txOutContexts(
         context: TransactionBuilder.Context,
-        recipient: PublicAddress,
-        amount: Amount
+        recipient: PublicAddress
     ) -> Result<(payload: TxOutContext, change: TxOutContext), TransactionBuilderError> {
-        // build reaches the same conclusion through its outlay math, which
-        // this path skips along with the inputs. Without it a caller could
-        // derive keys for a transaction that could never be built.
-        guard amount.tokenId == context.fee.tokenId else {
-            return .failure(.invalidInput("Mixed token type transactions not supported"))
-        }
-
         let builder: TransactionBuilder
         switch makeBuilder(context: context) {
         case .failure(let error):
@@ -281,9 +278,13 @@ extension TransactionBuilder {
             builder = made
         }
 
+        // Zero, because no amount reaches a draw. Both outputs use the fee's
+        // token id so the builder's mixed-token check cannot trip on values
+        // that do not describe a real transaction anyway.
+        let zero = Amount(0, in: context.fee.tokenId)
         let possibleTransaction = PossibleTransaction(
-            [TransactionOutput(recipient: recipient, amount: amount)],
-            Amount(0, in: context.fee.tokenId))
+            [TransactionOutput(recipient: recipient, amount: zero)],
+            zero)
 
         let (payloadContexts, changeContext) = addOutputs(
             context: context,

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -191,19 +191,11 @@ extension TransactionBuilder {
         }
 
         let builder: TransactionBuilder
-        do {
-            builder = try TransactionBuilder(
-                context: InnerContext(
-                    blockVersion: context.blockVersion,
-                    fogResolver: context.fogResolver,
-                    memoBuilder: context.memoType.createMemoBuilder(accountKey: context.accountKey),
-                    tombstoneBlockIndex: context.tombstoneBlockIndex,
-                    fee: context.fee))
-        } catch {
-            guard let error = error as? TransactionBuilderError else {
-                return .failure(.invalidInput("Unknown Error"))
-            }
+        switch makeBuilder(context: context) {
+        case .failure(let error):
             return .failure(error)
+        case .success(let made):
+            builder = made
         }
 
         for input in inputs {
@@ -215,19 +207,10 @@ extension TransactionBuilder {
 
         let seededRng = MobileCoinChaCha20Rng(rngSeed: context.rngSeed)
 
-        let payloadContexts = possibleTransaction.outputs.map { output in
-            builder.addOutput(
-                publicAddress: output.recipient,
-                amount: output.amount,
-                rng: seededRng
-            )
-        }
-
-        let changeContext = changeContext(
-            blockVersion: context.blockVersion,
-            accountKey: context.accountKey,
+        let (payloadContexts, changeContext) = addOutputs(
+            context: context,
             builder: builder,
-            changeAmount: possibleTransaction.changeAmount,
+            possibleTransaction: possibleTransaction,
             rng: seededRng)
 
         var presignedIncomeTxOutContexts = [TxOutContext]()
@@ -265,6 +248,110 @@ extension TransactionBuilder {
                 }
             }
         }
+    }
+
+    /// Derives the payload and change outputs a transaction built with
+    /// `context` would produce, without adding inputs or building one.
+    ///
+    /// Building the same transaction later with the same `context.rngSeed`
+    /// yields the same keys: inputs are added before the seeded RNG exists and
+    /// consume none of it, so they cannot move the outputs. That is also why
+    /// no balance is required here — inputs are what need funds.
+    ///
+    /// `amount` is what the eventual transaction will send. It does not affect
+    /// the keys, and neither does the change amount, which is zero here
+    /// because with no inputs there is no remainder to return.
+    static func txOutContexts(
+        context: TransactionBuilder.Context,
+        recipient: PublicAddress,
+        amount: Amount
+    ) -> Result<(payload: TxOutContext, change: TxOutContext), TransactionBuilderError> {
+        let builder: TransactionBuilder
+        switch makeBuilder(context: context) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let made):
+            builder = made
+        }
+
+        let possibleTransaction = PossibleTransaction(
+            [TransactionOutput(recipient: recipient, amount: amount)],
+            Amount(0, in: context.fee.tokenId))
+
+        let (payloadContexts, changeContext) = addOutputs(
+            context: context,
+            builder: builder,
+            possibleTransaction: possibleTransaction,
+            rng: MobileCoinChaCha20Rng(rngSeed: context.rngSeed))
+
+        return payloadContexts.collectResult().flatMap { payloads in
+            guard let payload = payloads.first else {
+                return .failure(.invalidInput("No payload output produced"))
+            }
+            return changeContext.map { change in (payload: payload, change: change) }
+        }
+    }
+
+    /// Builds the `TransactionBuilder` for `context`.
+    ///
+    /// Shared so that `build` and `txOutContexts` cannot construct it
+    /// differently: the fog resolver decides whether each output draws a real
+    /// fog hint or a fake one, and the block version decides where change is
+    /// sent, so a builder made two ways could produce two sets of keys.
+    private static func makeBuilder(
+        context: TransactionBuilder.Context
+    ) -> Result<TransactionBuilder, TransactionBuilderError> {
+        do {
+            return .success(try TransactionBuilder(
+                context: InnerContext(
+                    blockVersion: context.blockVersion,
+                    fogResolver: context.fogResolver,
+                    memoBuilder: context.memoType.createMemoBuilder(accountKey: context.accountKey),
+                    tombstoneBlockIndex: context.tombstoneBlockIndex,
+                    fee: context.fee)))
+        } catch {
+            guard let error = error as? TransactionBuilderError else {
+                return .failure(.invalidInput("Unknown Error"))
+            }
+            return .failure(error)
+        }
+    }
+
+    /// Adds the payload and change outputs to `builder`, in this order.
+    ///
+    /// Every draw the transaction makes from `rng` before it is built happens
+    /// here, so a given seed always produces the same outputs. `build` and
+    /// `txOutContexts` both route through this rather than adding outputs
+    /// themselves, so the keys one derives cannot drift from the keys the
+    /// other builds.
+    ///
+    /// Amounts do not influence the keys — nothing between the draws consumes
+    /// randomness — but the recipients do, because the fog hint drawn ahead of
+    /// each output's private key differs for an address with a fog report and
+    /// one without.
+    private static func addOutputs(
+        context: TransactionBuilder.Context,
+        builder: TransactionBuilder,
+        possibleTransaction: PossibleTransaction,
+        rng: MobileCoinRng
+    ) -> ([Result<TxOutContext, TransactionBuilderError>],
+          Result<TxOutContext, TransactionBuilderError>) {
+        let payloadContexts = possibleTransaction.outputs.map { output in
+            builder.addOutput(
+                publicAddress: output.recipient,
+                amount: output.amount,
+                rng: rng
+            )
+        }
+
+        let changeContext = changeContext(
+            blockVersion: context.blockVersion,
+            accountKey: context.accountKey,
+            builder: builder,
+            changeAmount: possibleTransaction.changeAmount,
+            rng: rng)
+
+        return (payloadContexts, changeContext)
     }
 
     private static func changeContext(

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -266,6 +266,13 @@ extension TransactionBuilder {
         recipient: PublicAddress,
         amount: Amount
     ) -> Result<(payload: TxOutContext, change: TxOutContext), TransactionBuilderError> {
+        // build reaches the same conclusion through its outlay math, which
+        // this path skips along with the inputs. Without it a caller could
+        // derive keys for a transaction that could never be built.
+        guard amount.tokenId == context.fee.tokenId else {
+            return .failure(.invalidInput("Mixed token type transactions not supported"))
+        }
+
         let builder: TransactionBuilder
         switch makeBuilder(context: context) {
         case .failure(let error):

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -250,63 +250,13 @@ extension TransactionBuilder {
         }
     }
 
-    /// Derives the payload and change outputs a transaction built with
-    /// `context` would produce, without adding inputs or building one.
-    ///
-    /// Building the same transaction later with the same `context.rngSeed`
-    /// yields the same keys: inputs are added before the seeded RNG exists and
-    /// consume none of it, so they cannot move the outputs. That is also why
-    /// no balance is required here — inputs are what need funds.
-    ///
-    /// Takes only what a key depends on. A TxOut public key is `r * D`: `r`
-    /// comes from the seed and the order of the builder's draws, `D` from the
-    /// recipient's subaddress. Nothing else reaches either — the builder draws
-    /// exactly twice per output, for the fog hint and for `r`, and everything
-    /// after that is handed the key rather than the RNG. Amounts, fees and
-    /// memos are therefore not parameters; the zeros and defaults used here
-    /// produce the same keys as any real transaction, which
-    /// `TxOutContextsDerivationTests` pins.
-    static func txOutContexts(
-        context: TransactionBuilder.Context,
-        recipient: PublicAddress
-    ) -> Result<(payload: TxOutContext, change: TxOutContext), TransactionBuilderError> {
-        let builder: TransactionBuilder
-        switch makeBuilder(context: context) {
-        case .failure(let error):
-            return .failure(error)
-        case .success(let made):
-            builder = made
-        }
-
-        // Zero, because no amount reaches a draw. Both outputs use the fee's
-        // token id so the builder's mixed-token check cannot trip on values
-        // that do not describe a real transaction anyway.
-        let zero = Amount(0, in: context.fee.tokenId)
-        let possibleTransaction = PossibleTransaction(
-            [TransactionOutput(recipient: recipient, amount: zero)],
-            zero)
-
-        let (payloadContexts, changeContext) = addOutputs(
-            context: context,
-            builder: builder,
-            possibleTransaction: possibleTransaction,
-            rng: MobileCoinChaCha20Rng(rngSeed: context.rngSeed))
-
-        return payloadContexts.collectResult().flatMap { payloads in
-            guard let payload = payloads.first else {
-                return .failure(.invalidInput("No payload output produced"))
-            }
-            return changeContext.map { change in (payload: payload, change: change) }
-        }
-    }
-
     /// Builds the `TransactionBuilder` for `context`.
     ///
     /// Shared so that `build` and `txOutContexts` cannot construct it
     /// differently: the fog resolver decides whether each output draws a real
     /// fog hint or a fake one, and the block version decides where change is
     /// sent, so a builder made two ways could produce two sets of keys.
-    private static func makeBuilder(
+    static func makeBuilder(
         context: TransactionBuilder.Context
     ) -> Result<TransactionBuilder, TransactionBuilderError> {
         do {
@@ -337,7 +287,7 @@ extension TransactionBuilder {
     /// randomness — but the recipients do, because the fog hint drawn ahead of
     /// each output's private key differs for an address with a fog report and
     /// one without.
-    private static func addOutputs(
+    static func addOutputs(
         context: TransactionBuilder.Context,
         builder: TransactionBuilder,
         possibleTransaction: PossibleTransaction,
@@ -362,7 +312,7 @@ extension TransactionBuilder {
         return (payloadContexts, changeContext)
     }
 
-    private static func changeContext(
+    static func changeContext(
         blockVersion: BlockVersion,
         accountKey: AccountKey,
         builder: TransactionBuilder,

--- a/Tests/Unit/Rng/SeedableRngUnitTests.swift
+++ b/Tests/Unit/Rng/SeedableRngUnitTests.swift
@@ -48,6 +48,8 @@ class SeedableRngUnitTests: XCTestCase {
 
         let builderSeed = try XCTUnwrap(MobileCoinChaCha20Rng(rngSeed: seed).generateRngSeed())
 
-        XCTAssertEqual(builderSeed.data.hexEncodedString(), "7606151ea291727acfbea41cc1e71d57b1e219e3aeb8accfa3a9bcbc190bc3f5")
+        XCTAssertEqual(
+            builderSeed.data.hexEncodedString(),
+            "7606151ea291727acfbea41cc1e71d57b1e219e3aeb8accfa3a9bcbc190bc3f5")
     }
 }

--- a/Tests/Unit/Rng/SeedableRngUnitTests.swift
+++ b/Tests/Unit/Rng/SeedableRngUnitTests.swift
@@ -27,4 +27,27 @@ class SeedableRngUnitTests: XCTestCase {
             XCTAssertEqual(rng1.next(), rng2.next(), "Same-seed RNGs should gen matching values")
         }
     }
+
+    /// The seed a `TransactionBuilder` runs on is derived from the caller's
+    /// RNG, and the two platforms derive it differently: this takes four
+    /// `next()` UInt64s reduced into `Data`, where android-sdk takes
+    /// `nextBytes(32)`. Both should yield the same 32 bytes off the same
+    /// stream, because `next_u64` combines two u32 words as `w[i+1] << 32 |
+    /// w[i]` and its little-endian bytes are exactly what `fill_bytes` writes
+    /// for those words.
+    ///
+    /// Nothing else in the derivation is platform-specific — the builder's own
+    /// stream and `add_output` are the same Rust through FFI — so this hop is
+    /// the only place iOS and Android can disagree about a TxOut public key.
+    /// `TxOutContextsTest#testBuilderSeedIsPlatformIndependent` in android-sdk
+    /// asserts the same seed against the same expected bytes.
+    func testBuilderSeedIsPlatformIndependent() throws {
+        // "goto https://buy.mobilecoin.com\0", the seed android-sdk's
+        // TxOutContextsTest uses, so both assert against one stream.
+        let seed = try XCTUnwrap(RngSeed(Data("goto https://buy.mobilecoin.com\0".utf8)))
+
+        let builderSeed = try XCTUnwrap(MobileCoinChaCha20Rng(rngSeed: seed).generateRngSeed())
+
+        XCTAssertEqual(builderSeed.data.hexEncodedString(), "7606151ea291727acfbea41cc1e71d57b1e219e3aeb8accfa3a9bcbc190bc3f5")
+    }
 }

--- a/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
+++ b/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
@@ -110,6 +110,40 @@ class TxOutContextsDerivationTests: XCTestCase {
         XCTAssertEqual(realFee.change.txOutPublicKey, absurdFee.change.txOutPublicKey)
     }
 
+    /// The token id is its own question, separate from the value.
+    /// `txOutContexts` takes both zero amounts from `context.fee.tokenId`, and
+    /// `MobileCoinClient` pins that to `.MOB`, so a caller deriving for a
+    /// non-MOB transaction runs the builder with a token id the real send will
+    /// not use. This pins that it makes no difference to the keys.
+    ///
+    /// Both sides run at block version two because that is the first version
+    /// accepting a token id other than MOB — at the fixture's own version the
+    /// non-MOB build fails with `TokenIdNotSupportedAtBlockVersion` rather
+    /// than producing keys to compare.
+    func testTokenIdDoesNotMoveTheKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let inMob = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(
+                fixture: fixture,
+                rngSeed: seed,
+                fee: Amount(fixture.fee.value, in: .MOB),
+                blockVersion: .versionTwo),
+            recipient: output.recipient))
+        let inMobUsd = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(
+                fixture: fixture,
+                rngSeed: seed,
+                fee: Amount(fixture.fee.value, in: .MOBUSD),
+                blockVersion: .versionTwo),
+            recipient: output.recipient))
+
+        XCTAssertEqual(inMob.payload.txOutPublicKey, inMobUsd.payload.txOutPublicKey)
+        XCTAssertEqual(inMob.change.txOutPublicKey, inMobUsd.change.txOutPublicKey)
+    }
+
     /// And the memo, which is what a payment request id would select.
     func testMemoTypeDoesNotMoveTheKeys() throws {
         let fixture = try Transaction.Fixtures.BuildTxTestNet()
@@ -152,11 +186,12 @@ class TxOutContextsDerivationTests: XCTestCase {
         fixture: Transaction.Fixtures.BuildTxTestNet,
         rngSeed: RngSeed,
         fee: Amount? = nil,
-        memoType: MemoType = .recoverable
+        memoType: MemoType = .recoverable,
+        blockVersion: BlockVersion? = nil
     ) -> TransactionBuilder.Context {
         TransactionBuilder.Context(
             accountKey: fixture.accountKey,
-            blockVersion: fixture.blockVersion,
+            blockVersion: blockVersion ?? fixture.blockVersion,
             fogResolver: fixture.fogResolver,
             memoType: memoType,
             tombstoneBlockIndex: fixture.tombstoneBlockIndex,

--- a/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
+++ b/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
@@ -1,0 +1,131 @@
+//
+//  Copyright (c) 2020-2026 MobileCoin. All rights reserved.
+//
+
+@testable import MobileCoin
+import XCTest
+
+/// Covers deriving TxOut public keys ahead of the transaction that will carry
+/// them.
+///
+/// The reason this is safe at all is that inputs consume none of the seeded
+/// RNG, so the outputs a seed produces do not depend on what is being spent.
+/// These pin that: if a draw is ever added ahead of the output keys, or the
+/// two paths stop sharing `addOutputs`, the first test here fails.
+class TxOutContextsDerivationTests: XCTestCase {
+
+    func testDerivedKeysMatchTheBuiltTransaction() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let context = Self.context(fixture: fixture, rngSeed: testRngSeed())
+
+        let output = try XCTUnwrap(fixture.outputs.first)
+        let built = try XCTUnwrapSuccess(TransactionBuilder.build(
+            context: context,
+            inputs: fixture.inputs,
+            to: output.recipient,
+            amount: output.amount))
+
+        let derived = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: context,
+            recipient: output.recipient,
+            amount: output.amount))
+
+        XCTAssertEqual(derived.payload.txOutPublicKey, built.payloadTxOutContext.txOutPublicKey)
+        XCTAssertEqual(derived.change.txOutPublicKey, built.changeTxOutContext.txOutPublicKey)
+    }
+
+    /// The derivation reports no change amount, because with no inputs there is
+    /// nothing left over. The change key still has to match the built
+    /// transaction's, which it can only do if amounts never reach the RNG.
+    func testChangeAmountDoesNotMoveTheChangeKey() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let context = Self.context(fixture: fixture, rngSeed: testRngSeed())
+
+        let output = try XCTUnwrap(fixture.outputs.first)
+        let built = try XCTUnwrapSuccess(TransactionBuilder.build(
+            context: context,
+            inputs: fixture.inputs,
+            to: output.recipient,
+            amount: output.amount))
+
+        let derived = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: context,
+            recipient: output.recipient,
+            amount: output.amount))
+
+        // Guards the test itself: if the built change were also zero there
+        // would be nothing to distinguish the amounts.
+        XCTAssertNotEqual(
+            built.changeTxOutContext.txOut.value(accountKey: fixture.accountKey), 0)
+        XCTAssertEqual(derived.change.txOutPublicKey, built.changeTxOutContext.txOutPublicKey)
+    }
+
+    func testSameSeedDerivesTheSameKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let first = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: output.recipient,
+            amount: output.amount))
+        let second = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: output.recipient,
+            amount: output.amount))
+
+        XCTAssertEqual(first.payload.txOutPublicKey, second.payload.txOutPublicKey)
+        XCTAssertEqual(first.change.txOutPublicKey, second.change.txOutPublicKey)
+    }
+
+    func testDifferentSeedsDeriveDifferentKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let first = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: RngSeed()),
+            recipient: output.recipient,
+            amount: output.amount))
+        let second = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: RngSeed()),
+            recipient: output.recipient,
+            amount: output.amount))
+
+        XCTAssertNotEqual(first.payload.txOutPublicKey, second.payload.txOutPublicKey)
+        XCTAssertNotEqual(first.change.txOutPublicKey, second.change.txOutPublicKey)
+    }
+
+    /// The public key is `r * D`, so the recipient is as much an input to it as
+    /// the seed. A caller holding only a seed cannot know the key.
+    func testRecipientChangesThePayloadKey() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let toRecipient = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: output.recipient,
+            amount: output.amount))
+        let toSelf = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: fixture.accountKey.publicAddress,
+            amount: output.amount))
+
+        XCTAssertNotEqual(toRecipient.payload.txOutPublicKey, toSelf.payload.txOutPublicKey)
+    }
+
+    private static func context(
+        fixture: Transaction.Fixtures.BuildTxTestNet,
+        rngSeed: RngSeed
+    ) -> TransactionBuilder.Context {
+        TransactionBuilder.Context(
+            accountKey: fixture.accountKey,
+            blockVersion: fixture.blockVersion,
+            fogResolver: fixture.fogResolver,
+            memoType: .recoverable,
+            tombstoneBlockIndex: fixture.tombstoneBlockIndex,
+            fee: fixture.fee,
+            rngSeed: rngSeed)
+    }
+
+}

--- a/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
+++ b/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
@@ -110,6 +110,27 @@ class TxOutContextsDerivationTests: XCTestCase {
         XCTAssertEqual(realFee.change.txOutPublicKey, absurdFee.change.txOutPublicKey)
     }
 
+    /// The derivation fetches the block version at derive time, and the send
+    /// fetches it again later. If the network advanced in between, the two
+    /// would build at different versions — so this pins that the version does
+    /// not move the keys either, and a caller need not derive and send close
+    /// together to be safe.
+    func testBlockVersionDoesNotMoveTheKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let atOne = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed, blockVersion: .versionOne),
+            recipient: output.recipient))
+        let atTwo = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed, blockVersion: .versionTwo),
+            recipient: output.recipient))
+
+        XCTAssertEqual(atOne.payload.txOutPublicKey, atTwo.payload.txOutPublicKey)
+        XCTAssertEqual(atOne.change.txOutPublicKey, atTwo.change.txOutPublicKey)
+    }
+
     /// The token id is its own question, separate from the value.
     /// `txOutContexts` takes both zero amounts from `context.fee.tokenId`, and
     /// `MobileCoinClient` pins that to `.MOB`, so a caller deriving for a

--- a/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
+++ b/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
@@ -83,11 +83,11 @@ class TxOutContextsDerivationTests: XCTestCase {
         let output = try XCTUnwrap(fixture.outputs.first)
 
         let first = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
-            context: Self.context(fixture: fixture, rngSeed: RngSeed()),
+            context: Self.context(fixture: fixture, rngSeed: testRngSeed()),
             recipient: output.recipient,
             amount: output.amount))
         let second = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
-            context: Self.context(fixture: fixture, rngSeed: RngSeed()),
+            context: Self.context(fixture: fixture, rngSeed: Self.otherRngSeed),
             recipient: output.recipient,
             amount: output.amount))
 
@@ -113,6 +113,10 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         XCTAssertNotEqual(toRecipient.payload.txOutPublicKey, toSelf.payload.txOutPublicKey)
     }
+
+    /// A second seed, fixed so a failure can be re-run. Differs from
+    /// `testRngSeed()` in its last byte.
+    private static let otherRngSeed = RngSeed(Data(repeating: 0, count: 31) + Data([1]))!
 
     private static func context(
         fixture: Transaction.Fixtures.BuildTxTestNet,

--- a/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
+++ b/Tests/Unit/Transaction/TxOutContextsDerivationTests.swift
@@ -27,16 +27,15 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         let derived = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: context,
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
 
         XCTAssertEqual(derived.payload.txOutPublicKey, built.payloadTxOutContext.txOutPublicKey)
         XCTAssertEqual(derived.change.txOutPublicKey, built.changeTxOutContext.txOutPublicKey)
     }
 
-    /// The derivation reports no change amount, because with no inputs there is
-    /// nothing left over. The change key still has to match the built
-    /// transaction's, which it can only do if amounts never reach the RNG.
+    /// The derivation names no amounts at all — it has no parameter for them —
+    /// while the built transaction carries real ones. The keys still match,
+    /// which is what shows no amount reaches a draw.
     func testChangeAmountDoesNotMoveTheChangeKey() throws {
         let fixture = try Transaction.Fixtures.BuildTxTestNet()
         let context = Self.context(fixture: fixture, rngSeed: testRngSeed())
@@ -50,8 +49,7 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         let derived = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: context,
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
 
         // Guards the test itself: if the built change were also zero there
         // would be nothing to distinguish the amounts.
@@ -67,12 +65,10 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         let first = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: seed),
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
         let second = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: seed),
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
 
         XCTAssertEqual(first.payload.txOutPublicKey, second.payload.txOutPublicKey)
         XCTAssertEqual(first.change.txOutPublicKey, second.change.txOutPublicKey)
@@ -84,15 +80,51 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         let first = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: testRngSeed()),
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
         let second = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: Self.otherRngSeed),
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
 
         XCTAssertNotEqual(first.payload.txOutPublicKey, second.payload.txOutPublicKey)
         XCTAssertNotEqual(first.change.txOutPublicKey, second.change.txOutPublicKey)
+    }
+
+    /// Same reasoning for the fee: the derivation is given one that no real
+    /// transaction would use, and the keys are unaffected.
+    func testFeeDoesNotMoveTheKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let realFee = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: output.recipient))
+        let absurdFee = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(
+                fixture: fixture,
+                rngSeed: seed,
+                fee: Amount(999_999_999, in: fixture.fee.tokenId)),
+            recipient: output.recipient))
+
+        XCTAssertEqual(realFee.payload.txOutPublicKey, absurdFee.payload.txOutPublicKey)
+        XCTAssertEqual(realFee.change.txOutPublicKey, absurdFee.change.txOutPublicKey)
+    }
+
+    /// And the memo, which is what a payment request id would select.
+    func testMemoTypeDoesNotMoveTheKeys() throws {
+        let fixture = try Transaction.Fixtures.BuildTxTestNet()
+        let seed = testRngSeed()
+        let output = try XCTUnwrap(fixture.outputs.first)
+
+        let recoverable = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed),
+            recipient: output.recipient))
+        let unused = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
+            context: Self.context(fixture: fixture, rngSeed: seed, memoType: .unused),
+            recipient: output.recipient))
+
+        XCTAssertEqual(recoverable.payload.txOutPublicKey, unused.payload.txOutPublicKey)
+        XCTAssertEqual(recoverable.change.txOutPublicKey, unused.change.txOutPublicKey)
     }
 
     /// The public key is `r * D`, so the recipient is as much an input to it as
@@ -104,12 +136,10 @@ class TxOutContextsDerivationTests: XCTestCase {
 
         let toRecipient = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: seed),
-            recipient: output.recipient,
-            amount: output.amount))
+            recipient: output.recipient))
         let toSelf = try XCTUnwrapSuccess(TransactionBuilder.txOutContexts(
             context: Self.context(fixture: fixture, rngSeed: seed),
-            recipient: fixture.accountKey.publicAddress,
-            amount: output.amount))
+            recipient: fixture.accountKey.publicAddress))
 
         XCTAssertNotEqual(toRecipient.payload.txOutPublicKey, toSelf.payload.txOutPublicKey)
     }
@@ -120,15 +150,17 @@ class TxOutContextsDerivationTests: XCTestCase {
 
     private static func context(
         fixture: Transaction.Fixtures.BuildTxTestNet,
-        rngSeed: RngSeed
+        rngSeed: RngSeed,
+        fee: Amount? = nil,
+        memoType: MemoType = .recoverable
     ) -> TransactionBuilder.Context {
         TransactionBuilder.Context(
             accountKey: fixture.accountKey,
             blockVersion: fixture.blockVersion,
             fogResolver: fixture.fogResolver,
-            memoType: .recoverable,
+            memoType: memoType,
             tombstoneBlockIndex: fixture.tombstoneBlockIndex,
-            fee: fixture.fee,
+            fee: fee ?? fixture.fee,
             rngSeed: rngSeed)
     }
 


### PR DESCRIPTION
Currently, the only way to get a txout's public key is by calling prepareTransaction, which selects inputs and consequently needs a funded, synced account. But it shouldn't need that.

Inputs are added at [`TransactionBuilder.swift:211`](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/4f261da84c3e3ae1dc6e20b8df42d57aec4c42de/Sources/Common/Transaction/TransactionBuilder.swift#L211) — *before* the seeded RNG is even created at [`:216`](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/4f261da84c3e3ae1dc6e20b8df42d57aec4c42de/Sources/Common/Transaction/TransactionBuilder.swift#L216) — and consume none of it. So the keys a seed produces have never depended on what is being spent.

## What this adds

`TransactionBuilder.txOutContexts` runs the output-adding against a builder with no inputs and never calls `build()`. `MobileCoinClient.txOutContexts` wraps it: same `generateRngSeed()` hop as `prepareTransaction`, fog resolved for the recipient and the account's own address, block version fetched, then delegate.

## Why it's an extraction, not a parallel path

The point is that the two paths *cannot* disagree, so both shared dependencies are now extracted rather than duplicated:

| Extracted | Why it matters to the keys |
| --- | --- |
| `addOutputs` | Holds the payload loop and the existing [`changeContext`](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/4f261da84c3e3ae1dc6e20b8df42d57aec4c42de/Sources/Common/Transaction/TransactionBuilder.swift#L270) branch, so every draw before `build()` happens in one place |
| `makeBuilder` | `build` and the new path had been constructing the builder identically by hand. The fog resolver decides real hint vs fake hint — different numbers of draws — and the block version decides where change goes |

That is not theoretical. In core, [`create_fog_hint` draws before the tx private key](https://github.com/mobilecoinfoundation/mobilecoin/blob/fe8017c7067b6c4c116f353b9e1beb3db5639888/transaction/builder/src/transaction_builder.rs#L670), and [`r` is drawn immediately after](https://github.com/mobilecoinfoundation/mobilecoin/blob/fe8017c7067b6c4c116f353b9e1beb3db5639888/transaction/builder/src/transaction_builder.rs#L681), so a resolver built differently shifts every key that follows.

For the same reason `MobileCoinClient.txOutContexts` resolves fog through the `desiredMinPubkeyExpiry` overload, matching [`TransactionPreparer.swift:137`](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/4f261da84c3e3ae1dc6e20b8df42d57aec4c42de/Sources/Common/Transaction/TransactionPreparer.swift#L137) rather than the plainer one. An earlier revision used the plain overload and would have returned keys the built transaction did not carry.

## The zero change amount

The derivation reports zero change, having no inputs to leave a remainder, and still has to match a real transaction's keys.

`testChangeAmountDoesNotMoveTheChangeKey` proves it: the built transaction's change is asserted non-zero so the test cannot pass vacuously, and the change keys match anyway. **Amounts never reach the RNG.** That was the load-bearing assumption behind the zero, and it is now demonstrated rather than argued.

## Cross-platform parity

Both SDKs derive the builder seed from the caller's RNG differently — [`generateRngSeed()`](https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/4f261da84c3e3ae1dc6e20b8df42d57aec4c42de/Sources/Common/Utils/Rng/MobileCoinRng.swift#L15) is four `next()` UInt64s reduced into `Data`, where android-sdk takes `nextBytes(32)`. They should agree, since `next_u64` combines two u32 words as `w[i+1] << 32 | w[i]` and its little-endian bytes are what `fill_bytes` writes for those words, but nothing had checked: idempotent retries always happen on the device that created the seed.

That hop is the only platform-specific code in the chain, so `SeedableRngUnitTests.testBuilderSeedIsPlatformIndependent` pins it with a golden value. android-sdk asserts the same constant against the same seed. **The two must change together or not at all.**