### PR TITLE
refactor(SENTZ-5518): depend on the test-vectors product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // and from where they can be fetched:
         .package(
             url: "https://github.com/mobilecoinofficial/libmobilecoin.git",
-            from: "6.0.4"
+            from: "6.1.0"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
@@ -45,9 +45,15 @@ let package = Package(
                 "HTTPS",
             ]
          ),
+        // LibMobileCoinTestVector is its own product from 6.1.0. It used to ride
+        // along inside the Core products, so the tests picked it up through
+        // MobileCoin without asking.
         .testTarget(
             name: "MobileCoinTests",
-            dependencies: ["MobileCoin"],
+            dependencies: [
+                "MobileCoin",
+                .product(name: "LibMobileCoinTestVectors", package: "libmobilecoin"),
+            ],
             path: "Tests",
             exclude: [
                 "Common/Secrets/secrets.json.sample",


### PR DESCRIPTION
Soundtrack of this PR: [The Beatles - Come Together](https://www.youtube.com/results?search_query=the+beatles+come+together)

### Motivation

Currently the test vectors are read out of libmobilecoin's vendor tree by path. That works only because the vendored checkout happens to be laid out that way. libmobilecoin vends them as a product from 6.1.0, so this side should ask for the product.

### In this PR
* Depend on the `LibMobileCoinTestVectors` product on the test target, instead of reaching into the vendor tree by path.
* Point the libmobilecoin dependency at 6.1.0.

`Package.resolved` still pins libmobilecoin 6.0.4 while `Package.swift` asks for 6.1.0, so a resolve fails today and this PR cannot merge yet. It is not fixable from this branch, because v6.1.0 does not exist. The order that clears it: the libmobilecoin stack merges, its release cuts v6.1.0, a resolve here commits the pin, then this merges.

Implements SENTZ-5518.

### Future Work
* SENTZ-5527 - the two test targets still carry `.swiftLanguageMode(.v5)`.
* SENTZ-5528 - `make test-spm` fails to link with an undefined `_mc_mr_enclave_verifier_create`, pre-existing on `master`.
