### PR TITLE
chore: bump pod version to 6.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.7] - 2026-08-31
+
+### Added
+
+- `MobileCoinClient.txOutContexts(to:rngSeed:)` derives the payload and change
+  TxOut public keys a transaction will carry, from an RNG seed alone, without
+  building or submitting one. Send with
+  `prepareTransaction(rng: MobileCoinChaCha20Rng(rngSeed: seed))` on the same
+  seed and the transaction carries the keys it reported.
+
 ## [4.0.1] - 2023-03-02
 
 ### Added

--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - Keys (1.0.1)
   - LibMobileCoin/CoreHTTP (6.0.2):
     - SwiftProtobuf (~> 1.5)
-  - MobileCoin (6.0.6)
-  - MobileCoin/CoreHTTP (6.0.6):
+  - MobileCoin (6.0.7)
+  - MobileCoin/CoreHTTP (6.0.7):
     - LibMobileCoin/CoreHTTP (~> 6.0.0-pre1)
     - SwiftLint
     - SwiftProtobuf (~> 1.28)
-  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (6.0.6):
+  - MobileCoin/CoreHTTP/HttpProtocolUnitTests (6.0.7):
     - LibMobileCoin/CoreHTTP (~> 6.0.0-pre1)
     - SwiftLint
     - SwiftProtobuf (~> 1.28)
-  - MobileCoin/IntegrationNonTransactingTests (6.0.6)
-  - MobileCoin/IntegrationTransactingTests (6.0.6)
-  - MobileCoin/PerformanceTests (6.0.6)
-  - MobileCoin/Tests (6.0.6)
+  - MobileCoin/IntegrationNonTransactingTests (6.0.7)
+  - MobileCoin/IntegrationTransactingTests (6.0.7)
+  - MobileCoin/PerformanceTests (6.0.7)
+  - MobileCoin/Tests (6.0.7)
   - SwiftLint (0.47.1)
   - SwiftProtobuf (1.38.1)
 
@@ -47,7 +47,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 8503f567fa32184a5be7bc038fbd727747dd9991
-  MobileCoin: c7c510515736c9b56fa6a7386097e2cbb0eae5b7
+  MobileCoin: c60956395470181e3a7231adf405baaad05fae48
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 409d3aaec90e51b1705b1dd8065b56893450e77c
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "MobileCoin"
-  s.version      = "6.0.6"
+  s.version      = "6.0.7"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"


### PR DESCRIPTION
## What this releases

#286: `MobileCoinClient.txOutContexts(to:rngSeed:)`, which derives the payload and change TxOut public keys a transaction will carry from an RNG seed alone, without building or submitting one. The MistySign offramp needs a `mobilecoin_txo_pub_key` before the transaction exists, and the plugin's `getTxOutPublicKeys` bridge is waiting on this pod.