### PR TITLE
chore(SENTZ-5553): Raise the libmobilecoin floor to 6.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
           path: ~/Library/Logs/DiagnosticReports
           if-no-files-found: ignore
 
-  # Proves SPM consumers can resolve libmobilecoin (with its LFS-tracked
-  # Artifacts submodule) without the CocoaPods toolchain, so this job skips
-  # the setup action on purpose. `swift test` is not run: generating
-  # Tests/Common/Secrets/secrets.json needs a macOS-keychain identity.
+  # Proves SPM consumers can resolve libmobilecoin without the CocoaPods
+  # toolchain, so this job skips the setup action on purpose. `swift test` is
+  # not run: generating Tests/Common/Secrets/secrets.json needs a
+  # macOS-keychain identity.
   build-spm:
     name: Swift package build
     runs-on: macos-26
@@ -92,39 +92,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # `.build` is not cached on purpose: SwiftPM keeps both a bare clone and
-      # a checkout of libmobilecoin's LFS artifacts, so each entry would fill
-      # most of the repo's Actions cache budget and evict the gem and Pods
-      # caches the slower jobs depend on.
+      # `.build` is not cached on purpose: an entry would carry the binary
+      # target's 333 MiB unpacked xcframework, more than every cache this repo
+      # currently holds put together.
+      #
+      # SwiftPM verifies the binary target's SHA-256 and fails the resolve on a
+      # mismatch, which covers a corrupt or substituted download. It does not
+      # check what the release job put in the archive.
       - name: Build
         run: make build-spm
-
-      # SwiftPM clones libmobilecoin itself; if git-lfs smudging doesn't happen
-      # in that clone the .a files arrive as pointer text and the failure shows
-      # up much later as an unrelated linker error.
-      - name: Verify SwiftPM resolved the LFS binaries
-        run: |
-          set -euo pipefail
-          lib=".build/checkouts/libmobilecoin/Artifacts/LibMobileCoinLibrary.xcframework"
-          if [[ ! -d "$lib" ]]; then
-            echo "::error::$lib is missing from the SwiftPM checkout."
-            exit 1
-          fi
-          count=0
-          while IFS= read -r archive; do
-            if head -c 100 "$archive" | grep -q 'git-lfs.github.com'; then
-              echo "::error::$archive is an unresolved Git LFS pointer."
-              exit 1
-            fi
-            echo "ok: $archive ($(du -h "$archive" | cut -f1))"
-            count=$((count + 1))
-          done < <(find "$lib" -name '*.a')
-          # Without this the check passes vacuously if the xcframework layout
-          # ever changes and `find` matches nothing.
-          if [[ "$count" -eq 0 ]]; then
-            echo "::error::Found no .a archives under $lib."
-            exit 1
-          fi
 
       # `swift build` rewrites Package.resolved when the declared dependencies
       # and the committed resolution disagree.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# The floor for every job; publish-pod-release raises its own.
+# The floor for every job.
 permissions:
   contents: read
 
@@ -122,91 +122,3 @@ jobs:
 
       - name: Check for uncommitted changes
         run: ./scripts/check_dirty_git
-
-  # Lints dynamically, the same validation `pod trunk push` runs at release
-  # time, so a green run here means the publish job's lint will also pass.
-  pod-lib-lint:
-    name: CocoaPods podspec lint
-    runs-on: macos-26
-    timeout-minutes: 120
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          lfs: true
-
-      - name: Setup
-        uses: ./.github/actions/setup-macos-ci
-
-      - name: Lint podspec
-        run: make lint-locally-strict-podspec
-
-      - name: Check for uncommitted changes
-        run: ./scripts/check_dirty_git
-
-  publish-pod-release:
-    name: Publish pod release
-    # pod-lib-lint runs the same validation `pod trunk push` performs, so it
-    # gates the publish to fail fast before tagging.
-    needs: [build-and-test-example-http, swiftlint, pod-lib-lint]
-    if: >-
-      github.event_name == 'push' &&
-      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/'))
-    runs-on: macos-26
-    timeout-minutes: 60
-    permissions:
-      contents: write
-    env:
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          lfs: true
-          # `make tag-release` pushes a tag using the checkout credentials.
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Setup
-        uses: ./.github/actions/setup-macos-ci
-
-      # Skip commits that don't bump the podspec version. Trunk is the source
-      # of truth: a git-tag check would skip the publish forever after a run
-      # that pushed the tag and then failed before the trunk push landed.
-      - name: Check whether this version is already released
-        id: version
-        run: |
-          set -euo pipefail
-          version="$(bundle exec pod ipc spec MobileCoin.podspec | jq -r '.version')"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          if bundle exec pod trunk info MobileCoin | grep -qF -- "- ${version} ("; then
-            echo "Version ${version} is already on trunk; nothing to publish."
-            echo "should-publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should-publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set git credentials
-        if: steps.version.outputs.should-publish == 'true'
-        run: |
-          git config user.email "mobilecoin-ci@mobilecoin.com"
-          git config user.name "mobilecoin-ci"
-
-      # The podspec's source is `:tag => "v#{s.version}"`, so the tag must
-      # exist before the trunk push. Kept idempotent so a rerun after a failed
-      # trunk push does not die on the already-pushed tag.
-      - name: Tag release
-        if: steps.version.outputs.should-publish == 'true'
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "Tag v${{ steps.version.outputs.version }} already exists; skipping tag push."
-          else
-            make tag-release
-          fi
-
-      - name: Publish pod to trunk
-        if: steps.version.outputs.should-publish == 'true'
-        run: make publish-podspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,8 @@ jobs:
           if-no-files-found: ignore
 
   # Proves SPM consumers can resolve libmobilecoin without the CocoaPods
-  # toolchain, so this job skips the setup action on purpose. Test targets are
-  # compiled but not run: generating Tests/Common/Secrets/secrets.json needs a
-  # macOS-keychain identity.
+  # toolchain, so this job skips the setup action on purpose. Test targets
+  # compile but do not run: secrets.json needs a macOS-keychain identity.
   build-spm:
     name: Swift package build
     runs-on: macos-26
@@ -92,18 +91,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # `.build` is not cached on purpose: an entry would carry the binary
-      # target's 333 MiB unpacked xcframework, more than every cache this repo
-      # currently holds put together.
-      #
-      # SwiftPM verifies the binary target's SHA-256 and fails the resolve on a
-      # mismatch, which covers a corrupt or substituted download. It does not
-      # check what the release job put in the archive.
+      # No `.build` cache on purpose: the entry would be the whole build tree,
+      # about 660 MiB compressed, against 143 MiB of cache in this repo total.
       - name: Build
         run: make build-spm
 
-      # `swift build` rewrites Package.resolved when the declared dependencies
-      # and the committed resolution disagree.
+      # The build rewrites Package.resolved when the declared dependencies and
+      # the committed resolution disagree.
       - name: Check for uncommitted changes
         run: ./scripts/check_dirty_git
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           if-no-files-found: ignore
 
   # Proves SPM consumers can resolve libmobilecoin without the CocoaPods
-  # toolchain, so this job skips the setup action on purpose. `swift test` is
-  # not run: generating Tests/Common/Secrets/secrets.json needs a
+  # toolchain, so this job skips the setup action on purpose. Test targets are
+  # compiled but not run: generating Tests/Common/Secrets/secrets.json needs a
   # macOS-keychain identity.
   build-spm:
     name: Swift package build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Vendor/libmobilecoin"]
 	path = Vendor/libmobilecoin
-	url = https://github.com/mobilecoinofficial/libmobilecoin.git
+	url = https://github.com/mobilecoinofficial/libmobilecoin-archive.git
 	shallow = true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -97,6 +97,9 @@ included: # paths to include during linting. Ignored if `--path` is present unle
   - Tests
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - "Sources/Network/HTTPS/HttpConnection/HttpConnections/HttpProtoGenerated"
+  # SwiftPM fixes the manifest's shape. `let package` cannot take a `k` prefix,
+  # and the file header rule wants a header the manifest does not carry.
+  - "Package.swift"
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level
 force_cast: warning # implicitly

--- a/Makefile
+++ b/Makefile
@@ -141,13 +141,14 @@ upgrade-deps:
 generate-local-process-info:
 	tools/generate_process_info_jsons.sh
 
-# Builds every target in Package.swift. Unlike `run-all-tests-spm` this needs no
-# secrets, so it is the one SPM check CI can run today. The test targets declare
-# resources (secrets.json, process_info.json) that are generated rather than
-# committed; SwiftPM only warns about those at build time.
+# Builds every target in Package.swift, test targets included. Unlike
+# `run-all-tests-spm` this needs no secrets, so it is the one SPM check CI can
+# run today. The test targets declare resources (secrets.json,
+# process_info.json) that are generated rather than committed. SwiftPM only
+# warns about those at build time.
 .PHONY: build-spm
 build-spm:
-	swift build
+	swift build --build-tests
 
 .PHONY: fund-test-wallets-spm
 fund-test-wallets-spm:

--- a/Makefile
+++ b/Makefile
@@ -61,44 +61,20 @@ autocorrect:
 	@PATH="./ExampleHTTP/Pods/SwiftLint:$$PATH" swiftlint --fix
 
 .PHONY: lint-all
-lint-all: lint lint-podspec lint-docs
-
-.PHONY: publish
-publish: tag-release publish-podspec
+lint-all: lint lint-docs
 
 # Release
 
+# The podspec is the version source for the tag.
 .PHONY: tag-release
 tag-release:
 	VERSION="$$(bundle exec pod ipc spec MobileCoin.podspec | jq -r '.version')" && \
-		git tag "v$$VERSION" && \
-		git push origin "refs/tags/v$$VERSION"
-
-# MobileCoin pod
-
-# Dynamic linkage, matching what `pod trunk push` validates at release time.
-# pod lint strips linker errors from xcodebuild output; add --verbose to see them.
-POD_LINT_FLAGS = --skip-tests
-
-.PHONY: lint-locally-podspec
-lint-locally-podspec:
-	cd ExampleHTTP; bundle exec pod repo update;
-	bundle exec pod lib lint MobileCoin.podspec $(POD_LINT_FLAGS) --allow-warnings
-
-.PHONY: lint-locally-strict-podspec
-lint-locally-strict-podspec:
-	cd ExampleHTTP; bundle exec pod repo update;
-	bundle exec pod lib lint MobileCoin.podspec $(POD_LINT_FLAGS)
-
-.PHONY: lint-podspec
-lint-podspec:
-	cd ExampleHTTP; bundle exec pod repo update;
-	bundle exec pod spec lint MobileCoin.podspec $(POD_LINT_FLAGS)
-
-.PHONY: publish-podspec
-publish-podspec:
-	cd ExampleHTTP; bundle exec pod repo update;
-	bundle exec pod trunk push MobileCoin.podspec --skip-tests
+		if git ls-remote --exit-code --tags origin "refs/tags/v$$VERSION" >/dev/null 2>&1; then \
+			echo "Tag v$$VERSION already exists."; \
+		else \
+			git tag "v$$VERSION" && \
+			git push origin "refs/tags/v$$VERSION"; \
+		fi
 
 # Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,8 @@ upgrade-deps:
 generate-local-process-info:
 	tools/generate_process_info_jsons.sh
 
-# Builds every target in Package.swift, test targets included. Unlike
-# `run-all-tests-spm` this needs no secrets, so it is the one SPM check CI can
-# run today. The test targets declare resources (secrets.json,
-# process_info.json) that are generated rather than committed. SwiftPM only
-# warns about those at build time.
+# Builds every target including tests. The one SPM check CI can run without
+# secrets; the generated resource files are absent, so SwiftPM warns.
 .PHONY: build-spm
 build-spm:
 	swift build --build-tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mobilecoinofficial/libmobilecoin.git",
       "state" : {
-        "revision" : "aaef756fe293bb1036f3e2147d1c085568568ecf",
-        "version" : "6.0.4"
+        "revision" : "87d4793bcf5fd8fca9985f306b823bb24e7e27d4",
+        "version" : "6.1.0"
       }
     },
     {
@@ -93,10 +93,10 @@
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf",
+      "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
+        "version" : "1.37.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mobilecoinofficial/libmobilecoin.git",
       "state" : {
-        "revision" : "87d4793bcf5fd8fca9985f306b823bb24e7e27d4",
+        "revision" : "ed3669985753477b4d57959400bd21156833a77c",
         "version" : "6.1.0"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // and from where they can be fetched:
         .package(
             url: "https://github.com/mobilecoinofficial/libmobilecoin.git",
-            from: "6.0.4"
+            from: "6.1.0"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,14 @@ let package = Package(
          ),
         .testTarget(
             name: "MobileCoinTests",
-            dependencies: ["MobileCoin"],
+            // 6.1.0 keeps the vectors out of LibMobileCoinCore so a shipping app
+            // does not carry them, so the test target asks for them by name.
+            // Without this `canImport(LibMobileCoinTestVector)` is false and the
+            // tests read vectors this target never copies.
+            dependencies: [
+                "MobileCoin",
+                .product(name: "LibMobileCoinTestVectors", package: "libmobilecoin"),
+            ],
             path: "Tests",
             exclude: [
                 "Common/Secrets/secrets.json.sample",

--- a/README.md
+++ b/README.md
@@ -15,14 +15,19 @@ MobileCoin is a privacy-preserving payments network designed for use on mobile d
 * MobileCoin is a prototype. Expect substantial changes before the release.
 * Please see [*CONTRIBUTING.md*](./CONTRIBUTING.md) for notes on contributing bug reports and code.
 
-# `libmobilecoin` history rewrite
+# `libmobilecoin` moved
 
-We migrated `libmobilecoin`, our static library submodule, with `git lfs migrate`. It rewrites the commit history 
-so older submodule commit hashes will be broken.  We archived all those commits here:
+A fresh `libmobilecoin` repository took over the name. Its history starts at
+v6.1.0, so every older commit hash resolves only in
+[`libmobilecoin-archive`](https://github.com/mobilecoinofficial/libmobilecoin-archive).
+The `Vendor/libmobilecoin` submodule points there until the CocoaPods
+migration removes it.
 
-[`libmobilecoin-archive`](https://github.com/mobilecoinofficial/libmobilecoin-archive)
-
-which can be used in place of `libmobilecoin` for older commits. 
+Both repositories carry a `v6.1.0` tag, and `libmobilecoin.git` served the
+archive's one before the rename. SwiftPM records the fingerprint it first
+resolved for a URL and refuses a different one. A machine that saw the
+archive's tag needs `~/.swiftpm/security/fingerprints/libmobilecoin-*.json`
+deleted once.
 
 # Table of Contents
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -17,17 +17,9 @@ MobileCoin is a privacy-preserving payments network designed for use on mobile d
 
 # `libmobilecoin` moved
 
-A fresh `libmobilecoin` repository took over the name. Its history starts at
-v6.1.0, so every older commit hash resolves only in
-[`libmobilecoin-archive`](https://github.com/mobilecoinofficial/libmobilecoin-archive).
-The `Vendor/libmobilecoin` submodule points there until the CocoaPods
-migration removes it.
+A fresh `libmobilecoin` repository took over the name. Its history starts at v6.1.0, so every older commit hash resolves only in [`libmobilecoin-archive`](https://github.com/mobilecoinofficial/libmobilecoin-archive). The `Vendor/libmobilecoin` submodule points there until the CocoaPods migration removes it. An existing clone needs `git submodule sync --recursive` to pick up the new URL.
 
-Both repositories carry a `v6.1.0` tag, and `libmobilecoin.git` served the
-archive's one before the rename. SwiftPM records the fingerprint it first
-resolved for a URL and refuses a different one. A machine that saw the
-archive's tag needs `~/.swiftpm/security/fingerprints/libmobilecoin-*.json`
-deleted once.
+Both repositories carry a `v6.1.0` tag, and `libmobilecoin.git` served the archive's one before the rename. SwiftPM records the fingerprint it first resolved for a URL and refuses a different one. A machine that saw the archive's tag needs `~/.swiftpm/security/fingerprints/libmobilecoin-*.json` deleted once.
 
 # Table of Contents
 - [License](#license)

--- a/Tests/Unit/Encodings/Base58CoderTests.swift
+++ b/Tests/Unit/Encodings/Base58CoderTests.swift
@@ -5,6 +5,10 @@
 @testable import MobileCoin
 import XCTest
 
+#if canImport(LibMobileCoinTestVector)
+import LibMobileCoinTestVector
+#endif
+
 extension Bundle {
     static func getVectorPath(_ filename: String) throws -> URL {
         #if canImport(LibMobileCoinTestVector)


### PR DESCRIPTION
libmobilecoin v6.0.4 carries two submodules, `Vendor/mobilecoin` for the foundation monorepo and `Artifacts` for a git-lfs repo of prebuilt `.a` files, and every SwiftPM consumer pays both at resolve time. v6.1.0 has no `.gitmodules`: it ships the xcframework as a checksummed release asset through a `binaryTarget`, so the resolve takes the asset and no submodule. The lock also moves swift-protobuf to 1.37.0, because the libmobilecoin change forces a full re-resolve and 6.1.0 caps swift-protobuf below 1.38.0.

`libmobilecoin` then moved. A fresh repository took over the name and the old one became `libmobilecoin-archive`, which killed GitHub's rename redirect and every pin that resolved a pre-6.1.0 object. This branch repins SwiftPM at the new repository's v6.1.0 revision and repoints the `Vendor/libmobilecoin` submodule at the archive that still holds its gitlink.

Notes:

- `pod-lib-lint` and `publish-pod-release` are removed here rather than deferred. `MobileCoin.podspec` pins `LibMobileCoin/CoreHTTP` at `~> 6.0.0-pre1`, CocoaPods takes the highest match, and that is 6.0.2, whose source is the repository name the fresh libmobilecoin now holds. `pod lib lint` reads CocoaPods trunk and nothing else, so the clone fails. Three of the 47 trunk versions carry that source; the rest point at libmobilecoin-ios-artifacts and still resolve. SENTZ-5564 retires the pod rather than republishing it.
- `MobileCoin.podspec` stays. ExampleHTTP consumes it through a local `path:` external source that never reads trunk, and the SwiftLint binary comes from the Pods tree the same `pod install` populates, so deleting it would take out the two jobs that are currently green.
- A new `build-spm` job compiles the package and its test targets without the CocoaPods toolchain, which is what proves an SPM consumer can resolve libmobilecoin on a cold machine. The tests compile but do not run, because generating `Tests/Common/Secrets/secrets.json` needs a macOS-keychain identity.
- mobilecoin-app reaches this repo through CocoaPods today, so the floor does not change the app. SENTZ-5555 moves the Flutter plugin onto SwiftPM.
- `Package.swift` joins the SwiftLint `excluded:` list. SwiftPM fixes the manifest's shape, so `file_header` and `prefixed_toplevel_constant` fire on it and can never be satisfied.