### PR TITLE
chore(SENTZ-5600): Correct ten misattributed Safety comments

### DIFF
--- a/Sources/Common/Ledger/TxOutUtils.swift
+++ b/Sources/Common/Ledger/TxOutUtils.swift
@@ -234,7 +234,7 @@ enum TxOutUtils {
                             // supplied incorrectly.
                             logger.fatalError("error: \(redacting: error)")
                         default:
-                            // Safety: mc_fog_resolver_add_report_response should not throw
+                            // Safety: mc_tx_out_get_subaddress_spend_public_key should not throw
                             // non-documented errors.
                             logger.fatalError("Unhandled LibMobileCoin error: \(redacting: error)")
                         }
@@ -279,10 +279,10 @@ enum TxOutUtils {
                             return nil
                         case .invalidInput:
                             // Safety: This condition indicates a programming error and can only
-                            // happen if arguments to mc_tx_out_get_value are supplied incorrectly.
+                            // happen if arguments to mc_tx_out_get_amount are supplied incorrectly.
                             logger.fatalError("error: \(redacting: error)")
                         default:
-                            // Safety: mc_tx_out_get_value should not throw non-documented errors.
+                            // Safety: mc_tx_out_get_amount should not throw non-documented errors.
                             logger.fatalError("Unhandled LibMobileCoin error: \(redacting: error)")
                         }
                     }

--- a/Sources/Common/Network/Attestation/AttestationVerifier.swift
+++ b/Sources/Common/Network/Attestation/AttestationVerifier.swift
@@ -13,7 +13,7 @@ final class AttestationVerifier {
     private let ptr: OpaquePointer
 
     init(attestation: Attestation) {
-        // Safety: mc_verifier_create should never return nil.
+        // Safety: mc_trusted_identities_create should never return nil.
         self.ptr = withMcInfallible(mc_trusted_identities_create)
 
         attestation.mrEnclaves.forEach(addMrEnclave)
@@ -61,7 +61,7 @@ private final class MrEnclaveVerifier {
         }
 
         self.ptr = mrEnclave.mrEnclave.asMcBuffer { mrEnclavePtr in
-            // Safety: mc_mr_enclave_verifier_create should never fail.
+            // Safety: mc_trusted_identity_mr_enclave_create should never fail.
             withMcInfallible {
                 mc_trusted_identity_mr_enclave_create(
                     mrEnclavePtr,
@@ -97,7 +97,7 @@ private final class MrSignerVerifier {
         }
 
         self.ptr = mrSigner.mrSigner.asMcBuffer { mrSignerPtr in
-            // Safety: mc_mr_signer_verifier_create should never fail.
+            // Safety: mc_trusted_identity_mr_signer_create should never fail.
             withMcInfallible {
                 mc_trusted_identity_mr_signer_create(
                     mrSignerPtr,

--- a/Sources/Common/Transaction/Memos/SenderWithPaymentIntentMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/SenderWithPaymentIntentMemoUtils.swift
@@ -118,13 +118,14 @@ enum SenderWithPaymentIntentMemoUtils {
                         switch error.errorCode {
                         case .invalidInput:
                             // Safety: This condition indicates a programming error and can only
-                            // happen if arguments to mc_tx_out_reconstruct_commitment are
-                            // supplied incorrectly.
+                            // happen if arguments to
+                            // mc_memo_sender_with_payment_intent_memo_create are supplied
+                            // incorrectly.
                             logger.warning("error: \(redacting: error)")
                             return nil
                         default:
-                            // Safety: mc_tx_out_reconstruct_commitment should not throw
-                            // non-documented errors.
+                            // Safety: mc_memo_sender_with_payment_intent_memo_create should
+                            // not throw non-documented errors.
                             logger.warning("Unhandled LibMobileCoin error: \(redacting: error)")
                             return nil
                         }

--- a/Sources/Common/Transaction/Memos/SenderWithPaymentRequestMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/SenderWithPaymentRequestMemoUtils.swift
@@ -118,13 +118,14 @@ enum SenderWithPaymentRequestMemoUtils {
                         switch error.errorCode {
                         case .invalidInput:
                             // Safety: This condition indicates a programming error and can only
-                            // happen if arguments to mc_tx_out_reconstruct_commitment are
-                            // supplied incorrectly.
+                            // happen if arguments to
+                            // mc_memo_sender_with_payment_request_memo_create are supplied
+                            // incorrectly.
                             logger.warning("error: \(redacting: error)")
                             return nil
                         default:
-                            // Safety: mc_tx_out_reconstruct_commitment should not throw
-                            // non-documented errors.
+                            // Safety: mc_memo_sender_with_payment_request_memo_create should
+                            // not throw non-documented errors.
                             logger.warning("Unhandled LibMobileCoin error: \(redacting: error)")
                             return nil
                         }

--- a/Sources/Common/Transaction/SignedContingentInputBuilderUtils.swift
+++ b/Sources/Common/Transaction/SignedContingentInputBuilderUtils.swift
@@ -195,7 +195,7 @@ enum SignedContingentInputBuilderUtils {
                     logger.warning("error: \(redacting: error)")
                     return false
                 default:
-                    // Safety: mc_memo_sender_with_payment_request_memo_is_valid
+                    // Safety: mc_signed_contingent_input_data_is_valid
                     // should not throw non-documented errors.
                     logger.warning("Unhandled LibMobileCoin error: \(redacting: error)")
                     return false

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -81,7 +81,7 @@ final class TransactionBuilder {
                     case .invalidInput:
                         return .invalidInput("\(redacting: $0.description)")
                     default:
-                        // Safety: mc_transaction_builder_add_input should not throw
+                        // Safety: mc_transaction_builder_create should not throw
                         // non-documented errors.
                         logger.fatalError("Unhandled LibMobileCoin error: \(redacting: $0)")
                     }

--- a/Sources/Common/Utils/Rng/MobileCoinChaCha20Rng.swift
+++ b/Sources/Common/Utils/Rng/MobileCoinChaCha20Rng.swift
@@ -108,7 +108,7 @@ public final class MobileCoinChaCha20Rng: MobileCoinRng {
                     logger.fatalError(
                         "LibMobileCoin panic error: \(redacting: error.description)")
                 default:
-                    // Safety: mc_chacha20_set_word_pos should not throw
+                    // Safety: mc_chacha20_rng_set_word_pos should not throw
                     // non-documented errors.
                     logger.fatalError("Unhandled LibMobileCoin error: \(redacting: error)")
                 }


### PR DESCRIPTION
Soundtrack of this PR: [Talking Heads - Once in a Lifetime](https://www.youtube.com/watch?v=5IsSpAOD6K8)

### Motivation

Ten `Safety:` comments name a libmobilecoin function that their own file never calls. Three name `mc_verifier_create`, `mc_mr_enclave_verifier_create` and `mc_mr_signer_verifier_create`, which libmobilecoin declares in `attest.h` and implements nowhere, so a reader who follows one reaches a symbol the library never exports. The other seven are copy-paste from a neighbouring file and name a real symbol that belongs to a different call.

### In this PR
* `AttestationVerifier.swift` - the three comments name the `mc_trusted_identity` call on the line below them, which is what the two comments already above them do.
* Six more files - each comment names the call whose error its arm handles. Three of those blocks name the wrong function in the `invalidInput` case too, so those lines move with the block.
* The two memo files rewrap, because the correct name is longer than the old wrap allowed.

Comment text only. No call site moves.

Implements SENTZ-5600.

### Future Work
* [SENTZ-5528](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5528) deletes the three dead declarations from libmobilecoin, so the names this PR removes stop being reachable at all.


[SENTZ-5528]: https://sentz.atlassian.net/browse/SENTZ-5528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ