### PR TITLE
chore(SENTZ-5653): Remove the three podspec test globs that match no path

### DIFF
--- a/ExampleHTTP/Podfile.lock
+++ b/ExampleHTTP/Podfile.lock
@@ -55,7 +55,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
   LibMobileCoin: 966c1694581ebd50da6623c499ed18c0e1bbe211
-  MobileCoin: cc8983cf8a4808bff3f966c3bce203b38b811aca
+  MobileCoin: 18e1f2dea1effe8f030e2ab0525d7c4f49e2fc55
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   SwiftProtobuf: 3fafd1b2fb97e6d95ad9c8adb2215da9afec7c83
 

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -37,13 +37,13 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'IntegrationTransactingTests' do |test_spec|
-    test_spec.source_files = "Tests/{Common,Integration/Common,Integration/Transacting}/**/*.swift"
+    test_spec.source_files = "Tests/{Common,Integration/Transacting}/**/*.swift"
     test_spec.resource = "Tests/Common/FixtureData/**/*",
     test_spec.resource = "Tests/Common/Secrets/process_info.json"
   end
 
   s.test_spec 'IntegrationNonTransactingTests' do |test_spec|
-    test_spec.source_files = "Tests/{Common,Util,Integration/Common,Integration/NonTransacting}/**/*.swift"
+    test_spec.source_files = "Tests/{Common,Integration/NonTransacting}/**/*.swift"
     test_spec.resource = "Tests/Common/FixtureData/**/*",
     test_spec.resource = "Tests/Common/Secrets/process_info.json"
   end
@@ -70,7 +70,6 @@ Pod::Spec.new do |s|
 
     subspec.test_spec 'HttpProtocolUnitTests' do |test_spec|
       test_spec.source_files = "Tests/ProtocolSpecific/Http/**/*.swift"
-      test_spec.resource = "Tests/ProtocolSpecific/Http/FixtureData/**/*"
     end
 
     unless ENV["MC_ENABLE_SWIFTLINT_SCRIPT"].nil?

--- a/MobileCoin.podspec
+++ b/MobileCoin.podspec
@@ -38,14 +38,18 @@ Pod::Spec.new do |s|
 
   s.test_spec 'IntegrationTransactingTests' do |test_spec|
     test_spec.source_files = "Tests/{Common,Integration/Transacting}/**/*.swift"
-    test_spec.resource = "Tests/Common/FixtureData/**/*",
-    test_spec.resource = "Tests/Common/Secrets/process_info.json"
+    test_spec.resources = [
+      "Tests/Common/FixtureData/**/*",
+      "Tests/Common/Secrets/process_info.json",
+    ]
   end
 
   s.test_spec 'IntegrationNonTransactingTests' do |test_spec|
     test_spec.source_files = "Tests/{Common,Integration/NonTransacting}/**/*.swift"
-    test_spec.resource = "Tests/Common/FixtureData/**/*",
-    test_spec.resource = "Tests/Common/Secrets/process_info.json"
+    test_spec.resources = [
+      "Tests/Common/FixtureData/**/*",
+      "Tests/Common/Secrets/process_info.json",
+    ]
   end
 
   s.test_spec 'PerformanceTests' do |test_spec|


### PR DESCRIPTION
[Link to Task](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5653)

Three glob fragments in `MobileCoin.podspec` name paths the tree does not hold, so they contribute nothing to any testspec. The podspec asks for `Tests/Util`, `Tests/Integration/Common` and `Tests/ProtocolSpecific/Http/FixtureData`. The tree holds `Tests/Common/Utils`, `Tests/Common/Integration` and `Tests/ProtocolSpecific/Http/FixturesData` instead. Both integration testspecs compile the same 67 and 81 files after the removal.

A second commit states each integration testspec's resources as one array. The two lines it replaces are held together by a trailing comma. The comma makes the second assignment an element of the first one's right-hand side. So `resource` is written twice and ends up holding both paths, and the shipped value is correct today. Removing that comma as stray punctuation would silently drop the fixture glob.

Notes:

- `Tests/Common/FixtureData` is a different path, it is live, and the second commit keeps it.
- The lock carries the new `MobileCoin` spec checksum. CI runs `pod install --deployment`, and `verify_no_lockfile_changes!` fails on any delta.
- The removed `resource` glob copied nothing. The one file under `FixturesData` is already compiled by the `source_files` glob one line above it.
- `bundle exec pod install --deployment` needs Ruby 3.1.x, which this machine does not have. The checksum was derived twice by independent routes, each proven first against the value this commit replaces.
- The resources commit leaves the generated podspec JSON byte for byte unchanged, so it carries no lock update.
