### PR TITLE
refactor(SENTZ-5671): Delete the unreachable CocoaPods compile branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Cheap and first, so a broken secret lookup fails before the build.
+      - name: Check the secret lookup helper
+        run: tools/lookup_test.sh
+
       # No `.build` cache on purpose. The entry would be the whole build tree,
       # which is large against this repo's cache budget.
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Tests/Common/Secrets/secrets.json
 
 # process info JSON
 tools/TestSetupClient/TestSetupClientTests/process_info.json
+Tests/Common/Secrets/process_info.json

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,13 @@ swiftlint:
 generate-local-process-info:
 	tools/generate_process_info_jsons.sh
 
+# Writes the three generated test resources. The target decrypts, so it needs
+# your age keys in the keychain.
+.PHONY: init-secrets
+init-secrets:
+	tools/generate_process_info_jsons.sh
+	tools/generate_secrets_json.sh
+
 # Builds every target in Package.swift, test targets included. Plain `swift
 # build` skips those, so a test target that cannot compile still goes green.
 # The test targets declare generated resources, which from tools 6.0 must exist

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
             path: "Tests",
             exclude: [
                 "Common/Secrets/secrets.json.sample",
+                "Common/Secrets/process_info.json.sample",
                 "ProtocolSpecific/Grpc",
             ],
             resources: [

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,6 @@ let package = Package(
             name: "MobileCoinTests",
             // 6.1.0 keeps the vectors out of LibMobileCoinCore so a shipping app
             // does not carry them, so the test target asks for them by name.
-            // Without this `canImport(LibMobileCoinTestVector)` is false and the
-            // tests read vectors this target never copies.
             dependencies: [
                 "MobileCoin",
                 .product(name: "LibMobileCoinTestVectors", package: "libmobilecoin"),

--- a/Sources/Common/Account/Account+BalanceUpdater.swift
+++ b/Sources/Common/Account/Account+BalanceUpdater.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Account {
     struct BalanceUpdater {

--- a/Sources/Common/Account/AccountKey.swift
+++ b/Sources/Common/Account/AccountKey.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct AccountKey {
     static func make(

--- a/Sources/Common/Account/AccountKeyUtils.swift
+++ b/Sources/Common/Account/AccountKeyUtils.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum AccountKeyUtils {
     static func subaddressPrivateKeys(

--- a/Sources/Common/Account/AddressHash.swift
+++ b/Sources/Common/Account/AddressHash.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct AddressHash {
     let data16: Data16

--- a/Sources/Common/Account/PublicAddress.swift
+++ b/Sources/Common/Account/PublicAddress.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct PublicAddress {
     static func make(

--- a/Sources/Common/Account/RootEntropyUtils.swift
+++ b/Sources/Common/Account/RootEntropyUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum RootEntropyUtils {
     static func privateKeys(

--- a/Sources/Common/Crypto/CryptoUtils.swift
+++ b/Sources/Common/Crypto/CryptoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum CryptoUtils {
     static func ristrettoPrivateValidate(_ bytes: Data) -> Bool {

--- a/Sources/Common/Crypto/RistrettoPrivate.swift
+++ b/Sources/Common/Crypto/RistrettoPrivate.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct RistrettoPrivate {
     let data32: Data32

--- a/Sources/Common/Crypto/RistrettoPublic.swift
+++ b/Sources/Common/Crypto/RistrettoPublic.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct RistrettoPublic {
     let data32: Data32

--- a/Sources/Common/Crypto/VersionedCryptoBox.swift
+++ b/Sources/Common/Crypto/VersionedCryptoBox.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public enum VersionedCryptoBoxError: Error, Sendable {
     case invalidInput(String)

--- a/Sources/Common/Encodings/Base58Coder.swift
+++ b/Sources/Common/Encodings/Base58Coder.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public enum Base58DecodingResult {
     case publicAddress(PublicAddress)

--- a/Sources/Common/Encodings/PaymentRequest.swift
+++ b/Sources/Common/Encodings/PaymentRequest.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct PaymentRequest {
     public let publicAddress: PublicAddress

--- a/Sources/Common/Encodings/PrintableWrapper+Base58.swift
+++ b/Sources/Common/Encodings/PrintableWrapper+Base58.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Printable_PrintableWrapper {
     init?(base58Encoded base58String: String) {

--- a/Sources/Common/Encodings/TransferPayload.swift
+++ b/Sources/Common/Encodings/TransferPayload.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct TransferPayload {
     let rootEntropy32: Data32?

--- a/Sources/Common/Fog/FogKeyImageChecker.swift
+++ b/Sources/Common/Fog/FogKeyImageChecker.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct FogKeyImageChecker {
     private let serialQueue: DispatchQueue

--- a/Sources/Common/Fog/FogMerkleProofFetcher.swift
+++ b/Sources/Common/Fog/FogMerkleProofFetcher.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum FogMerkleProofFetcherError: Error, Sendable {
     case connectionError(ConnectionError)

--- a/Sources/Common/Fog/FogUntrustedTxOutFetcher.swift
+++ b/Sources/Common/Fog/FogUntrustedTxOutFetcher.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct FogUntrustedTxOutFetcher {
     private let fogUntrustedTxOutService: FogUntrustedTxOutService

--- a/Sources/Common/Fog/FogViewKeyScanner.swift
+++ b/Sources/Common/Fog/FogViewKeyScanner.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogViewKeyScanner {
     private let accountKey: AccountKey

--- a/Sources/Common/Fog/Report/FogReportManager.swift
+++ b/Sources/Common/Fog/Report/FogReportManager.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogReportManager {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/Common/Fog/Report/FogReportServer.swift
+++ b/Sources/Common/Fog/Report/FogReportServer.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogReportServer {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/Common/Fog/Report/FogResolver.swift
+++ b/Sources/Common/Fog/Report/FogResolver.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogResolver {
     private let ptr: OpaquePointer

--- a/Sources/Common/Fog/Report/FogResolverManager.swift
+++ b/Sources/Common/Fog/Report/FogResolverManager.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogResolverManager {
     private let serialQueue: DispatchQueue

--- a/Sources/Common/Fog/View/FogRng.swift
+++ b/Sources/Common/Fog/View/FogRng.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum FogRngError: Error, Sendable {
     case invalidKey(String)

--- a/Sources/Common/Fog/View/FogRngKey.swift
+++ b/Sources/Common/Fog/View/FogRngKey.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct FogRngKey {
     let pubkey: Data

--- a/Sources/Common/Fog/View/FogRngSet.swift
+++ b/Sources/Common/Fog/View/FogRngSet.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogRngSet {
     private var ingestInvocationIdToRngTrackers: [Int64: RngTracker] = [:]

--- a/Sources/Common/Fog/View/FogView+TxOutFetcher.swift
+++ b/Sources/Common/Fog/View/FogView+TxOutFetcher.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 import os
 
 extension FogView {

--- a/Sources/Common/Fog/View/FogView.swift
+++ b/Sources/Common/Fog/View/FogView.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogView {
     var syncCheckerLock: ReadWriteDispatchLock<FogSyncCheckable>

--- a/Sources/Common/Fog/View/FogViewUtils.swift
+++ b/Sources/Common/Fog/View/FogViewUtils.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum FogViewUtils {
     static func encryptTxOutRecord(

--- a/Sources/Common/Ledger/KeyImage.swift
+++ b/Sources/Common/Ledger/KeyImage.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct KeyImage {
     let data32: Data32

--- a/Sources/Common/Ledger/LedgerTxOut.swift
+++ b/Sources/Common/Ledger/LedgerTxOut.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct LedgerTxOut: TxOutProtocol {
     private let txOut: PartialTxOut

--- a/Sources/Common/Ledger/PartialTxOut.swift
+++ b/Sources/Common/Ledger/PartialTxOut.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct PartialTxOut: TxOutProtocol {
     let encryptedMemo: Data66

--- a/Sources/Common/Ledger/TxOut.swift
+++ b/Sources/Common/Ledger/TxOut.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TxOut: TxOutProtocol {
     typealias Keys = (publicKey: RistrettoPublic, targetKey: RistrettoPublic)

--- a/Sources/Common/Ledger/TxOutMembershipProof.swift
+++ b/Sources/Common/Ledger/TxOutMembershipProof.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TxOutMembershipProof {
     let serializedData: Data

--- a/Sources/Common/Ledger/TxOutProtocol.swift
+++ b/Sources/Common/Ledger/TxOutProtocol.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 protocol TxOutProtocol {
     var encryptedMemo: Data66 { get }

--- a/Sources/Common/Ledger/TxOutUtils.swift
+++ b/Sources/Common/Ledger/TxOutUtils.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum TxOutUtils {
     static func matchesSubaddress(

--- a/Sources/Common/LibMobileCoin/Data+withMcMutableBuffer.swift
+++ b/Sources/Common/LibMobileCoin/Data+withMcMutableBuffer.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Data {
     static func make(

--- a/Sources/Common/LibMobileCoin/Data16+withMcMutableBuffer.swift
+++ b/Sources/Common/LibMobileCoin/Data16+withMcMutableBuffer.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Data16 {
     static func make(

--- a/Sources/Common/LibMobileCoin/Data32+withMcMutableBuffer.swift
+++ b/Sources/Common/LibMobileCoin/Data32+withMcMutableBuffer.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Data32 {
     static func make(

--- a/Sources/Common/LibMobileCoin/Data64+withMcMutableBuffer.swift
+++ b/Sources/Common/LibMobileCoin/Data64+withMcMutableBuffer.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Data64 {
     static func make(

--- a/Sources/Common/LibMobileCoin/Data66+withMcMutableBuffer.swift
+++ b/Sources/Common/LibMobileCoin/Data66+withMcMutableBuffer.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension Data66 {
     static func make(

--- a/Sources/Common/LibMobileCoin/LibMobileCoinError.swift
+++ b/Sources/Common/LibMobileCoin/LibMobileCoinError.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct LibMobileCoinError: Error, Sendable {
     static func make(consuming error: UnsafeMutablePointer<McError>)

--- a/Sources/Common/LibMobileCoin/McData.swift
+++ b/Sources/Common/LibMobileCoin/McData.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class McData {
     let ptr: OpaquePointer

--- a/Sources/Common/LibMobileCoin/McError.swift
+++ b/Sources/Common/LibMobileCoin/McError.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 func withMcInfallible(_ body: () -> OpaquePointer?) -> OpaquePointer {
     guard let value = body() else {

--- a/Sources/Common/LibMobileCoin/McRngCallback.swift
+++ b/Sources/Common/LibMobileCoin/McRngCallback.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 func withMcRngObjCallback<T>(
     rng: MobileCoinRng,

--- a/Sources/Common/LibMobileCoin/McString.swift
+++ b/Sources/Common/LibMobileCoin/McString.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension String {
     init(mcString: UnsafeMutablePointer<CChar>) {

--- a/Sources/Common/LibMobileCoin/MobileCoinUpstreamInterop.swift
+++ b/Sources/Common/LibMobileCoin/MobileCoinUpstreamInterop.swift
@@ -5,9 +5,7 @@
 // swiftlint:disable orphaned_doc_comment
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 /// This file contains temporary interop code to allow easy source compatibility with upstream
 /// LibMobileCoin and MobileCoin server code. The code in this file can be removed once upstream

--- a/Sources/Common/LibMobileCoin/ProtoExtensions.swift
+++ b/Sources/Common/LibMobileCoin/ProtoExtensions.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 // MARK: - External
 

--- a/Sources/Common/LibMobileCoin/ProtoTypes+InfallibleDataSerializable.swift
+++ b/Sources/Common/LibMobileCoin/ProtoTypes+InfallibleDataSerializable.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 // MARK: - External
 

--- a/Sources/Common/LibMobileCoin/asMcBuffer.swift
+++ b/Sources/Common/LibMobileCoin/asMcBuffer.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension DataConvertible {
     func asMcBuffer<T>(_ body: (UnsafePointer<McBuffer>) throws -> T) rethrows -> T {

--- a/Sources/Common/Mistysign/MistysignAttestedSession.swift
+++ b/Sources/Common/Mistysign/MistysignAttestedSession.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 /// An attested channel to a Mistysign enclave whose transport is owned by the
 /// caller.

--- a/Sources/Common/Mistyswap/ForgetOfframp.swift
+++ b/Sources/Common/Mistyswap/ForgetOfframp.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension MistyswapOfframp_ForgetOfframpRequest {
 

--- a/Sources/Common/Mistyswap/GetOfframpStatus.swift
+++ b/Sources/Common/Mistyswap/GetOfframpStatus.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension MistyswapOfframp_GetOfframpStatusRequest {
 

--- a/Sources/Common/Mistyswap/InitiateOfframp.swift
+++ b/Sources/Common/Mistyswap/InitiateOfframp.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension MistyswapOfframp_InitiateOfframpRequest {
     static func make(

--- a/Sources/Common/Mistyswap/Mistyswap.swift
+++ b/Sources/Common/Mistyswap/Mistyswap.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct Mistyswap: MistyswapService {
     private let mistyswap: MistyswapService?

--- a/Sources/Common/Mnemonic/Bip39Utils.swift
+++ b/Sources/Common/Mnemonic/Bip39Utils.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum Bip39Utils {
     static func mnemonic(fromEntropy entropy: Data32) -> Mnemonic {

--- a/Sources/Common/Mnemonic/Slip10Utils.swift
+++ b/Sources/Common/Mnemonic/Slip10Utils.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 /// See https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 enum Slip10Utils {

--- a/Sources/Common/MobileCoinClient+MistySwap.swift
+++ b/Sources/Common/MobileCoinClient+MistySwap.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 extension MobileCoinClient {
 

--- a/Sources/Common/Network/Attestation/AttestAke.swift
+++ b/Sources/Common/Network/Attestation/AttestAke.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum AttestAkeError: Error, Sendable {
     case invalidInput(String)

--- a/Sources/Common/Network/Attestation/AttestationVerifier.swift
+++ b/Sources/Common/Network/Attestation/AttestationVerifier.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 // TrustedIdentities
 final class AttestationVerifier {

--- a/Sources/Common/Network/Connection/Connections/BlockchainConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/BlockchainConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 import SwiftProtobuf
 
 final class BlockchainConnection: Connection<

--- a/Sources/Common/Network/Connection/Connections/ConsensusConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/ConsensusConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class ConsensusConnection: Connection<
         GrpcProtocolConnectionFactory.ConsensusServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogBlockConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogBlockConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogBlockConnection: Connection<
         GrpcProtocolConnectionFactory.FogBlockServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogKeyImageConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogKeyImageConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogKeyImageConnection: Connection<
         GrpcProtocolConnectionFactory.FogKeyImageServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogMerkleProofConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogMerkleProofConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogMerkleProofConnection: Connection<
         GrpcProtocolConnectionFactory.FogMerkleProofServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogReportConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogReportConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogReportConnection: ArbitraryConnection<
         GrpcProtocolConnectionFactory.FogReportServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogUntrustedTxOutConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogUntrustedTxOutConnection: Connection<
         GrpcProtocolConnectionFactory.FogUntrustedTxOutServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/FogViewConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/FogViewConnection.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class FogViewConnection: Connection<
         GrpcProtocolConnectionFactory.FogViewServiceProvider,

--- a/Sources/Common/Network/Connection/Connections/MistyswapConnection.swift
+++ b/Sources/Common/Network/Connection/Connections/MistyswapConnection.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class MistyswapConnection: Connection<
         GrpcProtocolConnectionFactory.MistyswapServiceProvider,

--- a/Sources/Common/Network/Connection/ProtocolConnectionFactory.swift
+++ b/Sources/Common/Network/Connection/ProtocolConnectionFactory.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 protocol ProtocolConnectionFactory {
     associatedtype ConsensusServiceProvider: ConsensusServiceConnection

--- a/Sources/Common/Network/HttpRequester.swift
+++ b/Sources/Common/Network/HttpRequester.swift
@@ -5,13 +5,9 @@
 // swiftlint:disable all
 
 import Foundation
-import SwiftProtobuf
-#if canImport(LibMobileCoin)
 import LibMobileCoin
-#endif
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinHTTP
-#endif
+import SwiftProtobuf
 
 public protocol HttpRequester {
     func request(

--- a/Sources/Common/Network/Service/ConsensusService.swift
+++ b/Sources/Common/Network/Service/ConsensusService.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 protocol ConsensusService {
     func proposeTx(

--- a/Sources/Common/Network/Service/FogServices.swift
+++ b/Sources/Common/Network/Service/FogServices.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct FogViewQueryRequestWrapper {
     var requestAad = FogView_QueryRequestAAD()

--- a/Sources/Common/Network/Service/MistyswapServices.swift
+++ b/Sources/Common/Network/Service/MistyswapServices.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 protocol MistyswapService {
     func initiateOfframp(

--- a/Sources/Common/Transaction/Amount.swift
+++ b/Sources/Common/Transaction/Amount.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct Amount: Sendable {
     public let value: UInt64

--- a/Sources/Common/Transaction/MaskedAmount.swift
+++ b/Sources/Common/Transaction/MaskedAmount.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct MaskedAmount {
     enum Version {

--- a/Sources/Common/Transaction/McTransactionBuilderRing.swift
+++ b/Sources/Common/Transaction/McTransactionBuilderRing.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 final class McTransactionBuilderRing {
     private let ptr: OpaquePointer

--- a/Sources/Common/Transaction/Memos/DestinationMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/DestinationMemoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum DestinationMemoUtils {
 

--- a/Sources/Common/Transaction/Memos/DestinationWithPaymentIntentMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/DestinationWithPaymentIntentMemoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum DestinationWithPaymentIntentMemoUtils {
 

--- a/Sources/Common/Transaction/Memos/DestinationWithPaymentRequestMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/DestinationWithPaymentRequestMemoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum DestinationWithPaymentRequestMemoUtils {
 

--- a/Sources/Common/Transaction/Memos/SenderMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/SenderMemoUtils.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum SenderMemoUtils {
     static func isValid(

--- a/Sources/Common/Transaction/Memos/SenderWithPaymentIntentMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/SenderWithPaymentIntentMemoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum SenderWithPaymentIntentMemoUtils {
 

--- a/Sources/Common/Transaction/Memos/SenderWithPaymentRequestMemoUtils.swift
+++ b/Sources/Common/Transaction/Memos/SenderWithPaymentRequestMemoUtils.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum SenderWithPaymentRequestMemoUtils {
 

--- a/Sources/Common/Transaction/Outputs/TxOutConfirmationNumber.swift
+++ b/Sources/Common/Transaction/Outputs/TxOutConfirmationNumber.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TxOutConfirmationNumber {
     let data32: Data32

--- a/Sources/Common/Transaction/Receipt.swift
+++ b/Sources/Common/Transaction/Receipt.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 /// Represents a single "output" `TxOut` from a `Transaction`. Intended to be serialized and sent to
 /// the recipient of that `TxOut`. The recipient is able to use `Receipt` to validate that a

--- a/Sources/Common/Transaction/SignedContingentInput.swift
+++ b/Sources/Common/Transaction/SignedContingentInput.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct SignedContingentInput: Sendable {
     fileprivate let proto: External_SignedContingentInput

--- a/Sources/Common/Transaction/SignedContingentInputBuilder.swift
+++ b/Sources/Common/Transaction/SignedContingentInputBuilder.swift
@@ -5,9 +5,7 @@
 // swiftlint:disable closure_body_length
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum SignedContingentInputBuilderError: Error, Sendable {
     case invalidInput(String)

--- a/Sources/Common/Transaction/SignedContingentInputBuilderUtils.swift
+++ b/Sources/Common/Transaction/SignedContingentInputBuilderUtils.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum SignedContingentInputBuilderUtils {
 

--- a/Sources/Common/Transaction/Transaction.swift
+++ b/Sources/Common/Transaction/Transaction.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public struct Transaction: Sendable {
     fileprivate let proto: External_Tx

--- a/Sources/Common/Transaction/TransactionBuilder.swift
+++ b/Sources/Common/Transaction/TransactionBuilder.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum TransactionBuilderError: Error, Sendable {
     case invalidInput(String)

--- a/Sources/Common/Transaction/TransactionBuilderUtils.swift
+++ b/Sources/Common/Transaction/TransactionBuilderUtils.swift
@@ -5,9 +5,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 enum TransactionBuilderUtils {
     static func addInput(

--- a/Sources/Common/Transaction/TransactionStatusChecker.swift
+++ b/Sources/Common/Transaction/TransactionStatusChecker.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TransactionStatusChecker {
     private let account: ReadWriteDispatchLock<Account>

--- a/Sources/Common/Transaction/TransactionStatusTxOutChecker.swift
+++ b/Sources/Common/Transaction/TransactionStatusTxOutChecker.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TransactionStatusTxOutChecker {
     private let account: ReadWriteDispatchLock<Account>

--- a/Sources/Common/Transaction/TransactionSubmitter.swift
+++ b/Sources/Common/Transaction/TransactionSubmitter.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 struct TransactionSubmitter {
     private let consensusService: ConsensusService

--- a/Sources/Common/Transaction/TxOutMemoBuilder.swift
+++ b/Sources/Common/Transaction/TxOutMemoBuilder.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 public enum MemoType {
     case unused

--- a/Sources/Common/Utils/Rng/MobileCoinChaCha20Rng.swift
+++ b/Sources/Common/Utils/Rng/MobileCoinChaCha20Rng.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 //
 //    Full access to the RNG class is no longer neccessary for repeatable transaction creation.

--- a/Sources/HTTPS/DefaultHttpRequester.swift
+++ b/Sources/HTTPS/DefaultHttpRequester.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 // The pinning delegate is a separate object now, so the session is a `let`
 // built in init rather than a racy `lazy var`.

--- a/Sources/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/ArbitraryHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 class ArbitraryHttpConnection {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/HTTPS/HttpConnection/AttestedHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/AttestedHttpConnection.swift
@@ -7,10 +7,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 enum AttestedHttpConnectionError: Error, Sendable {
     case connectionError(ConnectionError)

--- a/Sources/HTTPS/HttpConnection/HttpCallable/AttestedHttpCallable.swift
+++ b/Sources/HTTPS/HttpConnection/HttpCallable/AttestedHttpCallable.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 import SwiftProtobuf
 
 protocol AttestedHttpCallable: HttpCallable {

--- a/Sources/HTTPS/HttpConnection/HttpCallable/AuthHttpCallable.swift
+++ b/Sources/HTTPS/HttpConnection/HttpCallable/AuthHttpCallable.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 protocol AuthHttpCallable {
     var requester: RestApiRequester { get }

--- a/Sources/HTTPS/HttpConnection/HttpCallable/AuthHttpCallableClientWrapper.swift
+++ b/Sources/HTTPS/HttpConnection/HttpCallable/AuthHttpCallableClientWrapper.swift
@@ -5,10 +5,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinHTTP
 import LibMobileCoinCommon
-#endif
 
 
 protocol AuthQueryHttpCalleeAndClient : QueryHttpCallee, AuthHttpCallee, HTTPClient {}

--- a/Sources/HTTPS/HttpConnection/HttpCallable/HttpCallable.swift
+++ b/Sources/HTTPS/HttpConnection/HttpCallable/HttpCallable.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 public protocol HttpCallable {
     associatedtype Request

--- a/Sources/HTTPS/HttpConnection/HttpClient/AuthHttpCallableClient.swift
+++ b/Sources/HTTPS/HttpConnection/HttpClient/AuthHttpCallableClient.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 protocol AuthHttpCallableClient: AttestableHttpClient, AuthHttpCallable {
     func auth(_ request: Attest_AuthMessage, callOptions: HTTPCallOptions?)

--- a/Sources/HTTPS/HttpConnection/HttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 class HttpConnection: ConnectionProtocol {
     private let inner: SerialDispatchLock<Inner>

--- a/Sources/HTTPS/HttpConnection/HttpConnections/BlockchainHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/BlockchainHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 import SwiftProtobuf
 
 final class BlockchainHttpConnection: HttpConnection, BlockchainService {

--- a/Sources/HTTPS/HttpConnection/HttpConnections/ConsensusHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/ConsensusHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class ConsensusHttpConnection: AttestedHttpConnection, ConsensusService {
     private let client: ConsensusClient_ConsensusClientAPIRestClient

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogBlockHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogBlockHttpConnection.swift
@@ -5,10 +5,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinHTTP
 import LibMobileCoinCommon
-#endif
 
 
 final class FogBlockHttpConnection: HttpConnection, FogBlockService {

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogKeyImageHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogKeyImageHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class FogKeyImageHttpConnection: AttestedHttpConnection, FogKeyImageService {
     private let client: AuthHttpCallableClientWrapper<FogLedger_FogKeyImageAPIRestClient>

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogMerkleProofHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogMerkleProofHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class FogMerkleProofHttpConnection: AttestedHttpConnection, FogMerkleProofService {
     private let client: AuthHttpCallableClientWrapper<FogLedger_FogMerkleProofAPIRestClient>

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogReportHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogReportHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class FogReportHttpConnection: ArbitraryHttpConnection, FogReportService {
     private let client: Report_ReportAPIRestClient

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogUntrustedTxOutHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogUntrustedTxOutHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class FogUntrustedTxOutHttpConnection: HttpConnection, FogUntrustedTxOutService {
     private let client: FogLedger_FogUntrustedTxOutApiRestClient

--- a/Sources/HTTPS/HttpConnection/HttpConnections/FogViewHttpConnection.swift
+++ b/Sources/HTTPS/HttpConnection/HttpConnections/FogViewHttpConnection.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 final class FogViewHttpConnection: AttestedHttpConnection, FogViewService {
     private let client: AuthHttpCallableClientWrapper<FogView_FogViewAPIRestClient>

--- a/Sources/HTTPS/RestApiRequester.swift
+++ b/Sources/HTTPS/RestApiRequester.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 public class RestApiRequester {
     let requester: HttpRequester

--- a/Sources/HTTPS/Utils/HttpCallResult.swift
+++ b/Sources/HTTPS/Utils/HttpCallResult.swift
@@ -4,10 +4,8 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinHTTP)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 
 public struct HttpCallResult<ResponsePayload> {
     let error: Error?

--- a/Tests/Common/Fixtures/Crypto/VersionedCryptoBox+Fixtures.swift
+++ b/Tests/Common/Fixtures/Crypto/VersionedCryptoBox+Fixtures.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 extension VersionedCryptoBox {

--- a/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
+++ b/Tests/Common/Fixtures/Encodings/PaymentRequest.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 extension PaymentRequest {

--- a/Tests/Common/Fixtures/Encodings/TransferPayload.swift
+++ b/Tests/Common/Fixtures/Encodings/TransferPayload.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 extension TransferPayload {

--- a/Tests/Common/Fixtures/Fog/Report/FogResolver+Fixtures.swift
+++ b/Tests/Common/Fixtures/Fog/Report/FogResolver+Fixtures.swift
@@ -4,9 +4,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Fixtures/Mistyswap/Mistyswap+Fixtures.swift
+++ b/Tests/Common/Fixtures/Mistyswap/Mistyswap+Fixtures.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Fixtures/Network/Connection/TestBlockchainService.swift
+++ b/Tests/Common/Fixtures/Network/Connection/TestBlockchainService.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 struct TestBlockchainService: BlockchainService {

--- a/Tests/Common/Fixtures/Network/Connection/TestConsensusService.swift
+++ b/Tests/Common/Fixtures/Network/Connection/TestConsensusService.swift
@@ -4,9 +4,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 struct TestConsensusService: ConsensusService {

--- a/Tests/Common/Fixtures/Network/NetworkPreset.swift
+++ b/Tests/Common/Fixtures/Network/NetworkPreset.swift
@@ -6,10 +6,6 @@
 @testable import MobileCoin
 import XCTest
 
-#if canImport(Keys)
-import Keys
-#endif
-
 enum NetworkPreset {
     /// MainNet (MobileCoin Consensus node1 + MobileCoin Fog)
     case mainNet
@@ -62,12 +58,7 @@ struct DynamicNetworkConfig {
 
 extension DynamicNetworkConfig {
 
-    #if canImport(Keys)
-        private static let dynamicFogAuthoritySpki =
-            MobileCoinKeys().dynamicFogAuthoritySpki
-    #else
-        private static let dynamicFogAuthoritySpki = ""
-    #endif
+    private static let dynamicFogAuthoritySpki = ""
 
     enum AlphaDevelopment {
         static let user = ""
@@ -864,50 +855,25 @@ extension NetworkPreset {
         }
     }
 
-#if canImport(Keys)
-    private static let devNetworkAuthUsername =
-        MobileCoinKeys().devNetworkAuthUsername
-#else
     private static let devNetworkAuthUsername = {
         (try? TestSecrets.load().DEV_NETWORK_AUTH_USERNAME) ?? ""
     }()
-#endif
 
-#if canImport(Keys)
-    private static let devNetworkAuthPassword =
-        MobileCoinKeys().devNetworkAuthPassword
-#else
     private static let devNetworkAuthPassword = {
         (try? TestSecrets.load().DEV_NETWORK_AUTH_PASSWORD) ?? ""
     }()
-#endif
 
-#if canImport(Keys)
-    private static let testNetTestAccountMnemonicsCommaSeparated =
-        MobileCoinKeys().testNetTestAccountMnemonicsCommaSeparated
-#else
     private static let testNetTestAccountMnemonicsCommaSeparated = {
         (try? TestSecrets.load().TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED) ?? ""
     }()
-#endif
 
-#if canImport(Keys)
-    private static let mobileDevTestAccountMnemonicsCommaSeparated =
-        MobileCoinKeys().mobileDevTestAccountMnemonicsCommaSeparated
-#else
     private static let mobileDevTestAccountMnemonicsCommaSeparated = {
         (try? TestSecrets.load().MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED) ?? ""
     }()
-#endif
 
-#if canImport(Keys)
-    private static let dynamicTestAccountSeedEntropiesCommaSeparated =
-        MobileCoinKeys().dynamicTestAccountSeedEntropiesCommaSeparated
-#else
     private static let dynamicTestAccountSeedEntropiesCommaSeparated = {
         (try? TestSecrets.load().DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED) ?? ""
     }()
-#endif
 
     // swiftlint:disable force_unwrapping
     var testAccountsPrivateKeys:

--- a/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/Transaction+Fixtures.swift
@@ -4,9 +4,7 @@
 // swiftlint:disable file_length multiline_function_chains force_unwrapping function_body_length
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 
@@ -1485,13 +1483,9 @@ extension Transaction.Fixtures.ExactChange {
 extension Transaction.Fixtures.Serialization {
 
     fileprivate static func serializedData() throws -> Data {
-        #if canImport(LibMobileCoinHTTP)
         try Data(
             contentsOf: Bundle.testDataModuleUrl("TransactionSerializedData", withExtension: "bin")
         )
-        #else
-        try Data(contentsOf: Bundle.url("TransactionSerializedData", "bin"))
-        #endif
     }
 
 }

--- a/Tests/Common/Fixtures/Transaction/TxOutMemoParser+Fixtures.swift
+++ b/Tests/Common/Fixtures/Transaction/TxOutMemoParser+Fixtures.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Fixtures/UrlLoadBalancerFixtures.swift
+++ b/Tests/Common/Fixtures/UrlLoadBalancerFixtures.swift
@@ -2,9 +2,7 @@
 //  Copyright (c) 2020-2022 MobileCoin. All rights reserved.
 //
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Fixtures/UrlLoadBalancerFixturesIntegration.swift
+++ b/Tests/Common/Fixtures/UrlLoadBalancerFixturesIntegration.swift
@@ -2,9 +2,7 @@
 //  Copyright (c) 2020-2022 MobileCoin. All rights reserved.
 //
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Integration/IntegrationTestFixtures.swift
+++ b/Tests/Common/Integration/IntegrationTestFixtures.swift
@@ -458,20 +458,11 @@ struct ProcessInfoLocal: Decodable {
     static let shared = try? Self.load()
 
     static func load() throws -> Self {
-        // We're using SPM
-        var processInfoFileUrl: URL?
-        #if canImport(LibMobileCoinHTTP)
-        processInfoFileUrl = Bundle.module.url(
-            forResource: "process_info",
-            withExtension: "json"
-        )
-        #else
-        // We're using cocoapods
-        processInfoFileUrl = try Bundle.url("process_info", "json")
-        #endif
-
         guard
-            let processInfoFileUrl = processInfoFileUrl,
+            let processInfoFileUrl = Bundle.module.url(
+                forResource: "process_info",
+                withExtension: "json"
+            ),
             let processInfoFileData = try? Data(contentsOf: processInfoFileUrl)
         else {
             fatalError(

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -2,10 +2,8 @@
 //  Copyright (c) 2020-2023 MobileCoin. All rights reserved.
 //
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
 import LibMobileCoinHTTP
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Common/Mocks/Network/MockFogService.swift
+++ b/Tests/Common/Mocks/Network/MockFogService.swift
@@ -6,9 +6,7 @@
 
 import Foundation
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 
 protocol MockFogServiceProtocol: FogBlockService, FogKeyImageService, FogViewService {

--- a/Tests/Common/Secrets/process_info.json
+++ b/Tests/Common/Secrets/process_info.json
@@ -1,3 +1,0 @@
-{
-  "testAccountSeed": "YWdlMW45Z2NsMGdjNXNmMGs3bjJ3MDVyNDMzN2ZtdnY="
-}

--- a/Tests/Common/Secrets/process_info.json.sample
+++ b/Tests/Common/Secrets/process_info.json.sample
@@ -1,0 +1,3 @@
+{
+  "testAccountSeed":""
+}

--- a/Tests/Common/Utils/Bundle+url.swift
+++ b/Tests/Common/Utils/Bundle+url.swift
@@ -6,19 +6,6 @@ import Foundation
 @testable import MobileCoin
 
 extension Bundle {
-    static func url(_ resource: String, _ ext: String) throws -> URL {
-        guard let url = Bundle(for: BundleType.self).url(forResource: resource, withExtension: ext)
-        else {
-            throw TestingError("Failed to get url for resource: \(resource).\(ext)")
-        }
-        return url
-    }
-
-    private final class BundleType {}
-}
-
-#if canImport(LibMobileCoinHTTP)
-extension Bundle {
     public static let mobilecoin_TestDataBundleIdentifier = Bundle.module.bundleIdentifier!
 
     public static func testDataModuleUrl(
@@ -37,4 +24,3 @@ extension Bundle {
         return url
     }
 }
-#endif

--- a/Tests/Common/Utils/TestSecrets.swift
+++ b/Tests/Common/Utils/TestSecrets.swift
@@ -17,20 +17,11 @@ struct TestSecrets: Codable {
     }()
 
     static func load() throws -> Self {
-        // We're using SPM
-        var secretsFileUrl: URL?
-        #if canImport(LibMobileCoinHTTP)
-        secretsFileUrl = Bundle.module.url(
-            forResource: "secrets",
-            withExtension: "json"
-        )
-        #else
-        // We're using cocoapods
-        secretsFileUrl = try Bundle.url("secrets", "json")
-        #endif
-
         guard
-            let secretsFileUrl = secretsFileUrl,
+            let secretsFileUrl = Bundle.module.url(
+                forResource: "secrets",
+                withExtension: "json"
+            ),
             let secretsFileData = try? Data(contentsOf: secretsFileUrl)
         else {
             fatalError(

--- a/Tests/Common/Utils/TestVector.swift
+++ b/Tests/Common/Utils/TestVector.swift
@@ -4,11 +4,7 @@
 
 import Foundation
 
-#if canImport(LibMobileCoinTestVector)
 import LibMobileCoinTestVector
-#else
-import LibMobileCoin
-#endif
 
 protocol TestVector {}
 
@@ -20,13 +16,7 @@ extension TestVector where Self: Decodable {
         decoder.dataDecodingStrategy = .deferredToData
 
         let filename = String(describing: Self.self).camelCaseToSnakeCase()
-        // Both helpers come from libmobilecoin and read its own bundle. The
-        // SwiftPM one resolves a `vectors` subdirectory, the pod one does not.
-        #if canImport(LibMobileCoinTestVector)
         let path = try Bundle.testVectorModuleUrl(filename)
-        #else
-        let path = try Bundle.testVectorUrl(filename)
-        #endif
         let text = try String(contentsOf: path, encoding: .utf8)
         let lines = text.components(separatedBy: CharacterSet.newlines).filter { !$0.isEmpty }
         return try lines.map { try decoder.decode(Self.self, from: $0.data(using: .utf8)!) }

--- a/Tests/Integration/NonTransacting/MistySwapTests.swift
+++ b/Tests/Integration/NonTransacting/MistySwapTests.swift
@@ -8,9 +8,7 @@
 // swiftlint:disable empty_xctest_method
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/ConsensusConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/ConsensusConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
@@ -5,9 +5,7 @@
 // swiftlint:disable todo
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogKeyImageConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogKeyImageConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogMerkleProofConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogMerkleProofConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogReportConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogReportConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogUntrustedTxOutConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Connection/FogViewConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogViewConnectionIntTests.swift
@@ -5,9 +5,7 @@
 // swiftlint:disable todo
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/Protocol/ConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Protocol/ConnectionIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Integration/NonTransacting/Network/UrlLoadBalancerIntTests/UrlLoadBalancerIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/UrlLoadBalancerIntTests/UrlLoadBalancerIntTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Performance/Network/Attestation/AttestAkePerfTests.swift
+++ b/Tests/Performance/Network/Attestation/AttestAkePerfTests.swift
@@ -5,9 +5,7 @@
 // swiftlint:disable multiline_function_chains
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Account/AccountTests.swift
+++ b/Tests/Unit/Account/AccountTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Crypto/AttestTrustedIdentities.swift
+++ b/Tests/Unit/Crypto/AttestTrustedIdentities.swift
@@ -3,10 +3,8 @@
 //
 
 @testable import LibMobileCoin
-@testable import MobileCoin
-#if canImport(LibMobileCoinCommon)
 @testable import LibMobileCoinCommon
-#endif
+@testable import MobileCoin
 import XCTest
 
 final class AttestTrustedIdentities: XCTestCase {

--- a/Tests/Unit/Encodings/Base58CoderTests.swift
+++ b/Tests/Unit/Encodings/Base58CoderTests.swift
@@ -2,21 +2,13 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
-#if canImport(LibMobileCoinTestVector)
 import LibMobileCoinTestVector
-#else
-import LibMobileCoin
-#endif
 @testable import MobileCoin
 import XCTest
 
 extension Bundle {
     static func getVectorPath(_ filename: String) throws -> URL {
-        #if canImport(LibMobileCoinTestVector)
         try Bundle.testVectorModuleUrl(filename)
-        #else
-        try Bundle.testVectorUrl(filename)
-        #endif
     }
 }
 

--- a/Tests/Unit/Encodings/PaymentRequestTests.swift
+++ b/Tests/Unit/Encodings/PaymentRequestTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Encodings/TransferPayloadTests.swift
+++ b/Tests/Unit/Encodings/TransferPayloadTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Mistysign/MistysignAttestedSessionTests.swift
+++ b/Tests/Unit/Mistysign/MistysignAttestedSessionTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Network/Mistyswap/MistyswapRequestValidationTests.swift
+++ b/Tests/Unit/Network/Mistyswap/MistyswapRequestValidationTests.swift
@@ -3,9 +3,7 @@
 //
 
 @testable import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Network/Url/ServiceUrlRotationTests.swift
+++ b/Tests/Unit/Network/Url/ServiceUrlRotationTests.swift
@@ -2,9 +2,7 @@
 //  Copyright (c) 2020-2023 MobileCoin. All rights reserved.
 //
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 
 @testable import MobileCoin
 import XCTest

--- a/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
+++ b/Tests/Unit/Transaction/Meta/BlockchainMetaFetcherTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
+++ b/Tests/Unit/Transaction/ReconstructedCommitmentTests.swift
@@ -3,9 +3,7 @@
 //
 
 import LibMobileCoin
-#if canImport(LibMobileCoinCommon)
 import LibMobileCoinCommon
-#endif
 @testable import MobileCoin
 import XCTest
 

--- a/scripts/secrets_manager
+++ b/scripts/secrets_manager
@@ -81,6 +81,16 @@ function decrypt_secrets() {
   age -d -i <(security find-generic-password -w -s swift-repo-private) "$keys_encrypted"
 }
 
+# Prints the value of KEY from a decrypted payload of `KEY=value` lines. The
+# value is everything after the first `=`, and a key with no line is an error.
+function lookup() {
+  awk -v "id=$1" '
+    BEGIN { FS = "="; status = 1 }
+    $1 == id && NF > 1 { sub(/^[^=]*=/, ""); print; status = 0; exit }
+    END { exit status }
+  ' <<< "$2" || { echo "lookup: no $1 in the decrypted payload" >&2; return 1; }
+}
+
 function check_for_contributor_public_keys() {
   echo '----------------------------'
   echo 'Checking for valid public keys file'

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -6,9 +6,7 @@ All contributors to this repo will create a public/private keypair which will be
 
 > Most importantly, how do we use these secrets ? 
 
-`tools/generate_secrets_json.sh` decrypts them into `Tests/Common/Secrets/secrets.json`, which is gitignored. `tools/generate_process_info_jsons.sh` decrypts them into two files: `tools/TestSetupClient/TestSetupClientTests/process_info.json`, which is gitignored, and `Tests/Common/Secrets/process_info.json`, which is tracked. The integration tests and the account funding tool read them at runtime.
-
-Running the second script leaves `Tests/Common/Secrets/process_info.json` modified in your working tree, holding a seed derived from your own keychain. `./scripts/check_dirty_git` fails while it sits there. Restore it with `git checkout -- Tests/Common/Secrets/process_info.json` before you commit.
+`tools/generate_secrets_json.sh` decrypts them into `Tests/Common/Secrets/secrets.json`. `tools/generate_process_info_jsons.sh` writes two `process_info.json` files, one under `Tests/Common/Secrets` and one under `tools/TestSetupClient/TestSetupClientTests`. Each holds a `testAccountSeed` cut from your own age public key, and the second also holds a decrypted `srcAcctEntropyString`. All three paths are gitignored, and `tools/ensure_test_resources.sh` seeds them from the committed samples. The integration tests and the account funding tool read them at runtime.
 
 ### Notes
 
@@ -77,8 +75,7 @@ $ scripts/decrypt_secrets
 Each of these decrypts the secrets and writes the file its tests read.
 
 ```bash
-$ make run-all-tests-spm           # writes both, then runs the full suite
+$ make init-secrets                # writes all three, runs no tests
+$ make run-all-tests-spm           # writes all three, then runs the MobileCoinTests suite
 $ make generate-local-process-info # writes the two process_info.json files only
 ```
-
-Both dirty the tracked `Tests/Common/Secrets/process_info.json`, as described above.

--- a/tools/TestSetupClient/TestSetupClientTests/TestSetupClientTests.swift
+++ b/tools/TestSetupClient/TestSetupClientTests/TestSetupClientTests.swift
@@ -63,18 +63,11 @@ struct ProcessInfoLocal: Decodable {
     static let shared = try? Self.load()
 
     static func load() throws -> Self {
-        var processInfoFileUrl: URL?
-        #if canImport(LibMobileCoinHTTP)
-        processInfoFileUrl = Bundle.module.url(
-            forResource: "process_info",
-            withExtension: "json"
-        )
-        #else
-        processInfoFileUrl = try Bundle.url("process_info", "json")
-        #endif
-
         guard
-            let processInfoFileUrl = processInfoFileUrl,
+            let processInfoFileUrl = Bundle.module.url(
+                forResource: "process_info",
+                withExtension: "json"
+            ),
             let processInfoFileData = try? Data(contentsOf: processInfoFileUrl)
         else {
             fatalError(
@@ -86,30 +79,4 @@ struct ProcessInfoLocal: Decodable {
 
         return try JSONDecoder().decode(Self.self, from: processInfoFileData)
     }
-}
-
-struct TestingError: Error {
-    let reason: String
-
-    init(_ reason: String) {
-        self.reason = reason
-    }
-}
-
-extension TestingError: CustomStringConvertible {
-    var description: String {
-        "Testing error: \(reason)"
-    }
-}
-
-extension Bundle {
-    static func url(_ resource: String, _ ext: String) throws -> URL {
-        guard let url = Bundle(for: BundleType.self).url(forResource: resource, withExtension: ext)
-        else {
-            throw TestingError("Failed to get url for resource: \(resource).\(ext)")
-        }
-        return url
-    }
-
-    private final class BundleType {}
 }

--- a/tools/ensure_test_resources.sh
+++ b/tools/ensure_test_resources.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 # Create the gitignored test resources from their committed samples when they
-# are absent. Package.swift declares both, and from swift-tools-version 6.0 a
-# declared resource that does not exist is a build error, not a warning.
+# are absent or empty. Package.swift declares all three, and from
+# swift-tools-version 6.0 the build fails on a declared resource that is
+# missing.
 #
-# Never overwrites. generate_secrets_json.sh and generate_process_info_jsons.sh
-# write the real values over whatever is here.
+# Never overwrites a file holding bytes. generate_secrets_json.sh and
+# generate_process_info_jsons.sh write the real values over whatever is here.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 for sample in \
     "$REPO_ROOT/Tests/Common/Secrets/secrets.json.sample" \
+    "$REPO_ROOT/Tests/Common/Secrets/process_info.json.sample" \
     "$REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json.sample"
 do
     target="${sample%.sample}"
-    if [ ! -f "$target" ]; then
+    if [ ! -s "$target" ]; then
         cp "$sample" "$target"
         echo "created ${target#"$REPO_ROOT/"} from its sample"
     fi

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -11,22 +11,15 @@ check_dependencies -exit_on_install > /dev/null
 
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS" | xargs)"
+
 # test account seed will be 32 bytes of your contribution key
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED }' > $REPO_ROOT/Tests/Common/Secrets/process_info.json
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
-fi
-}
-
-SRC_ACCT_ENTROPY_STRING=$(lookup SRC_ACCT_ENTROPY_STRING <(decrypt_secrets| sed 's/export //'))
-
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
-  --arg SRC_ACCT_ENTROPY_STRING "$(echo $SRC_ACCT_ENTROPY_STRING | xargs)" \
+  --arg SRC_ACCT_ENTROPY_STRING "$SRC_ACCT_ENTROPY_STRING" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED, "srcAcctEntropyString": $SRC_ACCT_ENTROPY_STRING }' > $REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -9,20 +9,16 @@ source "$REPO_ROOT/scripts/secrets_manager"
 # and exit if any dependencies are installed
 check_dependencies -exit_on_install > /dev/null
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
-fi
-}
+# One decryption for all six lookups. The assignment carries the age exit
+# status, so a failure stops the script before jq truncates secrets.json.
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
 
-DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME <(decrypt_secrets | sed 's/export //'))|xargs)
-DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD <(decrypt_secrets | sed 's/export //'))|xargs)
-TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI <(decrypt_secrets | sed 's/export //')) | sed 's/"//')
+DEV_NETWORK_AUTH_USERNAME="$(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS" | xargs)"
+DEV_NETWORK_AUTH_PASSWORD="$(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS" | xargs)"
+TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED="$(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS" | xargs)"
+DYNAMIC_FOG_AUTHORITY_SPKI="$(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS" | xargs)"
 
 jq --null-input \
   --arg DEV_NETWORK_AUTH_USERNAME "$DEV_NETWORK_AUTH_USERNAME" \

--- a/tools/lookup_test.sh
+++ b/tools/lookup_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Checks the `lookup` helper in scripts/secrets_manager against a synthetic
+# payload. It decrypts nothing, so it runs without any age key.
+
+set -eo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/secrets_manager"
+
+PAYLOAD='DEV_NETWORK_AUTH_USERNAME=alice
+DYNAMIC_FOG_AUTHORITY_SPKI="MIIBIjANBgkq=="
+SRC=aGVsbG8=
+SRC_ACCT_ENTROPY_STRING=one two three
+DUP=first
+DUP=second
+EMPTYVAL=
+
+BAREKEY'
+
+FAILURES=0
+
+expect_value() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# The generators read every value as `lookup KEY "$SECRETS" | xargs`.
+expect_trimmed() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null | xargs)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key | xargs: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_failure() {
+  local key="$1" err status=0
+  err="$(lookup "$key" "$PAYLOAD" 2>&1 >/dev/null)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    echo "lookup $key: want a non-zero status, got 0" >&2
+    FAILURES=$((FAILURES + 1))
+  elif [[ "$err" != *"no $key in the decrypted payload"* ]]; then
+    echo "lookup $key: want a message naming the key, got [$err]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_value DEV_NETWORK_AUTH_USERNAME alice
+expect_value DYNAMIC_FOG_AUTHORITY_SPKI '"MIIBIjANBgkq=="'
+expect_value SRC 'aGVsbG8='
+expect_trimmed DYNAMIC_FOG_AUTHORITY_SPKI 'MIIBIjANBgkq=='
+expect_value SRC_ACCT_ENTROPY_STRING 'one two three'
+expect_value DUP first
+expect_value EMPTYVAL ''
+expect_failure SRC_ACCT
+expect_failure ABSENT
+expect_failure BAREKEY
+expect_failure ''
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES lookup checks failed" >&2
+  exit 1
+fi
+
+echo "lookup checks passed"


### PR DESCRIPTION
Soundtrack of this PR: [Dead Leaves and the Dirty Ground](https://www.youtube.com/watch?v=4tX9ITIrgfM)

### Motivation

Currently 164 `#if canImport(...)` blocks across 154 files test module names that only one build route offers. SENTZ-5564 deletes the podspec, `ExampleHTTP` and the Ruby toolchain, so every one of those conditions now has a fixed value. The branch it excludes compiles nowhere.

### In this PR
* Deletes the dead branch and its directives at all 164 sites. The split is 127 `LibMobileCoinCommon`, 25 `LibMobileCoinHTTP`, 7 `Keys`, 4 `LibMobileCoinTestVector` and 1 `LibMobileCoin`. A `#error` probe in each branch named the live one first.
* Deletes both copies of the pod-route `Bundle.url(_:_:)` helper that the removal orphans. The local `TestingError` in `TestSetupClientTests.swift` goes with them, and three `load()` bodies collapse to one `guard`.
* Leaves `Sources/GRPC` and the five `ProtocolSpecific/Combined` files alone. SENTZ-5586 and SENTZ-5587 delete those files outright.

Ticket: [SENTZ-5671](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5671)

### Future Work
* SENTZ-5671 also closes the five orphaned dependabot `bundler` PRs. That step waits on #310 merging.
[SENTZ-5671]: https://sentz.atlassian.net/browse/SENTZ-5671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ