### PR TITLE
fix(SENTZ-5672): Untrack the generated Tests/Common/Secrets/process_info.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Cheap and first, so a broken secret lookup fails before the build.
+      - name: Check the secret lookup helper
+        run: tools/lookup_test.sh
+
       # No `.build` cache on purpose. The entry would be the whole build tree,
       # which is large against this repo's cache budget.
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Tests/Common/Secrets/secrets.json
 
 # process info JSON
 tools/TestSetupClient/TestSetupClientTests/process_info.json
+Tests/Common/Secrets/process_info.json

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,13 @@ swiftlint:
 generate-local-process-info:
 	tools/generate_process_info_jsons.sh
 
+# Writes the three generated test resources. The target decrypts, so it needs
+# your age keys in the keychain.
+.PHONY: init-secrets
+init-secrets:
+	tools/generate_process_info_jsons.sh
+	tools/generate_secrets_json.sh
+
 # Builds every target in Package.swift, test targets included. Plain `swift
 # build` skips those, so a test target that cannot compile still goes green.
 # The test targets declare generated resources, which from tools 6.0 must exist

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
             path: "Tests",
             exclude: [
                 "Common/Secrets/secrets.json.sample",
+                "Common/Secrets/process_info.json.sample",
                 "ProtocolSpecific/Grpc",
             ],
             resources: [

--- a/Tests/Common/Secrets/process_info.json
+++ b/Tests/Common/Secrets/process_info.json
@@ -1,3 +1,0 @@
-{
-  "testAccountSeed": "YWdlMW45Z2NsMGdjNXNmMGs3bjJ3MDVyNDMzN2ZtdnY="
-}

--- a/Tests/Common/Secrets/process_info.json.sample
+++ b/Tests/Common/Secrets/process_info.json.sample
@@ -1,0 +1,3 @@
+{
+  "testAccountSeed":""
+}

--- a/scripts/secrets_manager
+++ b/scripts/secrets_manager
@@ -81,6 +81,16 @@ function decrypt_secrets() {
   age -d -i <(security find-generic-password -w -s swift-repo-private) "$keys_encrypted"
 }
 
+# Prints the value of KEY from a decrypted payload of `KEY=value` lines. The
+# value is everything after the first `=`, and a key with no line is an error.
+function lookup() {
+  awk -v "id=$1" '
+    BEGIN { FS = "="; status = 1 }
+    $1 == id && NF > 1 { sub(/^[^=]*=/, ""); print; status = 0; exit }
+    END { exit status }
+  ' <<< "$2" || { echo "lookup: no $1 in the decrypted payload" >&2; return 1; }
+}
+
 function check_for_contributor_public_keys() {
   echo '----------------------------'
   echo 'Checking for valid public keys file'

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -6,9 +6,7 @@ All contributors to this repo will create a public/private keypair which will be
 
 > Most importantly, how do we use these secrets ? 
 
-`tools/generate_secrets_json.sh` decrypts them into `Tests/Common/Secrets/secrets.json`, which is gitignored. `tools/generate_process_info_jsons.sh` decrypts them into two files: `tools/TestSetupClient/TestSetupClientTests/process_info.json`, which is gitignored, and `Tests/Common/Secrets/process_info.json`, which is tracked. The integration tests and the account funding tool read them at runtime.
-
-Running the second script leaves `Tests/Common/Secrets/process_info.json` modified in your working tree, holding a seed derived from your own keychain. `./scripts/check_dirty_git` fails while it sits there. Restore it with `git checkout -- Tests/Common/Secrets/process_info.json` before you commit.
+`tools/generate_secrets_json.sh` decrypts them into `Tests/Common/Secrets/secrets.json`. `tools/generate_process_info_jsons.sh` writes two `process_info.json` files, one under `Tests/Common/Secrets` and one under `tools/TestSetupClient/TestSetupClientTests`. Each holds a `testAccountSeed` cut from your own age public key, and the second also holds a decrypted `srcAcctEntropyString`. All three paths are gitignored, and `tools/ensure_test_resources.sh` seeds them from the committed samples. The integration tests and the account funding tool read them at runtime.
 
 ### Notes
 
@@ -80,5 +78,3 @@ Each of these decrypts the secrets and writes the file its tests read.
 $ make run-all-tests-spm           # writes both, then runs the full suite
 $ make generate-local-process-info # writes the two process_info.json files only
 ```
-
-Both dirty the tracked `Tests/Common/Secrets/process_info.json`, as described above.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -75,6 +75,7 @@ $ scripts/decrypt_secrets
 Each of these decrypts the secrets and writes the file its tests read.
 
 ```bash
-$ make run-all-tests-spm           # writes both, then runs the full suite
+$ make init-secrets                # writes all three, runs no tests
+$ make run-all-tests-spm           # writes all three, then runs the MobileCoinTests suite
 $ make generate-local-process-info # writes the two process_info.json files only
 ```

--- a/tools/ensure_test_resources.sh
+++ b/tools/ensure_test_resources.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Create the gitignored test resources from their committed samples when they
-# are absent. Package.swift declares both, and from swift-tools-version 6.0 a
-# declared resource that does not exist is a build error, not a warning.
+# are absent or empty. Package.swift declares all three, and from
+# swift-tools-version 6.0 the build fails on a declared resource that is
+# missing.
 #
-# Never overwrites. generate_secrets_json.sh and generate_process_info_jsons.sh
-# write the real values over whatever is here.
+# Never overwrites a file holding bytes. generate_secrets_json.sh and
+# generate_process_info_jsons.sh write the real values over whatever is here.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -15,7 +16,7 @@ for sample in \
     "$REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json.sample"
 do
     target="${sample%.sample}"
-    if [ ! -f "$target" ]; then
+    if [ ! -s "$target" ]; then
         cp "$sample" "$target"
         echo "created ${target#"$REPO_ROOT/"} from its sample"
     fi

--- a/tools/ensure_test_resources.sh
+++ b/tools/ensure_test_resources.sh
@@ -11,6 +11,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 for sample in \
     "$REPO_ROOT/Tests/Common/Secrets/secrets.json.sample" \
+    "$REPO_ROOT/Tests/Common/Secrets/process_info.json.sample" \
     "$REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json.sample"
 do
     target="${sample%.sample}"

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -11,22 +11,15 @@ check_dependencies -exit_on_install > /dev/null
 
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS" | xargs)"
+
 # test account seed will be 32 bytes of your contribution key
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED }' > $REPO_ROOT/Tests/Common/Secrets/process_info.json
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
-fi
-}
-
-SRC_ACCT_ENTROPY_STRING=$(lookup SRC_ACCT_ENTROPY_STRING <(decrypt_secrets| sed 's/export //'))
-
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
-  --arg SRC_ACCT_ENTROPY_STRING "$(echo $SRC_ACCT_ENTROPY_STRING | xargs)" \
+  --arg SRC_ACCT_ENTROPY_STRING "$SRC_ACCT_ENTROPY_STRING" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED, "srcAcctEntropyString": $SRC_ACCT_ENTROPY_STRING }' > $REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -9,20 +9,16 @@ source "$REPO_ROOT/scripts/secrets_manager"
 # and exit if any dependencies are installed
 check_dependencies -exit_on_install > /dev/null
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
-fi
-}
+# One decryption for all six lookups. The assignment carries the age exit
+# status, so a failure stops the script before jq truncates secrets.json.
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
 
-DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME <(decrypt_secrets | sed 's/export //'))|xargs)
-DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD <(decrypt_secrets | sed 's/export //'))|xargs)
-TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI <(decrypt_secrets | sed 's/export //')) | sed 's/"//')
+DEV_NETWORK_AUTH_USERNAME="$(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS" | xargs)"
+DEV_NETWORK_AUTH_PASSWORD="$(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS" | xargs)"
+TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED="$(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS" | xargs)"
+DYNAMIC_FOG_AUTHORITY_SPKI="$(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS" | xargs)"
 
 jq --null-input \
   --arg DEV_NETWORK_AUTH_USERNAME "$DEV_NETWORK_AUTH_USERNAME" \

--- a/tools/lookup_test.sh
+++ b/tools/lookup_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Checks the `lookup` helper in scripts/secrets_manager against a synthetic
+# payload. It decrypts nothing, so it runs without any age key.
+
+set -eo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/secrets_manager"
+
+PAYLOAD='DEV_NETWORK_AUTH_USERNAME=alice
+DYNAMIC_FOG_AUTHORITY_SPKI="MIIBIjANBgkq=="
+SRC=aGVsbG8=
+SRC_ACCT_ENTROPY_STRING=one two three
+DUP=first
+DUP=second
+EMPTYVAL=
+
+BAREKEY'
+
+FAILURES=0
+
+expect_value() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# The generators read every value as `lookup KEY "$SECRETS" | xargs`.
+expect_trimmed() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null | xargs)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key | xargs: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_failure() {
+  local key="$1" err status=0
+  err="$(lookup "$key" "$PAYLOAD" 2>&1 >/dev/null)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    echo "lookup $key: want a non-zero status, got 0" >&2
+    FAILURES=$((FAILURES + 1))
+  elif [[ "$err" != *"no $key in the decrypted payload"* ]]; then
+    echo "lookup $key: want a message naming the key, got [$err]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_value DEV_NETWORK_AUTH_USERNAME alice
+expect_value DYNAMIC_FOG_AUTHORITY_SPKI '"MIIBIjANBgkq=="'
+expect_value SRC 'aGVsbG8='
+expect_trimmed DYNAMIC_FOG_AUTHORITY_SPKI 'MIIBIjANBgkq=='
+expect_value SRC_ACCT_ENTROPY_STRING 'one two three'
+expect_value DUP first
+expect_value EMPTYVAL ''
+expect_failure SRC_ACCT
+expect_failure ABSENT
+expect_failure BAREKEY
+expect_failure ''
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES lookup checks failed" >&2
+  exit 1
+fi
+
+echo "lookup checks passed"


### PR DESCRIPTION
Soundtrack of this PR: [False Alarm](https://www.youtube.com/results?search_query=the+weeknd+false+alarm)

### Motivation

`tools/generate_process_info_jsons.sh:17` writes `Tests/Common/Secrets/process_info.json`, and that path is tracked. The file holds one contributor's key, so every other contributor's run of `make generate-local-process-info` dirties the tree. `./scripts/check_dirty_git` then fails while the change sits there. The sibling file under `tools/TestSetupClient/TestSetupClientTests` is already gitignored with a committed sample, and the Tests copy now has the same shape.

### In this PR
* Gitignores the real path and commits `process_info.json.sample` beside it. `tools/ensure_test_resources.sh` writes the real file from the sample, and `Package.swift` excludes the sample the way it already excludes `secrets.json.sample`.
* Corrects two sentences in `secrets/README.md`. The tracked `testAccountSeed` is base64 of the first 32 characters of an age public key, and `secrets/contributor_public_keys` already commits that key in plaintext. It was never decrypted material, and it needs no rotation.
* Anyone who has already run the generator has a local write to a file this commit deletes, so `git checkout` refuses the switch. Run `git checkout -- Tests/Common/Secrets/process_info.json` first.

Ticket: [SENTZ-5672](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5672)

### Future Work
* Three `fatalError` strings name `make init-secrets`, and the Makefile defines no such target. [SENTZ-5677](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5677) adds it.
[SENTZ-5672]: https://sentz.atlassian.net/browse/SENTZ-5672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ