### PR TITLE
chore(SENTZ-5677): Add the init-secrets target and stop the generators on a failed decryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Cheap and first, so a broken secret lookup fails before the build.
+      - name: Check the secret lookup helper
+        run: tools/lookup_test.sh
+
       # No `.build` cache on purpose. The entry would be the whole build tree,
       # which is large against this repo's cache budget.
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,13 @@ swiftlint:
 generate-local-process-info:
 	tools/generate_process_info_jsons.sh
 
+# Writes the three generated test resources. The target decrypts, so it needs
+# your age keys in the keychain.
+.PHONY: init-secrets
+init-secrets:
+	tools/generate_process_info_jsons.sh
+	tools/generate_secrets_json.sh
+
 # Builds every target in Package.swift, test targets included. Plain `swift
 # build` skips those, so a test target that cannot compile still goes green.
 # The test targets declare generated resources, which from tools 6.0 must exist

--- a/scripts/secrets_manager
+++ b/scripts/secrets_manager
@@ -81,6 +81,16 @@ function decrypt_secrets() {
   age -d -i <(security find-generic-password -w -s swift-repo-private) "$keys_encrypted"
 }
 
+# Prints the value of KEY from a decrypted payload of `KEY=value` lines. The
+# value is everything after the first `=`, and a key with no line is an error.
+function lookup() {
+  awk -v "id=$1" '
+    BEGIN { FS = "="; status = 1 }
+    $1 == id && NF > 1 { sub(/^[^=]*=/, ""); print; status = 0; exit }
+    END { exit status }
+  ' <<< "$2" || { echo "lookup: no $1 in the decrypted payload" >&2; return 1; }
+}
+
 function check_for_contributor_public_keys() {
   echo '----------------------------'
   echo 'Checking for valid public keys file'

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -75,6 +75,7 @@ $ scripts/decrypt_secrets
 Each of these decrypts the secrets and writes the file its tests read.
 
 ```bash
-$ make run-all-tests-spm           # writes both, then runs the full suite
+$ make init-secrets                # writes all three, runs no tests
+$ make run-all-tests-spm           # writes all three, then runs the MobileCoinTests suite
 $ make generate-local-process-info # writes the two process_info.json files only
 ```

--- a/tools/ensure_test_resources.sh
+++ b/tools/ensure_test_resources.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Create the gitignored test resources from their committed samples when they
-# are absent. Package.swift declares both, and from swift-tools-version 6.0 a
-# declared resource that does not exist is a build error, not a warning.
+# are absent or empty. Package.swift declares all three, and from
+# swift-tools-version 6.0 the build fails on a declared resource that is
+# missing.
 #
-# Never overwrites. generate_secrets_json.sh and generate_process_info_jsons.sh
-# write the real values over whatever is here.
+# Never overwrites a file holding bytes. generate_secrets_json.sh and
+# generate_process_info_jsons.sh write the real values over whatever is here.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -15,7 +16,7 @@ for sample in \
     "$REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json.sample"
 do
     target="${sample%.sample}"
-    if [ ! -f "$target" ]; then
+    if [ ! -s "$target" ]; then
         cp "$sample" "$target"
         echo "created ${target#"$REPO_ROOT/"} from its sample"
     fi

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -20,11 +20,12 @@ lookup() {
 if [[ -z "$1" ]] ; then
   echo ""
 else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
+  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
 fi
 }
 
-SRC_ACCT_ENTROPY_STRING=$(lookup SRC_ACCT_ENTROPY_STRING <(decrypt_secrets| sed 's/export //'))
+SECRETS="$(decrypt_secrets | sed 's/export //')"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
 
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -11,23 +11,15 @@ check_dependencies -exit_on_install > /dev/null
 
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS" | xargs)"
+
 # test account seed will be 32 bytes of your contribution key
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED }' > $REPO_ROOT/Tests/Common/Secrets/process_info.json
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
-fi
-}
-
-SECRETS="$(decrypt_secrets | sed 's/export //')"
-SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
-
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
-  --arg SRC_ACCT_ENTROPY_STRING "$(echo $SRC_ACCT_ENTROPY_STRING | xargs)" \
+  --arg SRC_ACCT_ENTROPY_STRING "$SRC_ACCT_ENTROPY_STRING" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED, "srcAcctEntropyString": $SRC_ACCT_ENTROPY_STRING }' > $REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 source "$REPO_ROOT/scripts/secrets_manager"
@@ -13,16 +13,20 @@ lookup() {
 if [[ -z "$1" ]] ; then
   echo ""
 else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' $2
+  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
 fi
 }
 
-DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME <(decrypt_secrets | sed 's/export //'))|xargs)
-DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD <(decrypt_secrets | sed 's/export //'))|xargs)
-TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED <(decrypt_secrets | sed 's/export //'))|xargs)
-DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI <(decrypt_secrets | sed 's/export //')) | sed 's/"//')
+# One decryption for all six lookups. The assignment carries the age exit
+# status, so a failure stops the script before jq truncates secrets.json.
+SECRETS="$(decrypt_secrets | sed 's/export //')"
+
+DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS")|xargs)
+DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS")|xargs)
+TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
+MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
+DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS")|xargs)
+DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS") | sed 's/"//')
 
 jq --null-input \
   --arg DEV_NETWORK_AUTH_USERNAME "$DEV_NETWORK_AUTH_USERNAME" \

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -9,24 +9,16 @@ source "$REPO_ROOT/scripts/secrets_manager"
 # and exit if any dependencies are installed
 check_dependencies -exit_on_install > /dev/null
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
-fi
-}
-
 # One decryption for all six lookups. The assignment carries the age exit
 # status, so a failure stops the script before jq truncates secrets.json.
-SECRETS="$(decrypt_secrets | sed 's/export //')"
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
 
-DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS")|xargs)
-DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS")|xargs)
-TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
-MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
-DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS")|xargs)
-DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS") | sed 's/"//')
+DEV_NETWORK_AUTH_USERNAME="$(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS" | xargs)"
+DEV_NETWORK_AUTH_PASSWORD="$(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS" | xargs)"
+TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED="$(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS" | xargs)"
+DYNAMIC_FOG_AUTHORITY_SPKI="$(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS" | xargs)"
 
 jq --null-input \
   --arg DEV_NETWORK_AUTH_USERNAME "$DEV_NETWORK_AUTH_USERNAME" \

--- a/tools/lookup_test.sh
+++ b/tools/lookup_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Checks the `lookup` helper in scripts/secrets_manager against a synthetic
+# payload. It decrypts nothing, so it runs without any age key.
+
+set -eo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/secrets_manager"
+
+PAYLOAD='DEV_NETWORK_AUTH_USERNAME=alice
+DYNAMIC_FOG_AUTHORITY_SPKI="MIIBIjANBgkq=="
+SRC=aGVsbG8=
+SRC_ACCT_ENTROPY_STRING=one two three
+DUP=first
+DUP=second
+EMPTYVAL=
+
+BAREKEY'
+
+FAILURES=0
+
+expect_value() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# The generators read every value as `lookup KEY "$SECRETS" | xargs`.
+expect_trimmed() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null | xargs)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key | xargs: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_failure() {
+  local key="$1" err status=0
+  err="$(lookup "$key" "$PAYLOAD" 2>&1 >/dev/null)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    echo "lookup $key: want a non-zero status, got 0" >&2
+    FAILURES=$((FAILURES + 1))
+  elif [[ "$err" != *"no $key in the decrypted payload"* ]]; then
+    echo "lookup $key: want a message naming the key, got [$err]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_value DEV_NETWORK_AUTH_USERNAME alice
+expect_value DYNAMIC_FOG_AUTHORITY_SPKI '"MIIBIjANBgkq=="'
+expect_value SRC 'aGVsbG8='
+expect_trimmed DYNAMIC_FOG_AUTHORITY_SPKI 'MIIBIjANBgkq=='
+expect_value SRC_ACCT_ENTROPY_STRING 'one two three'
+expect_value DUP first
+expect_value EMPTYVAL ''
+expect_failure SRC_ACCT
+expect_failure ABSENT
+expect_failure BAREKEY
+expect_failure ''
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES lookup checks failed" >&2
+  exit 1
+fi
+
+echo "lookup checks passed"


### PR DESCRIPTION
Soundtrack of this PR: [The Sound of Silence](https://www.youtube.com/results?search_query=simon+and+garfunkel+the+sound+of+silence)

### Motivation

Three `fatalError` messages tell a contributor to run `make init-secrets`, and the Makefile defines no such target. They sit at `Tests/Common/Integration/IntegrationTestFixtures.swift:470`, `Tests/Common/Utils/TestSecrets.swift:29` and `tools/TestSetupClient/TestSetupClientTests/TestSetupClientTests.swift:75`. Adding the target surfaced a second problem. `decrypt_secrets` sat inside a process substitution at all seven lookup sites across the two generators, and a `<(...)` subshell discards the exit status. Both scripts ran to the end when `age` failed, and `Tests/Common/Secrets/secrets.json` landed with six empty values.

### In this PR
* Adds the `init-secrets` target beside `generate-local-process-info`, running both generators in the order `run-all-tests-spm` already uses. `secrets/README.md` lists it with the two targets that write the same files.
* Hoists one decryption into a plain assignment in each generator. `set -o pipefail` makes that assignment carry the `age` status past the `sed` in its pipeline. `lookup` reads the text from a here-string.
* `pipefail` also covers `tools/generate_process_info_jsons.sh:12`, where the status taken was `base64`'s. A failing keychain read now stops the script in place of writing an empty seed.

Ticket: [SENTZ-5677](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5677)

### Future Work
* The `lookup` helper truncates any value holding a second `=`, and returns an empty string with status 0 for a key it cannot find. Both predate this branch. [SENTZ-5678](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5678)
[SENTZ-5677]: https://sentz.atlassian.net/browse/SENTZ-5677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ