### PR TITLE
fix(SENTZ-5678): Return whole secret values from the generator lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Cheap and first, so a broken secret lookup fails before the build.
+      - name: Check the secret lookup helper
+        run: tools/lookup_test.sh
+
       # No `.build` cache on purpose. The entry would be the whole build tree,
       # which is large against this repo's cache budget.
       - name: Test

--- a/scripts/secrets_manager
+++ b/scripts/secrets_manager
@@ -81,6 +81,16 @@ function decrypt_secrets() {
   age -d -i <(security find-generic-password -w -s swift-repo-private) "$keys_encrypted"
 }
 
+# Prints the value of KEY from a decrypted payload of `KEY=value` lines. The
+# value is everything after the first `=`, and a key with no line is an error.
+function lookup() {
+  awk -v "id=$1" '
+    BEGIN { FS = "="; status = 1 }
+    $1 == id && NF > 1 { sub(/^[^=]*=/, ""); print; status = 0; exit }
+    END { exit status }
+  ' <<< "$2" || { echo "lookup: no $1 in the decrypted payload" >&2; return 1; }
+}
+
 function check_for_contributor_public_keys() {
   echo '----------------------------'
   echo 'Checking for valid public keys file'

--- a/tools/ensure_test_resources.sh
+++ b/tools/ensure_test_resources.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Create the gitignored test resources from their committed samples when they
-# are absent. Package.swift declares both, and from swift-tools-version 6.0 a
-# declared resource that does not exist is a build error, not a warning.
+# are absent or empty. Package.swift declares all three, and from
+# swift-tools-version 6.0 the build fails on a declared resource that is
+# missing.
 #
-# Never overwrites. generate_secrets_json.sh and generate_process_info_jsons.sh
-# write the real values over whatever is here.
+# Never overwrites a file holding bytes. generate_secrets_json.sh and
+# generate_process_info_jsons.sh write the real values over whatever is here.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -15,7 +16,7 @@ for sample in \
     "$REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json.sample"
 do
     target="${sample%.sample}"
-    if [ ! -f "$target" ]; then
+    if [ ! -s "$target" ]; then
         cp "$sample" "$target"
         echo "created ${target#"$REPO_ROOT/"} from its sample"
     fi

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -11,23 +11,15 @@ check_dependencies -exit_on_install > /dev/null
 
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
+SECRETS="$(decrypt_secrets | sed 's/export //')"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
+
 # test account seed will be 32 bytes of your contribution key
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED }' > $REPO_ROOT/Tests/Common/Secrets/process_info.json
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
-fi
-}
-
-SECRETS="$(decrypt_secrets | sed 's/export //')"
-SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
-
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
-  --arg SRC_ACCT_ENTROPY_STRING "$(echo $SRC_ACCT_ENTROPY_STRING | xargs)" \
+  --arg SRC_ACCT_ENTROPY_STRING "$(echo "$SRC_ACCT_ENTROPY_STRING" | xargs)" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED, "srcAcctEntropyString": $SRC_ACCT_ENTROPY_STRING }' > $REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -11,7 +11,7 @@ check_dependencies -exit_on_install > /dev/null
 
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
-SECRETS="$(decrypt_secrets | sed 's/export //')"
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
 SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
 
 # test account seed will be 32 bytes of your contribution key

--- a/tools/generate_process_info_jsons.sh
+++ b/tools/generate_process_info_jsons.sh
@@ -12,7 +12,7 @@ check_dependencies -exit_on_install > /dev/null
 TEST_ACCOUNT_SEED="$(security find-generic-password -w -s swift-repo-public | head -c32 | base64)"
 
 SECRETS="$(decrypt_secrets | sed 's/^export //')"
-SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS")"
+SRC_ACCT_ENTROPY_STRING="$(lookup SRC_ACCT_ENTROPY_STRING "$SECRETS" | xargs)"
 
 # test account seed will be 32 bytes of your contribution key
 jq --null-input \
@@ -21,5 +21,5 @@ jq --null-input \
 
 jq --null-input \
   --arg TEST_ACCOUNT_SEED "$TEST_ACCOUNT_SEED" \
-  --arg SRC_ACCT_ENTROPY_STRING "$(echo "$SRC_ACCT_ENTROPY_STRING" | xargs)" \
+  --arg SRC_ACCT_ENTROPY_STRING "$SRC_ACCT_ENTROPY_STRING" \
   '{ "testAccountSeed": $TEST_ACCOUNT_SEED, "srcAcctEntropyString": $SRC_ACCT_ENTROPY_STRING }' > $REPO_ROOT/tools/TestSetupClient/TestSetupClientTests/process_info.json

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -11,7 +11,7 @@ check_dependencies -exit_on_install > /dev/null
 
 # One decryption for all six lookups. The assignment carries the age exit
 # status, so a failure stops the script before jq truncates secrets.json.
-SECRETS="$(decrypt_secrets | sed 's/export //')"
+SECRETS="$(decrypt_secrets | sed 's/^export //')"
 
 DEV_NETWORK_AUTH_USERNAME="$(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS" | xargs)"
 DEV_NETWORK_AUTH_PASSWORD="$(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS" | xargs)"

--- a/tools/generate_secrets_json.sh
+++ b/tools/generate_secrets_json.sh
@@ -9,24 +9,16 @@ source "$REPO_ROOT/scripts/secrets_manager"
 # and exit if any dependencies are installed
 check_dependencies -exit_on_install > /dev/null
 
-lookup() {
-if [[ -z "$1" ]] ; then
-  echo ""
-else
-  awk -v "id=$1" 'BEGIN { FS = "=" } $1 == id { print $2 ; exit }' <<< "$2"
-fi
-}
-
 # One decryption for all six lookups. The assignment carries the age exit
 # status, so a failure stops the script before jq truncates secrets.json.
 SECRETS="$(decrypt_secrets | sed 's/export //')"
 
-DEV_NETWORK_AUTH_USERNAME=$(echo $(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS")|xargs)
-DEV_NETWORK_AUTH_PASSWORD=$(echo $(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS")|xargs)
-TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
-MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED=$(echo $(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS")|xargs)
-DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED=$(echo $(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS")|xargs)
-DYNAMIC_FOG_AUTHORITY_SPKI=$(echo $(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS") | sed 's/"//')
+DEV_NETWORK_AUTH_USERNAME="$(lookup DEV_NETWORK_AUTH_USERNAME "$SECRETS" | xargs)"
+DEV_NETWORK_AUTH_PASSWORD="$(lookup DEV_NETWORK_AUTH_PASSWORD "$SECRETS" | xargs)"
+TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup TESTNET_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED="$(lookup MOBILEDEV_TEST_ACCOUNT_MNEMONICS_COMMA_SEPERATED "$SECRETS" | xargs)"
+DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED="$(lookup DYNAMIC_TEST_ACCOUNT_SEED_ENTROPIES_COMMA_SEPARATED "$SECRETS" | xargs)"
+DYNAMIC_FOG_AUTHORITY_SPKI="$(lookup DYNAMIC_FOG_AUTHORITY_SPKI "$SECRETS" | xargs)"
 
 jq --null-input \
   --arg DEV_NETWORK_AUTH_USERNAME "$DEV_NETWORK_AUTH_USERNAME" \

--- a/tools/lookup_test.sh
+++ b/tools/lookup_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Checks the `lookup` helper in scripts/secrets_manager against a synthetic
+# payload. It decrypts nothing, so it runs without any age key.
+
+set -eo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/secrets_manager"
+
+PAYLOAD='DEV_NETWORK_AUTH_USERNAME=alice
+DYNAMIC_FOG_AUTHORITY_SPKI="MIIBIjANBgkq=="
+SRC=aGVsbG8=
+SRC_ACCT_ENTROPY_STRING=one two three
+DUP=first
+DUP=second
+EMPTYVAL=
+
+BAREKEY'
+
+FAILURES=0
+
+expect_value() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# The generators read every value as `lookup KEY "$SECRETS" | xargs`.
+expect_trimmed() {
+  local key="$1" want="$2" got
+  got="$(lookup "$key" "$PAYLOAD" 2>/dev/null | xargs)" || got="<lookup failed>"
+  if [[ "$got" != "$want" ]]; then
+    echo "lookup $key | xargs: want [$want], got [$got]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_failure() {
+  local key="$1" err status=0
+  err="$(lookup "$key" "$PAYLOAD" 2>&1 >/dev/null)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    echo "lookup $key: want a non-zero status, got 0" >&2
+    FAILURES=$((FAILURES + 1))
+  elif [[ "$err" != *"no $key in the decrypted payload"* ]]; then
+    echo "lookup $key: want a message naming the key, got [$err]" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect_value DEV_NETWORK_AUTH_USERNAME alice
+expect_value DYNAMIC_FOG_AUTHORITY_SPKI '"MIIBIjANBgkq=="'
+expect_value SRC 'aGVsbG8='
+expect_trimmed DYNAMIC_FOG_AUTHORITY_SPKI 'MIIBIjANBgkq=='
+expect_value SRC_ACCT_ENTROPY_STRING 'one two three'
+expect_value DUP first
+expect_value EMPTYVAL ''
+expect_failure SRC_ACCT
+expect_failure ABSENT
+expect_failure BAREKEY
+expect_failure ''
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES lookup checks failed" >&2
+  exit 1
+fi
+
+echo "lookup checks passed"


### PR DESCRIPTION
The `lookup` helper in the two secret generators split each line on `=` and printed the second field. A value holding a second `=` lost everything from that character on. `DYNAMIC_FOG_AUTHORITY_SPKI` is base64, and a base64 value can end in one or two `=` pad characters. A key absent from the payload returned an empty string with status 0, so the generator wrote `""` and exited 0.

- The helper lives once in `scripts/secrets_manager`, which both generators already source. SENTZ-5678 asked for a fix in both copies, and one copy is the smaller diff.
- Each value is read as one `lookup KEY "$SECRETS" | xargs` assignment, so a failed read stops the script. The old shape word-split an unquoted command substitution and expanded a glob against the working directory.
- Both generators read the payload before their first write, so a failed read leaves the target files untouched.
- `sed 's/^export //'` is anchored. The unanchored form removes the first `export ` anywhere on a line.
- `ensure_test_resources.sh` seeds a zero-byte target as well as a missing one. A generator that dies mid-write leaves the target at zero bytes, and this script is the repair path.
- `tools/lookup_test.sh` runs the helper against a synthetic payload, so it needs no age key or keychain. The Swift package tests job runs it before the build.
- No age key on this machine is listed in `secrets/contributor_public_keys`, so the real values are unmeasured and every check used a synthetic payload.