### PR TITLE
chore(SENTZ-5654): Give the consensus trust-root skips an HTTP rationale

### DIFF
--- a/Tests/Integration/NonTransacting/Network/Connection/ConsensusConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/ConsensusConnectionIntTests.swift
@@ -167,6 +167,8 @@ class ConsensusConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func wrongTrustRootFails(transportProtocol: TransportProtocol) throws {
+        // A wrong trust root cancels the URLSession challenge, so the call over
+        // HTTP fails with `connectionFailure`, and that fails this case.
         try XCTSkipIf(true)
         let trustRootsFixture = try NetworkConfig.Fixtures.TrustRoots()
         let connection =
@@ -188,7 +190,7 @@ class ConsensusConnectionIntTests: XCTestCase, @unchecked Sendable {
             }
             expect.fulfill()
         })
-        waitForExpectations(timeout: .infinity)
+        waitForExpectations(timeout: 40)
     }
 
 }

--- a/Tests/Integration/Transacting/MobileCoinClientPublicApiIntTestsTransacting.swift
+++ b/Tests/Integration/Transacting/MobileCoinClientPublicApiIntTestsTransacting.swift
@@ -765,6 +765,9 @@ class MobileCoinClientPublicApiIntTestsTransacting: XCTestCase, @unchecked Senda
     }
 
     func testWrongConsensusTrustRootReturnsError() async throws {
+        // The requester pins fog and consensus against one merged key set. This
+        // case sets a wrong consensus root and leaves fog unset, so the balance
+        // read fails ahead of the submit.
         try XCTSkipIf(true)
 
         let description = "Submitting transaction"


### PR DESCRIPTION
Both consensus trust-root integration cases carry an unconditional skip with no stated reason. SENTZ-5587 removed the gRPC rationale, which named a transport the package no longer builds. This gives each case a rationale that matches the HTTP path.

- The HTTP requester does not retry a wrong trust root without end. It cancels the URLSession challenge once on a pinned-key mismatch, and the failure goes straight to the caller.
- `wrongTrustRootFails` stays skipped because a cancelled challenge arrives as `connectionFailure` and the case accepts only `authorizationFailure`. Deleting the skip and widening that switch would make it pass, and nothing here can run it to prove that.
- `testWrongConsensusTrustRootReturnsError` stays skipped because the requester pins fog and consensus against one merged key set. The case sets only a wrong consensus root, so its balance read fails ahead of the submit it names.
- The consensus case waited on its expectation without a bound and now waits 40 seconds, matching the case above it.
- No CI job runs either scheme. The ExampleHTTP test target scans the unit, performance and HTTP protocol schemes, and builds the two integration schemes without running them.
- SENTZ-5682 carries the merged pinning, the unrun schemes, and the two `FogBlockConnectionIntTests` skips that still have no rationale.
- Neither case was executed. No age key on this machine is listed in `secrets/contributor_public_keys`, so every conclusion is read from source.
