### PR TITLE
security(SENTZ-5655): Report pinning failures and keep server text out of the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumer that supplies its own `HttpRequester` replaces
   `DefaultHttpRequester` outright, so its traffic never reaches this code.
 - `HttpRequester` requires both trust-root setters and answers each with a
-  `Result`. The protocol carries no default, so a requester that stores no
-  roots fails to compile. This is a breaking change.
+  `Result`. The protocol doesn't carry a default, so a conformer must
+  implement both setters. This is a breaking change.
+- Both `HttpRequester` trust-root setters take `hosts: [String]`, naming the
+  endpoints that set of roots pins. This is a breaking change for a caller of
+  either setter and for a conformer outside this package.
+  `DefaultHttpRequester` judges a challenged host against the roots of every
+  set that names it and carries keys. A consensus host will be judged against
+  the pinned consensus roots alone when the consensus set is the only such set
+  for that host. Both setters store a host in the form a lookup uses, which
+  ignores case and trailing dots.
+- `DefaultHttpRequester` judges a host that no such set names against every
+  root it holds, which is the fallback and is what it did for every host
+  before. A lookup keeps a naming set only while it carries keys, so the
+  lookup takes that fallback for a host that keyless sets alone name. A
+  consumer that names the hosts of one setter alone leaves the other setter's
+  hosts there too.
 - `SecTrust.publicKeyTrustChain` returns a `Result` and carries the error of
   the certificate it could not read. `asPublicKeyTrustChain` is gone.
 - `SecTrust.certificateTrustChain` reads the chain with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped caller. A consumer that pins a CA the device does not trust can no
   longer connect there. That path carries no flag to turn the check off. A
   consumer that supplies its own `HttpRequester` replaces
-  `DefaultHttpRequester` outright, so its traffic never reaches this code. The
-  protocol's default trust-root setters do nothing, and they report no error.
+  `DefaultHttpRequester` outright, so its traffic never reaches this code.
+- The `HttpRequester` default trust-root setters store nothing and return a
+  failure. This is a breaking change for a consumer that reads the result as
+  proof the roots are pinned.
+- `SecTrust.publicKeyTrustChain` returns a `Result` and carries the error of
+  the certificate it could not read. `asPublicKeyTrustChain` is gone.
+- `SecTrust.certificateTrustChain` reads the chain with
+  `SecTrustCopyCertificateChain` on iOS 15 and macOS 12. Older systems keep the
+  deprecated calls.
 - A private CA the device trusts is an anchor like any other, so a chain under
   it is judged like any other.
 - `validateAgainst` reads the chain the system built. A server that presents a
@@ -31,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what `URLSession` supplies, a chain issued for another host is refused too.
   A CA pin is matched by any certificate that CA issues, so the host check
   is what separates the intended server from a sibling.
+- The pinning failure line carries the system's error code in place of its
+  description. The description quotes the server's own common name, so a name
+  holding a newline could forge a client log line.
+- The pinning success line names the index of the certificate that matched in
+  place of its public key.
+- `NetworkConfig.setConsensusTrustRoots` and `setFogTrustRoots` keep the roots
+  already set when the new roots fail to parse.
 
 ## [6.1.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer connect there. That path carries no flag to turn the check off. A
   consumer that supplies its own `HttpRequester` replaces
   `DefaultHttpRequester` outright, so its traffic never reaches this code.
-- The `HttpRequester` default trust-root setters store nothing and return a
-  failure. This is a breaking change for a consumer that reads the result as
-  proof the roots are pinned.
+- `HttpRequester` requires both trust-root setters and answers each with a
+  `Result`. The protocol carries no default, so a requester that stores no
+  roots fails to compile. This is a breaking change.
 - `SecTrust.publicKeyTrustChain` returns a `Result` and carries the error of
   the certificate it could not read. `asPublicKeyTrustChain` is gone.
 - `SecTrust.certificateTrustChain` reads the chain with
-  `SecTrustCopyCertificateChain` on iOS 15 and macOS 12. Older systems keep the
-  deprecated calls.
+  `SecTrustCopyCertificateChain` on iOS 15 and macOS 12. The deprecated calls
+  answer on an older system and wherever that call gives nil.
 - A private CA the device trusts is an anchor like any other, so a chain under
   it is judged like any other.
 - `validateAgainst` reads the chain the system built. A server that presents a
@@ -44,7 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The pinning success line names the index of the certificate that matched in
   place of its public key.
 - `NetworkConfig.setConsensusTrustRoots` and `setFogTrustRoots` keep the roots
-  already set when the new roots fail to parse.
+  already set when the new roots fail to parse, and they keep the new roots
+  only once the requester has taken them.
+- `MobileCoinClient` gives a config that carries no requester a
+  `DefaultHttpRequester`, so the trust roots on that config reach the
+  connections it opens. Before this the connection factory built its own
+  requester, which held no roots and pinned nothing.
+- `SecCertificate.publicKey(for:)` names the certificate in place of printing
+  its bytes.
 
 ## [6.1.0] - 2026-09-01
 

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -55,11 +55,10 @@ public final class MobileCoinClient {
         self.fogQueryScalingStrategy = config.fogQueryScalingStrategy
 
         var networkConfig = config.networkConfig
-        networkConfig.fillHttpRequester()
+        let httpRequester = networkConfig.filledHttpRequester()
 
         let grpcFactory = GrpcProtocolConnectionFactory()
-        let httpFactory = HttpProtocolConnectionFactory(
-            httpRequester: networkConfig.httpRequester)
+        let httpFactory = HttpProtocolConnectionFactory(httpRequester: httpRequester)
 
         self.serviceProvider = DefaultServiceProvider(
             networkConfig: networkConfig,
@@ -68,7 +67,7 @@ public final class MobileCoinClient {
             httpConnectionFactory: httpFactory)
 
         self.fogResolverManager = FogResolverManager(
-            fogReportAttestation: config.networkConfig.fogReportAttestation,
+            fogReportAttestation: networkConfig.fogReportAttestation,
             serviceProvider: serviceProvider,
             targetQueue: serialQueue)
 

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -54,13 +54,8 @@ public final class MobileCoinClient {
         self.mixinSelectionStrategy = config.mixinSelectionStrategy
         self.fogQueryScalingStrategy = config.fogQueryScalingStrategy
 
-        // The factory builds a requester of its own when it is given none, and
-        // that requester holds no trust roots. Setting one here sends the
-        // config's own roots to the requester the connections use.
         var networkConfig = config.networkConfig
-        if networkConfig.httpRequester == nil {
-            networkConfig.httpRequester = DefaultHttpRequester()
-        }
+        networkConfig.fillHttpRequester()
 
         let grpcFactory = GrpcProtocolConnectionFactory()
         let httpFactory = HttpProtocolConnectionFactory(

--- a/Sources/Common/MobileCoinClient.swift
+++ b/Sources/Common/MobileCoinClient.swift
@@ -54,12 +54,20 @@ public final class MobileCoinClient {
         self.mixinSelectionStrategy = config.mixinSelectionStrategy
         self.fogQueryScalingStrategy = config.fogQueryScalingStrategy
 
+        // The factory builds a requester of its own when it is given none, and
+        // that requester holds no trust roots. Setting one here sends the
+        // config's own roots to the requester the connections use.
+        var networkConfig = config.networkConfig
+        if networkConfig.httpRequester == nil {
+            networkConfig.httpRequester = DefaultHttpRequester()
+        }
+
         let grpcFactory = GrpcProtocolConnectionFactory()
         let httpFactory = HttpProtocolConnectionFactory(
-            httpRequester: config.networkConfig.httpRequester)
+            httpRequester: networkConfig.httpRequester)
 
         self.serviceProvider = DefaultServiceProvider(
-            networkConfig: config.networkConfig,
+            networkConfig: networkConfig,
             targetQueue: serialQueue,
             grpcConnectionFactory: grpcFactory,
             httpConnectionFactory: httpFactory)

--- a/Sources/Common/Network/HttpRequester.swift
+++ b/Sources/Common/Network/HttpRequester.swift
@@ -2,8 +2,6 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
-// swiftlint:disable all
-
 import Foundation
 import SwiftProtobuf
 #if canImport(LibMobileCoin)
@@ -19,26 +17,13 @@ public protocol HttpRequester {
         method: HTTPMethod,
         headers: [String: String]?,
         body: Data?,
-        completion: @escaping (Result<HTTPResponse, Error>) -> Void)
-    
+        completion: @escaping (Result<HTTPResponse, Error>) -> Void
+    )
+
+    // Every requester answers for its own trust roots, so a requester that
+    // stores none fails to compile against this protocol.
     @discardableResult
     func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError>
     @discardableResult
     func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError>
-}
-
-// A requester that does not store trust roots answers with a failure, so a
-// caller cannot read a discarded root as a root that is pinned.
-extension HttpRequester {
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
-        -> Result<(), InvalidInputError>
-    {
-        .failure(InvalidInputError("This HttpRequester does not store fog trust roots"))
-    }
-
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
-        -> Result<(), InvalidInputError>
-    {
-        .failure(InvalidInputError("This HttpRequester does not store consensus trust roots"))
-    }
 }

--- a/Sources/Common/Network/HttpRequester.swift
+++ b/Sources/Common/Network/HttpRequester.swift
@@ -21,15 +21,24 @@ public protocol HttpRequester {
         body: Data?,
         completion: @escaping (Result<HTTPResponse, Error>) -> Void)
     
-    func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
-    func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+    @discardableResult
+    func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError>
+    @discardableResult
+    func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError>
 }
 
+// A requester that does not store trust roots answers with a failure, so a
+// caller cannot read a discarded root as a root that is pinned.
 extension HttpRequester {
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) {
-        logger.debug("setting fog trust roots not implemented")
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
+        .failure(InvalidInputError("This HttpRequester does not store fog trust roots"))
     }
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?) {
-        logger.debug("setting consensus trust roots not implemented")
+
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
+        .failure(InvalidInputError("This HttpRequester does not store consensus trust roots"))
     }
 }

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -68,11 +68,13 @@ struct NetworkConfig {
     private func pushStoredTrustRoots() {
         guard let requester = httpRequester else { return }
         if let fog = fogTrustRoots[.http] as? SecSSLCertificates,
-           case .failure(let error) = requester.setFogTrustRoots(fog) {
+           case .failure(let error) = requester.setFogTrustRoots(
+            fog, hosts: fogUrls.map(\.host)) {
             logger.error("Fog trust roots stay unpinned: \(error)", logFunction: false)
         }
         if let consensus = consensusTrustRoots[.http] as? SecSSLCertificates,
-           case .failure(let error) = requester.setConsensusTrustRoots(consensus) {
+           case .failure(let error) = requester.setConsensusTrustRoots(
+            consensus, hosts: consensusUrls.map(\.host)) {
             logger.error("Consensus trust roots stay unpinned: \(error)", logFunction: false)
         }
     }
@@ -214,16 +216,18 @@ extension NetworkConfig {
     @discardableResult mutating public func setConsensusTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
-        setTrustRoots(trustRoots, into: \.consensusTrustRoots) { requester, certificates in
-            requester.setConsensusTrustRoots(certificates)
+        let hosts = consensusUrls.map(\.host)
+        return setTrustRoots(trustRoots, into: \.consensusTrustRoots) { requester, certificates in
+            requester.setConsensusTrustRoots(certificates, hosts: hosts)
         }
     }
 
     @discardableResult mutating public func setFogTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
-        setTrustRoots(trustRoots, into: \.fogTrustRoots) { requester, certificates in
-            requester.setFogTrustRoots(certificates)
+        let hosts = fogUrls.map(\.host)
+        return setTrustRoots(trustRoots, into: \.fogTrustRoots) { requester, certificates in
+            requester.setFogTrustRoots(certificates, hosts: hosts)
         }
     }
 

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -52,11 +52,15 @@ struct NetworkConfig {
         }
     }
 
-    // A config that holds no requester gives itself one, so that the roots it
-    // stores will reach the connections built from it.
-    mutating func fillHttpRequester() {
-        guard httpRequester == nil else { return }
-        httpRequester = DefaultHttpRequester()
+    // Answers with the config's own requester, and gives the config a
+    // DefaultHttpRequester first whenever it holds none.
+    mutating func filledHttpRequester() -> HttpRequester {
+        if let requester = httpRequester {
+            return requester
+        }
+        let requester = DefaultHttpRequester()
+        httpRequester = requester
+        return requester
     }
 
     // A property setter answers with nothing, so a refusal only goes to the
@@ -223,8 +227,8 @@ extension NetworkConfig {
         }
     }
 
-    // The requester takes the roots before the dictionary keeps them, so a
-    // refusal will leave the roots that are already pinned in place.
+    // The requester takes the http roots before the dictionary keeps them, so
+    // a refusal will leave the http roots that are already pinned in place.
     private mutating func setTrustRoots(
         _ trustRoots: [Data],
         into roots: WritableKeyPath<NetworkConfig, [TransportProtocol: SSLCertificates]>,

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -52,9 +52,15 @@ struct NetworkConfig {
         }
     }
 
-    // A property setter answers with nothing, so a requester that refuses the
-    // stored roots says so in the log. Absent roots stay absent, so a requester
-    // keeps the roots it already holds.
+    // A config that holds no requester gives itself one, so that the roots it
+    // stores will reach the connections built from it.
+    mutating func fillHttpRequester() {
+        guard httpRequester == nil else { return }
+        httpRequester = DefaultHttpRequester()
+    }
+
+    // A property setter answers with nothing, so a refusal only goes to the
+    // log. Roots the config doesn't hold leave the requester's own in place.
     private func pushStoredTrustRoots() {
         guard let requester = httpRequester else { return }
         if let fog = fogTrustRoots[.http] as? SecSSLCertificates,
@@ -218,8 +224,7 @@ extension NetworkConfig {
     }
 
     // The requester takes the roots before the dictionary keeps them, so a
-    // refusal leaves the roots that are already pinned in place. A config with
-    // no requester yet keeps the roots for the requester it is given later.
+    // refusal will leave the roots that are already pinned in place.
     private mutating func setTrustRoots(
         _ trustRoots: [Data],
         into roots: WritableKeyPath<NetworkConfig, [TransportProtocol: SSLCertificates]>,

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -48,8 +48,22 @@ struct NetworkConfig {
 
     var httpRequester: HttpRequester? {
         didSet {
-            httpRequester?.setFogTrustRoots(fogTrustRoots[.http] as? SecSSLCertificates)
-            httpRequester?.setConsensusTrustRoots(consensusTrustRoots[.http] as? SecSSLCertificates)
+            pushStoredTrustRoots()
+        }
+    }
+
+    // A property setter answers with nothing, so a requester that refuses the
+    // stored roots says so in the log. Absent roots stay absent, so a requester
+    // keeps the roots it already holds.
+    private func pushStoredTrustRoots() {
+        guard let requester = httpRequester else { return }
+        if let fog = fogTrustRoots[.http] as? SecSSLCertificates,
+           case .failure(let error) = requester.setFogTrustRoots(fog) {
+            logger.error("Fog trust roots stay unpinned: \(error)", logFunction: false)
+        }
+        if let consensus = consensusTrustRoots[.http] as? SecSSLCertificates,
+           case .failure(let error) = requester.setConsensusTrustRoots(consensus) {
+            logger.error("Consensus trust roots stay unpinned: \(error)", logFunction: false)
         }
     }
 
@@ -190,55 +204,47 @@ extension NetworkConfig {
     @discardableResult mutating public func setConsensusTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
-        let (grpc, http) = validatedCertificates(trustRoots)
-
-        if let certificates = try? grpc.get() {
-            self.consensusTrustRoots[.grpc] = certificates
+        setTrustRoots(trustRoots, into: \.consensusTrustRoots) { requester, certificates in
+            requester.setConsensusTrustRoots(certificates)
         }
-        if let certificates = try? http.get() {
-            self.consensusTrustRoots[.http] = certificates
-            if case .failure(let error) = pushConsensusTrustRoots(certificates) {
-                return .failure(error)
-            }
-        }
-
-        return currentProtocolValidation(grpc: grpc, http: http)
     }
 
     @discardableResult mutating public func setFogTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
+        setTrustRoots(trustRoots, into: \.fogTrustRoots) { requester, certificates in
+            requester.setFogTrustRoots(certificates)
+        }
+    }
+
+    // The requester takes the roots before the dictionary keeps them, so a
+    // refusal leaves the roots that are already pinned in place. A config with
+    // no requester yet keeps the roots for the requester it is given later.
+    private mutating func setTrustRoots(
+        _ trustRoots: [Data],
+        into roots: WritableKeyPath<NetworkConfig, [TransportProtocol: SSLCertificates]>,
+        pushedBy push: (HttpRequester, SecSSLCertificates) -> Result<(), InvalidInputError>
+    ) -> Result<(), InvalidInputError> {
         let (grpc, http) = validatedCertificates(trustRoots)
 
         if let certificates = try? grpc.get() {
-            self.fogTrustRoots[.grpc] = certificates
+            self[keyPath: roots][.grpc] = certificates
         }
         if let certificates = try? http.get() {
-            self.fogTrustRoots[.http] = certificates
-            if case .failure(let error) = pushFogTrustRoots(certificates) {
+            // A requester takes only Sec certificates, and nil there clears the
+            // roots it holds, so a cast that fails answers as a failure.
+            guard let httpCertificates = certificates as? SecSSLCertificates else {
+                return .failure(InvalidInputError("HTTP trust roots hold another type"))
+            }
+            if let requester = httpRequester,
+               case .failure(let error) = push(requester, httpCertificates) {
                 return .failure(error)
             }
+            self[keyPath: roots][.http] = certificates
         }
 
         return currentProtocolValidation(grpc: grpc, http: http)
     }
-
-    // A requester that discards the roots reports it, and a config with no
-    // requester yet has nothing to discard them.
-    private func pushConsensusTrustRoots(_ certificates: SSLCertificates)
-        -> Result<(), InvalidInputError>
-    {
-        guard let requester = httpRequester else { return .success(()) }
-        return requester.setConsensusTrustRoots(certificates as? SecSSLCertificates)
-    }
-
-    private func pushFogTrustRoots(_ certificates: SSLCertificates)
-        -> Result<(), InvalidInputError>
-    {
-        guard let requester = httpRequester else { return .success(()) }
-        return requester.setFogTrustRoots(certificates as? SecSSLCertificates)
-    }
-
 }
 
 extension NetworkConfig {

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -192,9 +192,15 @@ extension NetworkConfig {
     {
         let (grpc, http) = validatedCertificates(trustRoots)
 
-        self.consensusTrustRoots[.grpc] = try? grpc.get()
-        self.consensusTrustRoots[.http] = try? http.get()
-        self.httpRequester?.setConsensusTrustRoots(try? http.get() as? SecSSLCertificates)
+        if let certificates = try? grpc.get() {
+            self.consensusTrustRoots[.grpc] = certificates
+        }
+        if let certificates = try? http.get() {
+            self.consensusTrustRoots[.http] = certificates
+            if case .failure(let error) = pushConsensusTrustRoots(certificates) {
+                return .failure(error)
+            }
+        }
 
         return currentProtocolValidation(grpc: grpc, http: http)
     }
@@ -204,11 +210,33 @@ extension NetworkConfig {
     {
         let (grpc, http) = validatedCertificates(trustRoots)
 
-        self.fogTrustRoots[.grpc] = try? grpc.get()
-        self.fogTrustRoots[.http] = try? http.get()
-        self.httpRequester?.setFogTrustRoots(try? http.get() as? SecSSLCertificates)
+        if let certificates = try? grpc.get() {
+            self.fogTrustRoots[.grpc] = certificates
+        }
+        if let certificates = try? http.get() {
+            self.fogTrustRoots[.http] = certificates
+            if case .failure(let error) = pushFogTrustRoots(certificates) {
+                return .failure(error)
+            }
+        }
 
         return currentProtocolValidation(grpc: grpc, http: http)
+    }
+
+    // A requester that discards the roots reports it, and a config with no
+    // requester yet has nothing to discard them.
+    private func pushConsensusTrustRoots(_ certificates: SSLCertificates)
+        -> Result<(), InvalidInputError>
+    {
+        guard let requester = httpRequester else { return .success(()) }
+        return requester.setConsensusTrustRoots(certificates as? SecSSLCertificates)
+    }
+
+    private func pushFogTrustRoots(_ certificates: SSLCertificates)
+        -> Result<(), InvalidInputError>
+    {
+        guard let requester = httpRequester else { return .success(()) }
+        return requester.setFogTrustRoots(certificates as? SecSSLCertificates)
     }
 
 }

--- a/Sources/Common/Network/SecCertificate+Extensions.swift
+++ b/Sources/Common/Network/SecCertificate+Extensions.swift
@@ -18,8 +18,8 @@ extension SecCertificate {
         if let trust = trust, trustCreationStatus == errSecSuccess {
             publicKey = SecTrustCopyPublicKey(trust)
         } else {
-            // The status code names why the trust object refused the
-            // certificate, so the certificate bytes add nothing to the text.
+            // The status carries what SecTrustCreateWithCertificates
+            // reported, so the certificate bytes add nothing to the text.
             let error = SecurityError(trustCreationStatus, message: "root certificate")
             return .failure(error)
         }

--- a/Sources/Common/Network/SecCertificate+Extensions.swift
+++ b/Sources/Common/Network/SecCertificate+Extensions.swift
@@ -74,22 +74,19 @@ extension SecTrust {
     private typealias ChainOfTrustKey = (index: Int, key: SecKey)
 
     public var certificateCount: Int {
-        SecTrustGetCertificateCount(self)
+        certificateTrustChain.count
     }
 
     public var certificateTrustChain: [SecCertificate] {
-        [Int](0..<certificateCount).compactMap {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            return SecTrustCopyCertificateChain(self) as? [SecCertificate] ?? []
+        }
+        return [Int](0..<SecTrustGetCertificateCount(self)).compactMap {
             SecTrustGetCertificateAtIndex(self, $0)
         }
     }
 
-    public var publicKeyTrustChain: [SecKey] {
-        certificateTrustChain.compactMap {
-            try? $0.asPublicKey().get()
-        }
-    }
-
-    public var asPublicKeyTrustChain: Result<[SecKey], Error> {
+    public var publicKeyTrustChain: Result<[SecKey], Error> {
         do {
             let keys = try certificateTrustChain.map {
                 try $0.asPublicKey().get()
@@ -111,16 +108,23 @@ extension SecTrust {
         let matches: [ChainOfTrustKey]
         let serverTrust = self
 
-        // Pinning narrows which system-trusted chains are acceptable.
+        // Pinning narrows which system-trusted chains are acceptable. The system
+        // error description quotes the server's own certificate, so the code
+        // stands in for it and the line stays free of server text.
         var trustError: CFError?
         guard SecTrustEvaluateWithError(serverTrust, &trustError) else {
-            let reason = trustError.map { CFErrorCopyDescription($0) as String } ?? "unknown"
+            let code = trustError.map { "\(CFErrorGetCode($0))" } ?? "unknown"
             completion(.failure(SSLTrustError(
-                "Failure: the server's chain of trust failed system evaluation: \(reason)")))
+                Self.systemEvaluationFailure + code)))
             return
         }
 
-        let trustChainEnumerated = serverTrust.publicKeyTrustChain.enumerated()
+        guard let trustChain = try? serverTrust.publicKeyTrustChain.get() else {
+            completion(.failure(SSLTrustError(Self.unreadablePublicKey)))
+            return
+        }
+
+        let trustChainEnumerated = trustChain.enumerated()
         matches = trustChainEnumerated
             .map { chain -> ChainOfTrustKeyMatch in
                 let serverCertificateKey = chain.element
@@ -132,22 +136,29 @@ extension SecTrust {
 
         switch matches.isNotEmpty {
         case true:
+            // The index says which certificate matched. The key itself is
+            // material and stays out of the log.
             let indexes = matches.map { "\($0.index)" }
-            let keys = matches.compactMap { $0.key.data }.map { "\($0.base64EncodedString() )" }
-            let message = """
-                    Success: pinned certificates matched with server's chain of trust
-                    at index(es): [\(indexes.joined(separator: ", "))] \
-                    with key(s): \(keys.joined(separator: ", \n"))
-                    """
+            let message = Self.pinnedKeyMatched + "[\(indexes.joined(separator: ", "))]"
             completion(.success(message))
         case false:
             /// Failing here means that the public key of the server does not match the stored one.
             /// This can either indicate a MITM attack, or that the backend certificate and the
             /// private key changed, most likely due to expiration.
-            let message = "Failure: no pinned certificate matched in the server's chain of trust"
-            completion(.failure(SSLTrustError(message)))
+            completion(.failure(SSLTrustError(Self.noPinnedKeyMatched)))
         }
     }
+
+    // Named so a test can assert which refusal it read, rather than only that
+    // the check refused.
+    static let systemEvaluationFailure =
+        "Failure: the server's chain of trust failed system evaluation, code "
+    static let unreadablePublicKey =
+        "Failure: the server's chain of trust holds a certificate with no readable public key"
+    static let noPinnedKeyMatched =
+        "Failure: no pinned certificate matched in the server's chain of trust"
+    static let pinnedKeyMatched =
+        "Success: pinned certificates matched with the server's chain of trust at index(es): "
 }
 
 extension SecKey {

--- a/Sources/Common/Network/SecCertificate+Extensions.swift
+++ b/Sources/Common/Network/SecCertificate+Extensions.swift
@@ -18,8 +18,8 @@ extension SecCertificate {
         if let trust = trust, trustCreationStatus == errSecSuccess {
             publicKey = SecTrustCopyPublicKey(trust)
         } else {
-            // The certificate itself is key material and stays out of the text.
-            // The status says why the trust object refused it.
+            // The status code names why the trust object refused the
+            // certificate, so the certificate bytes add nothing to the text.
             let error = SecurityError(trustCreationStatus, message: "root certificate")
             return .failure(error)
         }

--- a/Sources/Common/Network/SecCertificate+Extensions.swift
+++ b/Sources/Common/Network/SecCertificate+Extensions.swift
@@ -14,19 +14,18 @@ extension SecCertificate {
         let policy = SecPolicyCreateBasicX509()
         var trust: SecTrust?
         let trustCreationStatus = SecTrustCreateWithCertificates(certificate, policy, &trust)
-        let data = certificate.data
 
         if let trust = trust, trustCreationStatus == errSecSuccess {
             publicKey = SecTrustCopyPublicKey(trust)
         } else {
-            let message = "root certificate: \(data.base64EncodedString())"
-            let error = SecurityError(trustCreationStatus, message: message)
+            // The certificate itself is key material and stays out of the text.
+            // The status says why the trust object refused it.
+            let error = SecurityError(trustCreationStatus, message: "root certificate")
             return .failure(error)
         }
 
         guard let key = publicKey else {
-            let message = ", root certificate: \(data.base64EncodedString())"
-            return .failure(SecurityError(nil, message: SecurityError.nilPublicKey + message))
+            return .failure(SecurityError(nil, message: SecurityError.nilPublicKey))
         }
 
         return .success(key)
@@ -77,9 +76,13 @@ extension SecTrust {
         certificateTrustChain.count
     }
 
+    // SecTrustCopyCertificateChain is nullable and documents no chain for a
+    // trust it has yet to evaluate. SecTrustGetCertificateAtIndex documents the
+    // leaf as always present, so it answers whenever the newer call gives nil.
     public var certificateTrustChain: [SecCertificate] {
-        if #available(iOS 15.0, macOS 12.0, *) {
-            return SecTrustCopyCertificateChain(self) as? [SecCertificate] ?? []
+        if #available(iOS 15.0, macOS 12.0, *),
+           let chain = SecTrustCopyCertificateChain(self) as? [SecCertificate] {
+            return chain
         }
         return [Int](0..<SecTrustGetCertificateCount(self)).compactMap {
             SecTrustGetCertificateAtIndex(self, $0)
@@ -149,8 +152,7 @@ extension SecTrust {
         }
     }
 
-    // Named so a test can assert which refusal it read, rather than only that
-    // the check refused.
+    // Each refusal carries its own name, so a test can assert which one it read.
     static let systemEvaluationFailure =
         "Failure: the server's chain of trust failed system evaluation, code "
     static let unreadablePublicKey =

--- a/Sources/HTTPS/DefaultHttpRequester.swift
+++ b/Sources/HTTPS/DefaultHttpRequester.swift
@@ -74,12 +74,20 @@ public final class DefaultHttpRequester: NSObject, HttpRequester {
         task.resume()
     }
 
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?) {
+    @discardableResult
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
         pinningDelegate.setConsensusTrustRoots(trustRoots)
+        return .success(())
     }
 
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) {
+    @discardableResult
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
         pinningDelegate.setFogTrustRoots(trustRoots)
+        return .success(())
     }
 }
 
@@ -124,7 +132,7 @@ final class CertificatePinningDelegate: NSObject {
     ) {
         guard
             let trust = challenge.protectionSpace.serverTrust,
-            SecTrustGetCertificateCount(trust) > 0
+            trust.certificateTrustChain.isNotEmpty
         else {
             // This case will probably get handled by ATS, but still...
             completionHandler(.cancelAuthenticationChallenge, nil)

--- a/Sources/HTTPS/DefaultHttpRequester.swift
+++ b/Sources/HTTPS/DefaultHttpRequester.swift
@@ -75,18 +75,18 @@ public final class DefaultHttpRequester: NSObject, HttpRequester {
     }
 
     @discardableResult
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
-        pinningDelegate.setConsensusTrustRoots(trustRoots)
+        pinningDelegate.setConsensusTrustRoots(trustRoots, hosts: hosts)
         return .success(())
     }
 
     @discardableResult
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
-        pinningDelegate.setFogTrustRoots(trustRoots)
+        pinningDelegate.setFogTrustRoots(trustRoots, hosts: hosts)
         return .success(())
     }
 }
@@ -103,27 +103,51 @@ extension DefaultHttpRequester {
 // URLSession calls this back on its own queue while the SDK can be setting
 // trust roots from another thread, so both roots sit behind one lock.
 final class CertificatePinningDelegate: NSObject {
+    private struct PinnedRoots {
+        var certificates: SecSSLCertificates?
+        var hosts: Set<String> = []
+
+        var keys: [SecKey] { certificates?.publicKeys ?? [] }
+    }
+
     private struct TrustRoots {
-        var fog: SecSSLCertificates?
-        var consensus: SecSSLCertificates?
+        var fog = PinnedRoots()
+        var consensus = PinnedRoots()
     }
 
     private let trustRoots = ReadWriteDispatchLock(TrustRoots())
 
-    // Internal so a test can prove each setter writes its own field. `handle`
-    // merges the two, so nothing downstream can tell a swap apart.
-    var pinnedKeys: [SecKey] {
-        trustRoots.readSync { [$0.fog, $0.consensus] }
-            .compactMap { $0?.publicKeys }
-            .flatMap { $0 }
+    /// Answers with the keys of each set that names `host` and carries keys.
+    /// A host no such set names gets the keys of every set.
+    func pinnedKeys(for host: String) -> [SecKey] {
+        let name = CertificatePinningDelegate.normalized(host)
+        let roots = trustRoots.readSync { [$0.fog, $0.consensus] }
+        let named = roots.filter { $0.hosts.contains(name) && $0.keys.isNotEmpty }
+        return (named.isNotEmpty ? named : roots).flatMap { $0.keys }
     }
 
-    func setFogTrustRoots(_ certificates: SecSSLCertificates?) {
-        trustRoots.writeSync { $0.fog = certificates }
+    /// Answers the stored form of `host`, so that a case difference or
+    /// trailing dots can't make a lookup miss the set that names that host.
+    private static func normalized(_ host: String) -> String {
+        var name = host.lowercased()
+        while name.hasSuffix(".") {
+            name = String(name.dropLast())
+        }
+        return name
     }
 
-    func setConsensusTrustRoots(_ certificates: SecSSLCertificates?) {
-        trustRoots.writeSync { $0.consensus = certificates }
+    func setFogTrustRoots(_ certificates: SecSSLCertificates?, hosts: [String]) {
+        let names = Set(hosts.map(CertificatePinningDelegate.normalized))
+        trustRoots.writeSync {
+            $0.fog = PinnedRoots(certificates: certificates, hosts: names)
+        }
+    }
+
+    func setConsensusTrustRoots(_ certificates: SecSSLCertificates?, hosts: [String]) {
+        let names = Set(hosts.map(CertificatePinningDelegate.normalized))
+        trustRoots.writeSync {
+            $0.consensus = PinnedRoots(certificates: certificates, hosts: names)
+        }
     }
 
     func handle(
@@ -139,7 +163,7 @@ final class CertificatePinningDelegate: NSObject {
             return
         }
 
-        let pinnedKeys = self.pinnedKeys
+        let pinnedKeys = self.pinnedKeys(for: challenge.protectionSpace.host)
         guard DefaultHttpRequester.certPinningEnabled && pinnedKeys.isNotEmpty else {
             completionHandler(.performDefaultHandling, nil)
             return

--- a/Sources/HTTPS/HttpProtocolConnectionFactory.swift
+++ b/Sources/HTTPS/HttpProtocolConnectionFactory.swift
@@ -7,8 +7,8 @@ import Foundation
 class HttpProtocolConnectionFactory: ProtocolConnectionFactory {
     let requester: HttpRequester
 
-    init(httpRequester: HttpRequester?) {
-        self.requester = httpRequester ?? DefaultHttpRequester()
+    init(httpRequester: HttpRequester) {
+        self.requester = httpRequester
     }
 
     func makeConsensusService(

--- a/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
+++ b/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
@@ -125,8 +125,8 @@ extension SecCertificateTests.Fixtures {
     struct ForgedCommonName {
         static let commonName = "evil.example.com\nforged-log-line"
 
-        /// This certificate is valid from 2026-09-06 to 2036-09-03, so a pinned
-        /// date keeps the refusal a matter of the anchor at every future run.
+        /// 2030-01-01, inside this certificate's window of 2026-09-06 to
+        /// 2036-09-03, so the refusal stays a matter of the anchor at every run.
         static let verifyDate = Date(timeIntervalSince1970: 1_893_456_000)
 
         let secTrust: SecTrust

--- a/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
+++ b/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
@@ -117,6 +117,41 @@ extension SecCertificateTests.Fixtures {
             )
         }
     }
+
+    /// A self-signed certificate whose common name holds a literal newline.
+    ///
+    /// The system quotes that name in its own error description, so this is the
+    /// text a refusal must keep out of the client log.
+    struct ForgedCommonName {
+        static let commonName = "evil.example.com\nforged-log-line"
+
+        let secTrust: SecTrust
+
+        init() throws {
+            let leaf = try SecCertificateTests.createCertificate(Self.certificateBase64)
+            let foreignAnchor = try SecCertificateTests.createCertificate(
+                SecCertificateTests.Fixtures.AlphaNet.wrongIntermediateCertificateBase64
+            )
+            self.secTrust = try SecCertificateTests.createSecTrust(
+                [leaf],
+                verifyDate: nil,
+                anchorOverride: foreignAnchor
+            )
+        }
+    }
+}
+
+extension SecCertificateTests.Fixtures.ForgedCommonName {
+    static let certificateBase64 = """
+        MIIBqzCCAVGgAwIBAgIUFZKsAIXLRa5nN4fRbRiMG0JrWwwwCgYIKoZIzj0EAwIwKzEpMCcGA1UEAwwg\
+        ZXZpbC5leGFtcGxlLmNvbQpmb3JnZWQtbG9nLWxpbmUwHhcNMjYwOTA2MTY1MjUyWhcNMzYwOTAzMTY1\
+        MjUyWjArMSkwJwYDVQQDDCBldmlsLmV4YW1wbGUuY29tCmZvcmdlZC1sb2ctbGluZTBZMBMGByqGSM49\
+        AgEGCCqGSM49AwEHA0IABIgX6AXI58Ol3o9faHwiekhrlToaNGQ+sTLwCnLiBmLhTJshSWObZthAO5H6\
+        MFctWjMfH5NMGIIwFTTjn4eay46jUzBRMB0GA1UdDgQWBBTq5kNFPSIxzvXpZM01uXHi6ShbeDAfBgNV\
+        HSMEGDAWgBTq5kNFPSIxzvXpZM01uXHi6ShbeDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gA\
+        MEUCIQD71wlZjLj8rfl2Cg8ZQb8LIfgz+f0PP+m0H47CGnznQwIgA04CDdEnqCm/gjEaSfDe0I4naW27\
+        fkCFXMiTqVtVYEs=
+        """
 }
 
 extension SecCertificateTests.Fixtures.TestNet {

--- a/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
+++ b/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
@@ -125,6 +125,11 @@ extension SecCertificateTests.Fixtures {
     struct ForgedCommonName {
         static let commonName = "evil.example.com\nforged-log-line"
 
+        /// This certificate is valid from 2026-09-06 to 2036-09-03, so it holds
+        /// its own date. A pinned date keeps the refusal a matter of the anchor
+        /// at every future run.
+        static let verifyDate = Date(timeIntervalSince1970: 1_893_456_000)
+
         let secTrust: SecTrust
 
         init() throws {
@@ -134,7 +139,7 @@ extension SecCertificateTests.Fixtures {
             )
             self.secTrust = try SecCertificateTests.createSecTrust(
                 [leaf],
-                verifyDate: nil,
+                verifyDate: Self.verifyDate,
                 anchorOverride: foreignAnchor
             )
         }

--- a/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
+++ b/Tests/Common/Fixtures/Network/SecCertificateTests+Fixtures.swift
@@ -125,9 +125,8 @@ extension SecCertificateTests.Fixtures {
     struct ForgedCommonName {
         static let commonName = "evil.example.com\nforged-log-line"
 
-        /// This certificate is valid from 2026-09-06 to 2036-09-03, so it holds
-        /// its own date. A pinned date keeps the refusal a matter of the anchor
-        /// at every future run.
+        /// This certificate is valid from 2026-09-06 to 2036-09-03, so a pinned
+        /// date keeps the refusal a matter of the anchor at every future run.
         static let verifyDate = Date(timeIntervalSince1970: 1_893_456_000)
 
         let secTrust: SecTrust

--- a/Tests/Common/Fixtures/UnitTestFixtures.swift
+++ b/Tests/Common/Fixtures/UnitTestFixtures.swift
@@ -52,7 +52,7 @@ enum UnitTestFixtures {
 
         fogUrlLoadBalancer.rotationEnabled = false
         let fogView = FogViewConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -73,7 +73,7 @@ enum UnitTestFixtures {
 
         fogUrlLoadBalancer.rotationEnabled = false
         let fogUntrustedTxOut = FogUntrustedTxOutConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -94,7 +94,7 @@ enum UnitTestFixtures {
 
         fogUrlLoadBalancer.rotationEnabled = false
         let fogMerkleProof = FogMerkleProofConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -115,7 +115,7 @@ enum UnitTestFixtures {
 
         fogUrlLoadBalancer.rotationEnabled = false
         let fogKeyImage = FogKeyImageConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -136,7 +136,7 @@ enum UnitTestFixtures {
 
         fogUrlLoadBalancer.rotationEnabled = false
         let fogBlock = FogBlockConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -157,7 +157,7 @@ enum UnitTestFixtures {
 
         consensusUrlLoadBalancer.rotationEnabled = false
         let blockchain = BlockchainConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -178,7 +178,7 @@ enum UnitTestFixtures {
 
         consensusUrlLoadBalancer.rotationEnabled = false
         let consensus = ConsensusConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(httpRequester: httpRequester),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)

--- a/Tests/Common/Integration/IntegrationTestFixtures+UrlLoadBalancing.swift
+++ b/Tests/Common/Integration/IntegrationTestFixtures+UrlLoadBalancing.swift
@@ -18,13 +18,14 @@ extension IntegrationTestFixtures {
         let consensusUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration()
             .validUrlsConsensusUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let fogView = FogViewConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -42,13 +43,14 @@ extension IntegrationTestFixtures {
         let consensusUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration()
             .validUrlsConsensusUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let fogUntrustedTxOut = FogUntrustedTxOutConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -66,13 +68,14 @@ extension IntegrationTestFixtures {
         let consensusUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration()
             .validUrlsConsensusUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let fogMerkleProof = FogMerkleProofConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -90,13 +93,14 @@ extension IntegrationTestFixtures {
         let consensusUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration()
             .validUrlsConsensusUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let fogKeyImage = FogKeyImageConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -114,13 +118,14 @@ extension IntegrationTestFixtures {
         let consensusUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration()
             .validUrlsConsensusUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let fogBlock = FogBlockConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -137,13 +142,14 @@ extension IntegrationTestFixtures {
 
         let fogUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration().validUrlsFogUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let blockchain = BlockchainConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)
@@ -160,13 +166,14 @@ extension IntegrationTestFixtures {
 
         let fogUrlLoadBalancer = try UrlLoadBalancerFixturesIntegration().validUrlsFogUrlBalancer
 
-        let networkConfig = try NetworkConfigFixtures.create(
+        var networkConfig = try NetworkConfigFixtures.create(
             transportProtocol: transportProtocol,
             consensusUrlLoadBalancer: consensusUrlLoadBalancer,
             fogUrlLoadBalancer: fogUrlLoadBalancer)
 
         let consensus = ConsensusConnection(
-            httpFactory: HttpProtocolConnectionFactory(httpRequester: networkConfig.httpRequester),
+            httpFactory: HttpProtocolConnectionFactory(
+                httpRequester: networkConfig.filledHttpRequester()),
             grpcFactory: GrpcProtocolConnectionFactory(),
             config: networkConfig,
             targetQueue: DispatchQueue.main)

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -23,9 +23,17 @@ public final class MockFailingHttpRequester: NSObject, HttpRequester {
         completion(.failure(ConnectionError.invalidServerResponse("Mock Http Request set to fail")))
     }
 
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?) {
+    @discardableResult
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
+        .success(())
     }
 
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) {
+    @discardableResult
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
+        .success(())
     }
 }

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -23,8 +23,6 @@ public final class MockFailingHttpRequester: NSObject, HttpRequester {
         completion(.failure(ConnectionError.invalidServerResponse("Mock Http Request set to fail")))
     }
 
-    // The roots are kept, so a success here names a root this mock can answer
-    // for, and a test can read which root arrived.
     public private(set) var consensusTrustRoots: SecSSLCertificates?
     public private(set) var fogTrustRoots: SecSSLCertificates?
 

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -24,21 +24,25 @@ public final class MockFailingHttpRequester: NSObject, HttpRequester {
     }
 
     public private(set) var consensusTrustRoots: SecSSLCertificates?
+    public private(set) var consensusHosts: [String] = []
     public private(set) var fogTrustRoots: SecSSLCertificates?
+    public private(set) var fogHosts: [String] = []
 
     @discardableResult
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
         consensusTrustRoots = trustRoots
+        consensusHosts = hosts
         return .success(())
     }
 
     @discardableResult
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
         fogTrustRoots = trustRoots
+        fogHosts = hosts
         return .success(())
     }
 }

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -23,17 +23,24 @@ public final class MockFailingHttpRequester: NSObject, HttpRequester {
         completion(.failure(ConnectionError.invalidServerResponse("Mock Http Request set to fail")))
     }
 
+    // The roots are kept, so a success here names a root this mock can answer
+    // for, and a test can read which root arrived.
+    public private(set) var consensusTrustRoots: SecSSLCertificates?
+    public private(set) var fogTrustRoots: SecSSLCertificates?
+
     @discardableResult
     public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
         -> Result<(), InvalidInputError>
     {
-        .success(())
+        consensusTrustRoots = trustRoots
+        return .success(())
     }
 
     @discardableResult
     public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
         -> Result<(), InvalidInputError>
     {
-        .success(())
+        fogTrustRoots = trustRoots
+        return .success(())
     }
 }

--- a/Tests/Common/Mocks/NullChallengeSender.swift
+++ b/Tests/Common/Mocks/NullChallengeSender.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+import Foundation
+
+// `URLAuthenticationChallenge` demands a sender.
+final class NullChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+    func cancel(_ challenge: URLAuthenticationChallenge) {}
+}

--- a/Tests/Common/Mocks/RefusingHttpRequester.swift
+++ b/Tests/Common/Mocks/RefusingHttpRequester.swift
@@ -1,30 +1,35 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-
-import Foundation
-import SwiftProtobuf
-#if canImport(LibMobileCoin)
 import LibMobileCoin
-#endif
-#if canImport(LibMobileCoinHTTP)
+#if canImport(LibMobileCoinCommon)
+import LibMobileCoinCommon
 import LibMobileCoinHTTP
 #endif
+import Foundation
+@testable import MobileCoin
 
-public protocol HttpRequester {
+// A requester that doesn't keep trust roots and says so.
+final class RefusingHttpRequester: HttpRequester {
     func request(
         url: URL,
         method: HTTPMethod,
         headers: [String: String]?,
         body: Data?,
         completion: @escaping (Result<HTTPResponse, Error>) -> Void
-    )
+    ) {
+        completion(.failure(ConnectionError.invalidServerResponse("unused")))
+    }
 
-    // `hosts` names the endpoints this set of roots pins.
-    @discardableResult
     func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
-    @discardableResult
+    {
+        .failure(InvalidInputError("This requester keeps no fog trust roots"))
+    }
+
     func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
+    {
+        .failure(InvalidInputError("This requester keeps no consensus trust roots"))
+    }
 }

--- a/Tests/Common/Mocks/TrustingProtectionSpace.swift
+++ b/Tests/Common/Mocks/TrustingProtectionSpace.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+import Foundation
+import Security
+
+// `URLProtectionSpace` builds its own `serverTrust` from a live TLS handshake,
+// so a fixture chain reaches a delegate only through an override.
+final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Sendable {
+    private let trust: SecTrust
+
+    init(trust: SecTrust, host: String) {
+        self.trust = trust
+        super.init(
+            host: host,
+            port: 443,
+            protocol: NSURLProtectionSpaceHTTPS,
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodServerTrust)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override var serverTrust: SecTrust? { trust }
+}

--- a/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
@@ -51,6 +51,8 @@ class FogBlockConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func getBlockZero(transportProtocol: TransportProtocol) throws {
+        // The body needs block 0 to carry outputs and a `globalTxoCount`
+        // equal to its own output count.
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")
@@ -133,6 +135,8 @@ class FogBlockConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func doSGetBlocks(transportProtocol: TransportProtocol) throws {
+        // The loop below sends many requests to the live shared fog ledger, so
+        // running the loop will put load on that ledger.
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -143,8 +143,8 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(message, SecTrust.pinnedKeyMatched + "[\(index)]")
     }
 
-    // Distinct fog and consensus roots are what make a swap of the two setters
-    // visible, because each one lands in a field of its own on the mock.
+    // Roots the config stored with no requester present reach the first
+    // requester it is given, each in the field its own setter names.
     func testTrustRootsSetBeforeTheRequesterReachIt() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
@@ -163,7 +163,7 @@ class CertificateTests: XCTestCase {
     }
 
     // The config's setters and the requester's share their names, so distinct
-    // roots pushed through a live requester are what will catch a swapped pair.
+    // roots are what will catch a swapped pair once a requester is present.
     func testEachConfigSetterPushesToItsOwnRequesterField() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
@@ -180,26 +180,53 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
     }
 
-    // A config with no requester of its own gets a DefaultHttpRequester, which
-    // then holds the roots the config was given before it.
+    // `pinnedKeys` reads fog before consensus, so an ordered comparison against
+    // distinct roots will show that each field arrives with its own keys.
     func testAConfigWithNoRequesterFillsInOneThatTakesItsRoots() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
         config.httpRequester = nil
         XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+        XCTAssertSuccess(config.setFogTrustRoots([fixture.wrongTrustRootBytes]))
 
-        config.fillHttpRequester()
+        let requester = try XCTUnwrap(config.filledHttpRequester() as? DefaultHttpRequester)
 
-        let requester = try XCTUnwrap(config.httpRequester as? DefaultHttpRequester)
         let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
         let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+        XCTAssertNotEqual(fog.publicKeys, consensus.publicKeys)
         XCTAssertEqual(
             try pinningDelegate(of: requester).pinnedKeys,
             fog.publicKeys + consensus.publicKeys)
     }
 
-    // A refused set leaves the config holding the roots the call before it
-    // stored, so a failure won't replace them with roots nothing accepted.
+    // A consumer's own requester decides how the connections handle TLS, so the
+    // fill answers with that one and keeps it in the config.
+    func testAConfigKeepsTheRequesterItAlreadyHolds() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let requester = MockFailingHttpRequester()
+        config.httpRequester = requester
+
+        XCTAssertTrue((config.filledHttpRequester() as? MockFailingHttpRequester) === requester)
+        XCTAssertTrue((config.httpRequester as? MockFailingHttpRequester) === requester)
+    }
+
+    // Roots the config doesn't hold leave the requester's own in place, so a
+    // requester that arrives with keys keeps pinning against them.
+    func testAConfigWithNoRootsLeavesTheRequestersOwnInPlace() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        config.consensusTrustRoots[.http] = nil
+        config.fogTrustRoots[.http] = nil
+        let requester = DefaultHttpRequester()
+        let roots = try alphaNetCertificates(.valid)
+        requester.setFogTrustRoots(roots)
+
+        config.httpRequester = requester
+
+        XCTAssertEqual(try pinningDelegate(of: requester).pinnedKeys, roots.publicKeys)
+    }
+
+    // A refused set keeps the pinned http roots the call before it stored, so a
+    // failure won't replace them with roots nothing accepted.
     func testRefusedTrustRootsLeaveThePinnedRootsInPlace() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -10,6 +10,14 @@ import LibMobileCoinHTTP
 @testable import MobileCoin
 import XCTest
 
+// The hosts a test pins against. `pinned` covers a case where one host is
+// enough, and `fog` and `consensus` separate the two setters' roots.
+private enum TestHost {
+    static let pinned = "example.com"
+    static let fog = "fog.example.com"
+    static let consensus = "consensus.example.com"
+}
+
 class CertificateTests: XCTestCase {
 
     func testValidTrustRoots() throws {
@@ -160,6 +168,8 @@ class CertificateTests: XCTestCase {
         XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
         XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
         XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusHosts, config.consensusUrls.map(\.host))
+        XCTAssertEqual(requester.fogHosts, config.fogUrls.map(\.host))
     }
 
     // The config's setters and the requester's share their names, so distinct
@@ -178,10 +188,12 @@ class CertificateTests: XCTestCase {
         XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
         XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
         XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusHosts, config.consensusUrls.map(\.host))
+        XCTAssertEqual(requester.fogHosts, config.fogUrls.map(\.host))
     }
 
-    // `pinnedKeys` reads fog before consensus, so an ordered comparison against
-    // distinct roots will show that each field arrives with its own keys.
+    // The config's fog and consensus URLs name different hosts, so each host
+    // will answer with the keys its own setter pushed.
     func testAConfigWithNoRequesterFillsInOneThatTakesItsRoots() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
@@ -194,9 +206,12 @@ class CertificateTests: XCTestCase {
         let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
         let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
         XCTAssertNotEqual(fog.publicKeys, consensus.publicKeys)
-        XCTAssertEqual(
-            try pinningDelegate(of: requester).pinnedKeys,
-            fog.publicKeys + consensus.publicKeys)
+        let delegate = try pinningDelegate(of: requester)
+        let fogUrlHost = try XCTUnwrap(config.fogUrls.first).host
+        let consensusUrlHost = try XCTUnwrap(config.consensusUrls.first).host
+        XCTAssertNotEqual(fogUrlHost, consensusUrlHost)
+        XCTAssertEqual(delegate.pinnedKeys(for: fogUrlHost), fog.publicKeys)
+        XCTAssertEqual(delegate.pinnedKeys(for: consensusUrlHost), consensus.publicKeys)
     }
 
     // A consumer's own requester decides how the connections handle TLS, so the
@@ -218,11 +233,13 @@ class CertificateTests: XCTestCase {
         config.fogTrustRoots[.http] = nil
         let requester = DefaultHttpRequester()
         let roots = try alphaNetCertificates(.valid)
-        requester.setFogTrustRoots(roots)
+        requester.setFogTrustRoots(roots, hosts: [TestHost.fog])
 
         config.httpRequester = requester
 
-        XCTAssertEqual(try pinningDelegate(of: requester).pinnedKeys, roots.publicKeys)
+        XCTAssertEqual(
+            try pinningDelegate(of: requester).pinnedKeys(for: TestHost.fog),
+            roots.publicKeys)
     }
 
     // A refused set keeps the pinned http roots the call before it stored, so a
@@ -257,13 +274,12 @@ class CertificateTests: XCTestCase {
             pinned.publicKeys)
     }
 
-    // The four below drive both delegate shims and each covers one of `handle`'s
-    // outcomes.
+    // The cases below drive both delegate shims across `handle`'s outcomes.
 
     func testServerTrustMatchingAPinnedKeyIsAccepted() throws {
         let fixture = try SecCertificateTests.Fixtures.AlphaNet()
         let requester = DefaultHttpRequester()
-        requester.setFogTrustRoots(try alphaNetCertificates(.valid))
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.pinned])
 
         let result = try answer(of: requester, against: fixture.secTrust)
 
@@ -271,16 +287,42 @@ class CertificateTests: XCTestCase {
         XCTAssertNotNil(result.credential)
     }
 
-    // The consensus root carries this one, so both roots take part in a
-    // challenge.
+    // The consensus roots pin this host and don't carry the fixture chain, so
+    // the challenge will be refused.
     func testServerTrustMatchingNoPinnedKeyIsCancelled() throws {
         let fixture = try SecCertificateTests.Fixtures.AlphaNet()
         let requester = DefaultHttpRequester()
-        requester.setConsensusTrustRoots(try alphaNetCertificates(.wrong))
+        requester.setConsensusTrustRoots(try alphaNetCertificates(.wrong), hosts: [TestHost.pinned])
 
         XCTAssertEqual(
             try answer(of: requester, against: fixture.secTrust).disposition,
             .cancelAuthenticationChallenge)
+    }
+
+    // The fog roots carry this fixture chain and the consensus roots don't, so
+    // the consensus host will be refused while the fog host is accepted.
+    func testTheRootsOfOneHostDoNotPinAnother() throws {
+        let fixture = try SecCertificateTests.Fixtures.AlphaNet()
+        let requester = DefaultHttpRequester()
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.fog])
+        requester.setConsensusTrustRoots(
+            try alphaNetCertificates(.wrong), hosts: [TestHost.consensus])
+
+        let refused = try answer(
+            of: requester, against: fixture.secTrust, host: TestHost.consensus)
+        XCTAssertEqual(refused.disposition, .cancelAuthenticationChallenge)
+        let accepted = try answer(of: requester, against: fixture.secTrust, host: TestHost.fog)
+        XCTAssertEqual(accepted.disposition, .useCredential)
+    }
+
+    // Neither setter names the challenged host, so every pinned root takes part
+    // in its challenge.
+    func testAHostNoSetterNamedIsJudgedAgainstEveryPinnedRoot() throws {
+        let fixture = try SecCertificateTests.Fixtures.AlphaNet()
+        let requester = DefaultHttpRequester()
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.fog])
+        let judged = try answer(of: requester, against: fixture.secTrust, host: TestHost.consensus)
+        XCTAssertEqual(judged.disposition, .useCredential)
     }
 
     // With no roots set there is nothing to pin against, so the challenge goes
@@ -319,30 +361,39 @@ class CertificateTests: XCTestCase {
         XCTAssertNil(delegate)
     }
 
-    // `pinnedKeys` reads fog before consensus, so distinct certificates and an
-    // ordered comparison are what make a swap of the two setters visible.
-    func testEachTrustRootSetterWritesItsOwnField() throws {
+    // Distinct fog and consensus roots let each lookup below name the set or
+    // sets that answered it.
+    func testTheSetThatNamesAHostAnswersForIt() throws {
         let requester = DefaultHttpRequester()
         let delegate = try pinningDelegate(of: requester)
         let fog = try alphaNetCertificates(.valid)
         let consensus = try alphaNetCertificates(.wrong)
+        XCTAssertNotEqual(fog.publicKeys, consensus.publicKeys)
 
-        XCTAssertTrue(delegate.pinnedKeys.isEmpty)
+        requester.setFogTrustRoots(fog, hosts: [TestHost.fog.uppercased()])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.consensus), fog.publicKeys)
 
-        requester.setFogTrustRoots(fog)
-        XCTAssertEqual(delegate.pinnedKeys, fog.publicKeys)
+        requester.setConsensusTrustRoots(consensus, hosts: [TestHost.consensus + "."])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), fog.publicKeys)
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.consensus + ".."), consensus.publicKeys)
 
-        requester.setConsensusTrustRoots(consensus)
-        XCTAssertEqual(delegate.pinnedKeys, fog.publicKeys + consensus.publicKeys)
+        let noKeys = try XCTUnwrap(SecSSLCertificates(trustRootBytes: []))
+        requester.setFogTrustRoots(noKeys, hosts: [TestHost.fog])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), consensus.publicKeys)
 
-        requester.setFogTrustRoots(nil)
-        XCTAssertEqual(delegate.pinnedKeys, consensus.publicKeys)
+        requester.setFogTrustRoots(nil, hosts: [])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), consensus.publicKeys)
+
+        requester.setFogTrustRoots(fog, hosts: [TestHost.consensus])
+        XCTAssertEqual(
+            delegate.pinnedKeys(for: TestHost.consensus),
+            fog.publicKeys + consensus.publicKeys)
+        XCTAssertEqual(
+            delegate.pinnedKeys(for: TestHost.pinned),
+            fog.publicKeys + consensus.publicKeys)
     }
 
-    private enum AlphaNetIntermediate {
-        case valid
-        case wrong
-    }
+    private enum AlphaNetIntermediate { case valid, wrong }
 
     private func alphaNetCertificates(
         _ intermediate: AlphaNetIntermediate
@@ -380,14 +431,15 @@ class CertificateTests: XCTestCase {
     // the calling thread, so both shims answer before this returns.
     private func answer(
         of requester: DefaultHttpRequester,
-        against trust: SecTrust?
+        against trust: SecTrust?,
+        host: String = TestHost.pinned
     ) throws -> (disposition: URLSession.AuthChallengeDisposition?, credential: URLCredential?) {
         let space: URLProtectionSpace
         if let trust = trust {
-            space = TrustingProtectionSpace(trust: trust)
+            space = TrustingProtectionSpace(trust: trust, host: host)
         } else {
             space = URLProtectionSpace(
-                host: "example.com",
+                host: host,
                 port: 443,
                 protocol: NSURLProtectionSpaceHTTPS,
                 realm: nil,
@@ -420,56 +472,4 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(sessionDisposition, taskDisposition)
         return (sessionDisposition, credential)
     }
-}
-
-// `URLProtectionSpace` builds its own `serverTrust` from a live TLS handshake,
-// so a fixture chain reaches the delegate only through an override.
-private final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Sendable {
-    private let trust: SecTrust
-
-    init(trust: SecTrust) {
-        self.trust = trust
-        super.init(
-            host: "example.com",
-            port: 443,
-            protocol: NSURLProtectionSpaceHTTPS,
-            realm: nil,
-            authenticationMethod: NSURLAuthenticationMethodServerTrust)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    override var serverTrust: SecTrust? { trust }
-}
-
-// A requester that keeps no trust roots and says so.
-private final class RefusingHttpRequester: HttpRequester {
-    func request(
-        url: URL,
-        method: HTTPMethod,
-        headers: [String: String]?,
-        body: Data?,
-        completion: @escaping (Result<HTTPResponse, Error>) -> Void
-    ) {
-        completion(.failure(ConnectionError.invalidServerResponse("unused")))
-    }
-
-    func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError> {
-        .failure(InvalidInputError("This requester keeps no fog trust roots"))
-    }
-
-    func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
-        -> Result<(), InvalidInputError>
-    {
-        .failure(InvalidInputError("This requester keeps no consensus trust roots"))
-    }
-}
-
-// URLAuthenticationChallenge demands a sender. Nothing under test calls back
-// into it.
-private final class NullChallengeSender: NSObject, URLAuthenticationChallengeSender {
-    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
-    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
-    func cancel(_ challenge: URLAuthenticationChallenge) {}
 }

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -143,24 +143,63 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(message, SecTrust.pinnedKeyMatched + "[\(index)]")
     }
 
-    // Roots set before the requester reach it as soon as it arrives, because the
-    // config sends what it holds to each requester it is given.
+    // Distinct fog and consensus roots are what make a swap of the two setters
+    // visible, because each one lands in a field of its own on the mock.
     func testTrustRootsSetBeforeTheRequesterReachIt() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
+        config.httpRequester = nil
         XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
-        XCTAssertSuccess(config.setFogTrustRoots(fixture.trustRootsBytes))
+        XCTAssertSuccess(config.setFogTrustRoots([fixture.wrongTrustRootBytes]))
 
         let requester = MockFailingHttpRequester()
         config.httpRequester = requester
 
-        let stored = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
-        XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, stored.publicKeys)
-        XCTAssertEqual(requester.fogTrustRoots?.publicKeys, stored.publicKeys)
+        let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+        let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
+        XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
+        XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
     }
 
-    // A requester that refuses the roots leaves the config holding the roots it
-    // had, so a caller reading the failure reads the roots that are pinned.
+    // The config's setters and the requester's share their names, so distinct
+    // roots pushed through a live requester are what will catch a swapped pair.
+    func testEachConfigSetterPushesToItsOwnRequesterField() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let fixture = try NetworkConfig.Fixtures.TrustRoots()
+        let requester = MockFailingHttpRequester()
+        config.httpRequester = requester
+
+        XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+        XCTAssertSuccess(config.setFogTrustRoots([fixture.wrongTrustRootBytes]))
+
+        let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+        let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
+        XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
+        XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
+    }
+
+    // A config with no requester of its own gets a DefaultHttpRequester, which
+    // then holds the roots the config was given before it.
+    func testAConfigWithNoRequesterFillsInOneThatTakesItsRoots() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let fixture = try NetworkConfig.Fixtures.TrustRoots()
+        config.httpRequester = nil
+        XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+
+        config.fillHttpRequester()
+
+        let requester = try XCTUnwrap(config.httpRequester as? DefaultHttpRequester)
+        let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
+        let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+        XCTAssertEqual(
+            try pinningDelegate(of: requester).pinnedKeys,
+            fog.publicKeys + consensus.publicKeys)
+    }
+
+    // A refused set leaves the config holding the roots the call before it
+    // stored, so a failure won't replace them with roots nothing accepted.
     func testRefusedTrustRootsLeaveThePinnedRootsInPlace() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -2,6 +2,11 @@
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
 
+import LibMobileCoin
+#if canImport(LibMobileCoinCommon)
+import LibMobileCoinCommon
+import LibMobileCoinHTTP
+#endif
 @testable import MobileCoin
 import XCTest
 
@@ -48,9 +53,9 @@ class CertificateTests: XCTestCase {
             fixture.certificateChain,
             verifyDate: nil)
 
-        atTheCurrentDate.validateAgainst(pinnedKeys: pinnedKeys) { result in
-            XCTAssertFailure(result)
-        }
+        XCTAssertTrue(
+            try refusal(of: atTheCurrentDate, against: pinnedKeys)
+                .hasPrefix(SecTrust.systemEvaluationFailure))
     }
 
     // The pinned key is an intermediate CA key, so it matches every certificate
@@ -71,9 +76,9 @@ class CertificateTests: XCTestCase {
             fixture.certificateChain,
             host: "fog.prod.mobilecoin.com")
 
-        forAnotherHost.validateAgainst(pinnedKeys: pinnedKeys) { result in
-            XCTAssertFailure(result)
-        }
+        XCTAssertTrue(
+            try refusal(of: forAnotherHost, against: pinnedKeys)
+                .hasPrefix(SecTrust.systemEvaluationFailure))
     }
 
     // Anchoring on another chain's top certificate leaves this chain with no
@@ -87,9 +92,9 @@ class CertificateTests: XCTestCase {
             alphaNet.certificateChain,
             anchorOverride: try XCTUnwrap(testNet.certificateChain.last))
 
-        onAForeignAnchor.validateAgainst(pinnedKeys: pinnedKeys) { result in
-            XCTAssertFailure(result)
-        }
+        XCTAssertTrue(
+            try refusal(of: onAForeignAnchor, against: pinnedKeys)
+                .hasPrefix(SecTrust.systemEvaluationFailure))
     }
 
     func testInvalidIntermediateAgainstCertificateChain() throws {
@@ -97,9 +102,71 @@ class CertificateTests: XCTestCase {
 
         let pinnedKeys = [try fixture.wrongIntermediate.asPublicKey().get()]
 
+        XCTAssertEqual(
+            try refusal(of: fixture.secTrust, against: pinnedKeys),
+            SecTrust.noPinnedKeyMatched)
+    }
+
+    // The system quotes the server's own common name in its error description,
+    // so a refusal that repeats it lets the server write the client's log.
+    func testARefusalCarriesTheCodeAndNotTheServersCommonName() throws {
+        let fixture = try SecCertificateTests.Fixtures.ForgedCommonName()
+
+        var systemError: CFError?
+        XCTAssertFalse(SecTrustEvaluateWithError(fixture.secTrust, &systemError))
+        let systemDescription = CFErrorCopyDescription(try XCTUnwrap(systemError)) as String
+        XCTAssertTrue(
+            systemDescription.contains(SecCertificateTests.Fixtures.ForgedCommonName.commonName))
+
+        let reason = try refusal(of: fixture.secTrust, against: [])
+
+        XCTAssertEqual(
+            reason,
+            SecTrust.systemEvaluationFailure + "\(CFErrorGetCode(try XCTUnwrap(systemError)))")
+        XCTAssertEqual(reason.components(separatedBy: "\n").count, 1)
+    }
+
+    // Exact equality is what proves the message carries no key material, rather
+    // than a search for one encoding of the key.
+    func testAMatchIsReportedByIndexAndNotByKey() throws {
+        let fixture = try SecCertificateTests.Fixtures.AlphaNet()
+        let pinnedKeys = [try fixture.validIntermediate.asPublicKey().get()]
+
+        var message: String?
         fixture.secTrust.validateAgainst(pinnedKeys: pinnedKeys) { result in
-            XCTAssertFailure(result)
+            message = try? result.get()
         }
+
+        let index = try XCTUnwrap(
+            fixture.secTrust.certificateTrustChain.firstIndex {
+                $0.data == fixture.validIntermediate.data
+            })
+        XCTAssertEqual(message, SecTrust.pinnedKeyMatched + "[\(index)]")
+    }
+
+    // A requester that stores no trust roots takes the protocol's own setters,
+    // and a caller that reads success there believes roots are pinned.
+    func testARequesterWithoutTrustRootStorageReportsAFailure() {
+        let requester = RequestOnlyHttpRequester()
+
+        XCTAssertFailure(requester.setFogTrustRoots(nil))
+        XCTAssertFailure(requester.setConsensusTrustRoots(nil))
+    }
+
+    // Roots that fail to parse leave the pinned roots in place, because a config
+    // with no roots falls through to the system's own handling.
+    func testAFailedParseKeepsTheTrustRootsAlreadySet() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let fixture = try NetworkConfig.Fixtures.TrustRoots()
+
+        XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+        let pinned = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+
+        XCTAssertFailure(config.setConsensusTrustRoots([fixture.invalidTrustRootBytes]))
+
+        XCTAssertEqual(
+            (config.consensusTrustRoots[.http] as? SecSSLCertificates)?.publicKeys,
+            pinned.publicKeys)
     }
 
     // The four below drive both delegate shims and each covers one of `handle`'s
@@ -203,6 +270,18 @@ class CertificateTests: XCTestCase {
         return try XCTUnwrap(try SecSSLCertificates(trustRootBytes: [bytes]))
     }
 
+    // `validateAgainst` calls back on the calling thread, so the reason is set
+    // before this returns.
+    private func refusal(of trust: SecTrust, against pinnedKeys: [SecKey]) throws -> String {
+        var reason: String?
+        trust.validateAgainst(pinnedKeys: pinnedKeys) { result in
+            if case .failure(let error) = result {
+                reason = error.reason
+            }
+        }
+        return try XCTUnwrap(reason)
+    }
+
     private func pinningDelegate(
         of requester: DefaultHttpRequester
     ) throws -> CertificatePinningDelegate {
@@ -274,6 +353,20 @@ private final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Send
     required init?(coder: NSCoder) { fatalError("unused") }
 
     override var serverTrust: SecTrust? { trust }
+}
+
+// A requester that implements only `request` takes the protocol's default
+// trust-root setters.
+private struct RequestOnlyHttpRequester: HttpRequester {
+    func request(
+        url: URL,
+        method: HTTPMethod,
+        headers: [String: String]?,
+        body: Data?,
+        completion: @escaping (Result<HTTPResponse, Error>) -> Void
+    ) {
+        completion(.failure(ConnectionError.invalidServerResponse("unused")))
+    }
 }
 
 // URLAuthenticationChallenge demands a sender. Nothing under test calls back

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -126,8 +126,7 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(reason.components(separatedBy: "\n").count, 1)
     }
 
-    // Exact equality is what proves the message carries no key material, rather
-    // than a search for one encoding of the key.
+    // Exact equality proves the message carries the index alone.
     func testAMatchIsReportedByIndexAndNotByKey() throws {
         let fixture = try SecCertificateTests.Fixtures.AlphaNet()
         let pinnedKeys = [try fixture.validIntermediate.asPublicKey().get()]
@@ -144,13 +143,36 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(message, SecTrust.pinnedKeyMatched + "[\(index)]")
     }
 
-    // A requester that stores no trust roots takes the protocol's own setters,
-    // and a caller that reads success there believes roots are pinned.
-    func testARequesterWithoutTrustRootStorageReportsAFailure() {
-        let requester = RequestOnlyHttpRequester()
+    // Roots set before the requester reach it as soon as it arrives, because the
+    // config sends what it holds to each requester it is given.
+    func testTrustRootsSetBeforeTheRequesterReachIt() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let fixture = try NetworkConfig.Fixtures.TrustRoots()
+        XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+        XCTAssertSuccess(config.setFogTrustRoots(fixture.trustRootsBytes))
 
-        XCTAssertFailure(requester.setFogTrustRoots(nil))
-        XCTAssertFailure(requester.setConsensusTrustRoots(nil))
+        let requester = MockFailingHttpRequester()
+        config.httpRequester = requester
+
+        let stored = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+        XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, stored.publicKeys)
+        XCTAssertEqual(requester.fogTrustRoots?.publicKeys, stored.publicKeys)
+    }
+
+    // A requester that refuses the roots leaves the config holding the roots it
+    // had, so a caller reading the failure reads the roots that are pinned.
+    func testRefusedTrustRootsLeaveThePinnedRootsInPlace() throws {
+        var config = try NetworkConfigFixtures.create(using: .http)
+        let fixture = try NetworkConfig.Fixtures.TrustRoots()
+        XCTAssertSuccess(config.setConsensusTrustRoots(fixture.trustRootsBytes))
+        let pinned = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
+
+        config.httpRequester = RefusingHttpRequester()
+
+        XCTAssertFailure(config.setConsensusTrustRoots([fixture.wrongTrustRootBytes]))
+        XCTAssertEqual(
+            (config.consensusTrustRoots[.http] as? SecSSLCertificates)?.publicKeys,
+            pinned.publicKeys)
     }
 
     // Roots that fail to parse leave the pinned roots in place, because a config
@@ -355,9 +377,8 @@ private final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Send
     override var serverTrust: SecTrust? { trust }
 }
 
-// A requester that implements only `request` takes the protocol's default
-// trust-root setters.
-private struct RequestOnlyHttpRequester: HttpRequester {
+// A requester that keeps no trust roots and says so.
+private final class RefusingHttpRequester: HttpRequester {
     func request(
         url: URL,
         method: HTTPMethod,
@@ -366,6 +387,16 @@ private struct RequestOnlyHttpRequester: HttpRequester {
         completion: @escaping (Result<HTTPResponse, Error>) -> Void
     ) {
         completion(.failure(ConnectionError.invalidServerResponse("unused")))
+    }
+
+    func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError> {
+        .failure(InvalidInputError("This requester keeps no fog trust roots"))
+    }
+
+    func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+        -> Result<(), InvalidInputError>
+    {
+        .failure(InvalidInputError("This requester keeps no consensus trust roots"))
     }
 }
 


### PR DESCRIPTION
[Link to Task](https://mobilecoin-eng.atlassian.net/browse/SENTZ-5655)

`HttpProtocolConnectionFactory` built its own `DefaultHttpRequester` whenever the config held none, so a client carrying trust roots could reach the network through a requester that pinned nothing. The factory now takes the requester it uses, and `NetworkConfig.filledHttpRequester()` is the one place that supplies it.

- `MobileCoinClient` calls `filledHttpRequester()` and hands the result to the factory. Dropping that call is a compile error, because the factory parameter is non-optional. A hand-written `DefaultHttpRequester` at that call site would still compile, so the guarantee covers the deletion alone.
- `NetworkConfig` pushes its stored roots to the requester from the `httpRequester` `didSet`, so roots set before a requester arrives still reach it. Roots the config doesn't hold leave the requester's own in place.
- A refused `setFogTrustRoots` or `setConsensusTrustRoots` writes an error to the log and keeps the http roots already pinned. A property setter answers with nothing, so the log is the only channel a `didSet` has.
- The trust-creation failure reports the status code it got, and the certificate bytes stay out of the message.
- Fourteen test call sites pass the requester the config holds. Six unit tests cover the fill, the setter pairing, and the refusal.
