### PR TITLE
security(SENTZ-5682): Pin each host against that host's own trust roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumer that supplies its own `HttpRequester` replaces
   `DefaultHttpRequester` outright, so its traffic never reaches this code.
 - `HttpRequester` requires both trust-root setters and answers each with a
-  `Result`. The protocol carries no default, so a requester that stores no
-  roots fails to compile. This is a breaking change.
+  `Result`. The protocol doesn't carry a default, so a conformer must
+  implement both setters. This is a breaking change.
+- Both `HttpRequester` trust-root setters take `hosts: [String]`, naming the
+  endpoints that set of roots pins. This is a breaking change for a caller of
+  either setter and for a conformer outside this package.
+  `DefaultHttpRequester` judges a challenged host against the roots of every
+  set that names it and carries keys. A consensus host will be judged against
+  the pinned consensus roots alone when the consensus set is the only such set
+  for that host. Both setters store a host in the form a lookup uses, which
+  ignores case and trailing dots.
+- `DefaultHttpRequester` judges a host that no such set names against every
+  root it holds, which is the fallback and is what it did for every host
+  before. A lookup keeps a naming set only while it carries keys, so it takes
+  that fallback for a host that keyless sets alone name. A consumer that names
+  the hosts of one setter alone leaves the other setter's hosts there too.
 - `SecTrust.publicKeyTrustChain` returns a `Result` and carries the error of
   the certificate it could not read. `asPublicKeyTrustChain` is gone.
 - `SecTrust.certificateTrustChain` reads the chain with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ignores case and trailing dots.
 - `DefaultHttpRequester` judges a host that no such set names against every
   root it holds, which is the fallback and is what it did for every host
-  before. A lookup keeps a naming set only while it carries keys, so it takes
-  that fallback for a host that keyless sets alone name. A consumer that names
-  the hosts of one setter alone leaves the other setter's hosts there too.
+  before. A lookup keeps a naming set only while it carries keys, so the
+  lookup takes that fallback for a host that keyless sets alone name. A
+  consumer that names the hosts of one setter alone leaves the other setter's
+  hosts there too.
 - `SecTrust.publicKeyTrustChain` returns a `Result` and carries the error of
   the certificate it could not read. `asPublicKeyTrustChain` is gone.
 - `SecTrust.certificateTrustChain` reads the chain with

--- a/Sources/Common/Network/NetworkConfig.swift
+++ b/Sources/Common/Network/NetworkConfig.swift
@@ -68,11 +68,13 @@ struct NetworkConfig {
     private func pushStoredTrustRoots() {
         guard let requester = httpRequester else { return }
         if let fog = fogTrustRoots[.http] as? SecSSLCertificates,
-           case .failure(let error) = requester.setFogTrustRoots(fog) {
+           case .failure(let error) = requester.setFogTrustRoots(
+            fog, hosts: fogUrls.map(\.host)) {
             logger.error("Fog trust roots stay unpinned: \(error)", logFunction: false)
         }
         if let consensus = consensusTrustRoots[.http] as? SecSSLCertificates,
-           case .failure(let error) = requester.setConsensusTrustRoots(consensus) {
+           case .failure(let error) = requester.setConsensusTrustRoots(
+            consensus, hosts: consensusUrls.map(\.host)) {
             logger.error("Consensus trust roots stay unpinned: \(error)", logFunction: false)
         }
     }
@@ -214,16 +216,18 @@ extension NetworkConfig {
     @discardableResult mutating public func setConsensusTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
-        setTrustRoots(trustRoots, into: \.consensusTrustRoots) { requester, certificates in
-            requester.setConsensusTrustRoots(certificates)
+        let hosts = consensusUrls.map(\.host)
+        return setTrustRoots(trustRoots, into: \.consensusTrustRoots) { requester, certificates in
+            requester.setConsensusTrustRoots(certificates, hosts: hosts)
         }
     }
 
     @discardableResult mutating public func setFogTrustRoots(_ trustRoots: [Data])
         -> Result<(), InvalidInputError>
     {
-        setTrustRoots(trustRoots, into: \.fogTrustRoots) { requester, certificates in
-            requester.setFogTrustRoots(certificates)
+        let hosts = fogUrls.map(\.host)
+        return setTrustRoots(trustRoots, into: \.fogTrustRoots) { requester, certificates in
+            requester.setFogTrustRoots(certificates, hosts: hosts)
         }
     }
 

--- a/Sources/HTTPS/DefaultHttpRequester.swift
+++ b/Sources/HTTPS/DefaultHttpRequester.swift
@@ -75,18 +75,18 @@ public final class DefaultHttpRequester: NSObject, HttpRequester {
     }
 
     @discardableResult
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
-        pinningDelegate.setConsensusTrustRoots(trustRoots)
+        pinningDelegate.setConsensusTrustRoots(trustRoots, hosts: hosts)
         return .success(())
     }
 
     @discardableResult
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
-        pinningDelegate.setFogTrustRoots(trustRoots)
+        pinningDelegate.setFogTrustRoots(trustRoots, hosts: hosts)
         return .success(())
     }
 }
@@ -103,27 +103,51 @@ extension DefaultHttpRequester {
 // URLSession calls this back on its own queue while the SDK can be setting
 // trust roots from another thread, so both roots sit behind one lock.
 final class CertificatePinningDelegate: NSObject {
+    private struct PinnedRoots {
+        var certificates: SecSSLCertificates?
+        var hosts: Set<String> = []
+
+        var keys: [SecKey] { certificates?.publicKeys ?? [] }
+    }
+
     private struct TrustRoots {
-        var fog: SecSSLCertificates?
-        var consensus: SecSSLCertificates?
+        var fog = PinnedRoots()
+        var consensus = PinnedRoots()
     }
 
     private let trustRoots = ReadWriteDispatchLock(TrustRoots())
 
-    // Internal so a test can prove each setter writes its own field. `handle`
-    // merges the two, so nothing downstream can tell a swap apart.
-    var pinnedKeys: [SecKey] {
-        trustRoots.readSync { [$0.fog, $0.consensus] }
-            .compactMap { $0?.publicKeys }
-            .flatMap { $0 }
+    /// Answers with the keys of each set that names `host` and carries keys.
+    /// A host no such set names gets the keys of every set.
+    func pinnedKeys(for host: String) -> [SecKey] {
+        let name = CertificatePinningDelegate.normalized(host)
+        let roots = trustRoots.readSync { [$0.fog, $0.consensus] }
+        let named = roots.filter { $0.hosts.contains(name) && $0.keys.isNotEmpty }
+        return (named.isNotEmpty ? named : roots).flatMap { $0.keys }
     }
 
-    func setFogTrustRoots(_ certificates: SecSSLCertificates?) {
-        trustRoots.writeSync { $0.fog = certificates }
+    /// Answers the stored form of `host`, so that a case difference or
+    /// trailing dots can't make a lookup miss the set that names that host.
+    private static func normalized(_ host: String) -> String {
+        var name = host.lowercased()
+        while name.hasSuffix(".") {
+            name = String(name.dropLast())
+        }
+        return name
     }
 
-    func setConsensusTrustRoots(_ certificates: SecSSLCertificates?) {
-        trustRoots.writeSync { $0.consensus = certificates }
+    func setFogTrustRoots(_ certificates: SecSSLCertificates?, hosts: [String]) {
+        let names = Set(hosts.map(CertificatePinningDelegate.normalized))
+        trustRoots.writeSync {
+            $0.fog = PinnedRoots(certificates: certificates, hosts: names)
+        }
+    }
+
+    func setConsensusTrustRoots(_ certificates: SecSSLCertificates?, hosts: [String]) {
+        let names = Set(hosts.map(CertificatePinningDelegate.normalized))
+        trustRoots.writeSync {
+            $0.consensus = PinnedRoots(certificates: certificates, hosts: names)
+        }
     }
 
     func handle(
@@ -139,7 +163,7 @@ final class CertificatePinningDelegate: NSObject {
             return
         }
 
-        let pinnedKeys = self.pinnedKeys
+        let pinnedKeys = self.pinnedKeys(for: challenge.protectionSpace.host)
         guard DefaultHttpRequester.certPinningEnabled && pinnedKeys.isNotEmpty else {
             completionHandler(.performDefaultHandling, nil)
             return

--- a/Tests/Common/Mocks/MockFailingHttpRequester.swift
+++ b/Tests/Common/Mocks/MockFailingHttpRequester.swift
@@ -24,21 +24,25 @@ public final class MockFailingHttpRequester: NSObject, HttpRequester {
     }
 
     public private(set) var consensusTrustRoots: SecSSLCertificates?
+    public private(set) var consensusHosts: [String] = []
     public private(set) var fogTrustRoots: SecSSLCertificates?
+    public private(set) var fogHosts: [String] = []
 
     @discardableResult
-    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
         consensusTrustRoots = trustRoots
+        consensusHosts = hosts
         return .success(())
     }
 
     @discardableResult
-    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?)
+    public func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
     {
         fogTrustRoots = trustRoots
+        fogHosts = hosts
         return .success(())
     }
 }

--- a/Tests/Common/Mocks/NullChallengeSender.swift
+++ b/Tests/Common/Mocks/NullChallengeSender.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+import Foundation
+
+// `URLAuthenticationChallenge` demands a sender.
+final class NullChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+    func cancel(_ challenge: URLAuthenticationChallenge) {}
+}

--- a/Tests/Common/Mocks/RefusingHttpRequester.swift
+++ b/Tests/Common/Mocks/RefusingHttpRequester.swift
@@ -1,30 +1,35 @@
 //
 //  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
 //
-
-import Foundation
-import SwiftProtobuf
-#if canImport(LibMobileCoin)
 import LibMobileCoin
-#endif
-#if canImport(LibMobileCoinHTTP)
+#if canImport(LibMobileCoinCommon)
+import LibMobileCoinCommon
 import LibMobileCoinHTTP
 #endif
+import Foundation
+@testable import MobileCoin
 
-public protocol HttpRequester {
+// A requester that doesn't keep trust roots and says so.
+final class RefusingHttpRequester: HttpRequester {
     func request(
         url: URL,
         method: HTTPMethod,
         headers: [String: String]?,
         body: Data?,
         completion: @escaping (Result<HTTPResponse, Error>) -> Void
-    )
+    ) {
+        completion(.failure(ConnectionError.invalidServerResponse("unused")))
+    }
 
-    // `hosts` names the endpoints this set of roots pins.
-    @discardableResult
     func setFogTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
-    @discardableResult
+    {
+        .failure(InvalidInputError("This requester keeps no fog trust roots"))
+    }
+
     func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?, hosts: [String])
         -> Result<(), InvalidInputError>
+    {
+        .failure(InvalidInputError("This requester keeps no consensus trust roots"))
+    }
 }

--- a/Tests/Common/Mocks/TrustingProtectionSpace.swift
+++ b/Tests/Common/Mocks/TrustingProtectionSpace.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2020-2021 MobileCoin. All rights reserved.
+//
+import Foundation
+import Security
+
+// `URLProtectionSpace` builds its own `serverTrust` from a live TLS handshake,
+// so a fixture chain reaches a delegate only through an override.
+final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Sendable {
+    private let trust: SecTrust
+
+    init(trust: SecTrust, host: String) {
+        self.trust = trust
+        super.init(
+            host: host,
+            port: 443,
+            protocol: NSURLProtectionSpaceHTTPS,
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodServerTrust)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override var serverTrust: SecTrust? { trust }
+}

--- a/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
@@ -135,8 +135,8 @@ class FogBlockConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func doSGetBlocks(transportProtocol: TransportProtocol) throws {
-        // The 100 requests below are identical and reach the shared integration
-        // fog ledger, so every run of the suite would load it for each protocol.
+        // The loop below sends many requests to the live shared fog ledger, so
+        // running the loop will put load on that ledger.
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")

--- a/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
+++ b/Tests/Integration/NonTransacting/Network/Connection/FogBlockConnectionIntTests.swift
@@ -51,6 +51,8 @@ class FogBlockConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func getBlockZero(transportProtocol: TransportProtocol) throws {
+        // The body needs block 0 to carry outputs and a `globalTxoCount`
+        // equal to its own output count.
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")
@@ -133,6 +135,8 @@ class FogBlockConnectionIntTests: XCTestCase, @unchecked Sendable {
     }
 
     func doSGetBlocks(transportProtocol: TransportProtocol) throws {
+        // The 100 requests below are identical and reach the shared integration
+        // fog ledger, so every run of the suite would load it for each protocol.
         try XCTSkipIf(true)
 
         let expect = expectation(description: "Fog GetBlocks request")

--- a/Tests/Unit/Network/Certificates/CertificateTests.swift
+++ b/Tests/Unit/Network/Certificates/CertificateTests.swift
@@ -10,6 +10,14 @@ import LibMobileCoinHTTP
 @testable import MobileCoin
 import XCTest
 
+// The hosts a test pins against. `pinned` covers a case where one host is
+// enough, and `fog` and `consensus` separate the two setters' roots.
+private enum TestHost {
+    static let pinned = "example.com"
+    static let fog = "fog.example.com"
+    static let consensus = "consensus.example.com"
+}
+
 class CertificateTests: XCTestCase {
 
     func testValidTrustRoots() throws {
@@ -160,6 +168,8 @@ class CertificateTests: XCTestCase {
         XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
         XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
         XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusHosts, config.consensusUrls.map(\.host))
+        XCTAssertEqual(requester.fogHosts, config.fogUrls.map(\.host))
     }
 
     // The config's setters and the requester's share their names, so distinct
@@ -178,10 +188,12 @@ class CertificateTests: XCTestCase {
         XCTAssertNotEqual(consensus.publicKeys, fog.publicKeys)
         XCTAssertEqual(requester.consensusTrustRoots?.publicKeys, consensus.publicKeys)
         XCTAssertEqual(requester.fogTrustRoots?.publicKeys, fog.publicKeys)
+        XCTAssertEqual(requester.consensusHosts, config.consensusUrls.map(\.host))
+        XCTAssertEqual(requester.fogHosts, config.fogUrls.map(\.host))
     }
 
-    // `pinnedKeys` reads fog before consensus, so an ordered comparison against
-    // distinct roots will show that each field arrives with its own keys.
+    // The config's fog and consensus URLs name different hosts, so each host
+    // will answer with the keys its own setter pushed.
     func testAConfigWithNoRequesterFillsInOneThatTakesItsRoots() throws {
         var config = try NetworkConfigFixtures.create(using: .http)
         let fixture = try NetworkConfig.Fixtures.TrustRoots()
@@ -194,9 +206,12 @@ class CertificateTests: XCTestCase {
         let fog = try XCTUnwrap(config.fogTrustRoots[.http] as? SecSSLCertificates)
         let consensus = try XCTUnwrap(config.consensusTrustRoots[.http] as? SecSSLCertificates)
         XCTAssertNotEqual(fog.publicKeys, consensus.publicKeys)
-        XCTAssertEqual(
-            try pinningDelegate(of: requester).pinnedKeys,
-            fog.publicKeys + consensus.publicKeys)
+        let delegate = try pinningDelegate(of: requester)
+        let fogUrlHost = try XCTUnwrap(config.fogUrls.first).host
+        let consensusUrlHost = try XCTUnwrap(config.consensusUrls.first).host
+        XCTAssertNotEqual(fogUrlHost, consensusUrlHost)
+        XCTAssertEqual(delegate.pinnedKeys(for: fogUrlHost), fog.publicKeys)
+        XCTAssertEqual(delegate.pinnedKeys(for: consensusUrlHost), consensus.publicKeys)
     }
 
     // A consumer's own requester decides how the connections handle TLS, so the
@@ -218,11 +233,13 @@ class CertificateTests: XCTestCase {
         config.fogTrustRoots[.http] = nil
         let requester = DefaultHttpRequester()
         let roots = try alphaNetCertificates(.valid)
-        requester.setFogTrustRoots(roots)
+        requester.setFogTrustRoots(roots, hosts: [TestHost.fog])
 
         config.httpRequester = requester
 
-        XCTAssertEqual(try pinningDelegate(of: requester).pinnedKeys, roots.publicKeys)
+        XCTAssertEqual(
+            try pinningDelegate(of: requester).pinnedKeys(for: TestHost.fog),
+            roots.publicKeys)
     }
 
     // A refused set keeps the pinned http roots the call before it stored, so a
@@ -257,13 +274,12 @@ class CertificateTests: XCTestCase {
             pinned.publicKeys)
     }
 
-    // The four below drive both delegate shims and each covers one of `handle`'s
-    // outcomes.
+    // The cases below drive both delegate shims across `handle`'s outcomes.
 
     func testServerTrustMatchingAPinnedKeyIsAccepted() throws {
         let fixture = try SecCertificateTests.Fixtures.AlphaNet()
         let requester = DefaultHttpRequester()
-        requester.setFogTrustRoots(try alphaNetCertificates(.valid))
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.pinned])
 
         let result = try answer(of: requester, against: fixture.secTrust)
 
@@ -271,16 +287,42 @@ class CertificateTests: XCTestCase {
         XCTAssertNotNil(result.credential)
     }
 
-    // The consensus root carries this one, so both roots take part in a
-    // challenge.
+    // The consensus roots pin this host and don't carry the fixture chain, so
+    // the challenge will be refused.
     func testServerTrustMatchingNoPinnedKeyIsCancelled() throws {
         let fixture = try SecCertificateTests.Fixtures.AlphaNet()
         let requester = DefaultHttpRequester()
-        requester.setConsensusTrustRoots(try alphaNetCertificates(.wrong))
+        requester.setConsensusTrustRoots(try alphaNetCertificates(.wrong), hosts: [TestHost.pinned])
 
         XCTAssertEqual(
             try answer(of: requester, against: fixture.secTrust).disposition,
             .cancelAuthenticationChallenge)
+    }
+
+    // The fog roots carry this fixture chain and the consensus roots don't, so
+    // the consensus host will be refused while the fog host is accepted.
+    func testTheRootsOfOneHostDoNotPinAnother() throws {
+        let fixture = try SecCertificateTests.Fixtures.AlphaNet()
+        let requester = DefaultHttpRequester()
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.fog])
+        requester.setConsensusTrustRoots(
+            try alphaNetCertificates(.wrong), hosts: [TestHost.consensus])
+
+        let refused = try answer(
+            of: requester, against: fixture.secTrust, host: TestHost.consensus)
+        XCTAssertEqual(refused.disposition, .cancelAuthenticationChallenge)
+        let accepted = try answer(of: requester, against: fixture.secTrust, host: TestHost.fog)
+        XCTAssertEqual(accepted.disposition, .useCredential)
+    }
+
+    // Neither setter names the challenged host, so every pinned root takes part
+    // in its challenge.
+    func testAHostNoSetterNamedIsJudgedAgainstEveryPinnedRoot() throws {
+        let fixture = try SecCertificateTests.Fixtures.AlphaNet()
+        let requester = DefaultHttpRequester()
+        requester.setFogTrustRoots(try alphaNetCertificates(.valid), hosts: [TestHost.fog])
+        let judged = try answer(of: requester, against: fixture.secTrust, host: TestHost.consensus)
+        XCTAssertEqual(judged.disposition, .useCredential)
     }
 
     // With no roots set there is nothing to pin against, so the challenge goes
@@ -319,30 +361,39 @@ class CertificateTests: XCTestCase {
         XCTAssertNil(delegate)
     }
 
-    // `pinnedKeys` reads fog before consensus, so distinct certificates and an
-    // ordered comparison are what make a swap of the two setters visible.
-    func testEachTrustRootSetterWritesItsOwnField() throws {
+    // Distinct fog and consensus roots let each lookup below name the set or
+    // sets that answered it.
+    func testTheSetThatNamesAHostAnswersForIt() throws {
         let requester = DefaultHttpRequester()
         let delegate = try pinningDelegate(of: requester)
         let fog = try alphaNetCertificates(.valid)
         let consensus = try alphaNetCertificates(.wrong)
+        XCTAssertNotEqual(fog.publicKeys, consensus.publicKeys)
 
-        XCTAssertTrue(delegate.pinnedKeys.isEmpty)
+        requester.setFogTrustRoots(fog, hosts: [TestHost.fog.uppercased()])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.consensus), fog.publicKeys)
 
-        requester.setFogTrustRoots(fog)
-        XCTAssertEqual(delegate.pinnedKeys, fog.publicKeys)
+        requester.setConsensusTrustRoots(consensus, hosts: [TestHost.consensus + "."])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), fog.publicKeys)
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.consensus + ".."), consensus.publicKeys)
 
-        requester.setConsensusTrustRoots(consensus)
-        XCTAssertEqual(delegate.pinnedKeys, fog.publicKeys + consensus.publicKeys)
+        let noKeys = try XCTUnwrap(SecSSLCertificates(trustRootBytes: []))
+        requester.setFogTrustRoots(noKeys, hosts: [TestHost.fog])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), consensus.publicKeys)
 
-        requester.setFogTrustRoots(nil)
-        XCTAssertEqual(delegate.pinnedKeys, consensus.publicKeys)
+        requester.setFogTrustRoots(nil, hosts: [])
+        XCTAssertEqual(delegate.pinnedKeys(for: TestHost.fog), consensus.publicKeys)
+
+        requester.setFogTrustRoots(fog, hosts: [TestHost.consensus])
+        XCTAssertEqual(
+            delegate.pinnedKeys(for: TestHost.consensus),
+            fog.publicKeys + consensus.publicKeys)
+        XCTAssertEqual(
+            delegate.pinnedKeys(for: TestHost.pinned),
+            fog.publicKeys + consensus.publicKeys)
     }
 
-    private enum AlphaNetIntermediate {
-        case valid
-        case wrong
-    }
+    private enum AlphaNetIntermediate { case valid, wrong }
 
     private func alphaNetCertificates(
         _ intermediate: AlphaNetIntermediate
@@ -380,14 +431,15 @@ class CertificateTests: XCTestCase {
     // the calling thread, so both shims answer before this returns.
     private func answer(
         of requester: DefaultHttpRequester,
-        against trust: SecTrust?
+        against trust: SecTrust?,
+        host: String = TestHost.pinned
     ) throws -> (disposition: URLSession.AuthChallengeDisposition?, credential: URLCredential?) {
         let space: URLProtectionSpace
         if let trust = trust {
-            space = TrustingProtectionSpace(trust: trust)
+            space = TrustingProtectionSpace(trust: trust, host: host)
         } else {
             space = URLProtectionSpace(
-                host: "example.com",
+                host: host,
                 port: 443,
                 protocol: NSURLProtectionSpaceHTTPS,
                 realm: nil,
@@ -420,56 +472,4 @@ class CertificateTests: XCTestCase {
         XCTAssertEqual(sessionDisposition, taskDisposition)
         return (sessionDisposition, credential)
     }
-}
-
-// `URLProtectionSpace` builds its own `serverTrust` from a live TLS handshake,
-// so a fixture chain reaches the delegate only through an override.
-private final class TrustingProtectionSpace: URLProtectionSpace, @unchecked Sendable {
-    private let trust: SecTrust
-
-    init(trust: SecTrust) {
-        self.trust = trust
-        super.init(
-            host: "example.com",
-            port: 443,
-            protocol: NSURLProtectionSpaceHTTPS,
-            realm: nil,
-            authenticationMethod: NSURLAuthenticationMethodServerTrust)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    override var serverTrust: SecTrust? { trust }
-}
-
-// A requester that keeps no trust roots and says so.
-private final class RefusingHttpRequester: HttpRequester {
-    func request(
-        url: URL,
-        method: HTTPMethod,
-        headers: [String: String]?,
-        body: Data?,
-        completion: @escaping (Result<HTTPResponse, Error>) -> Void
-    ) {
-        completion(.failure(ConnectionError.invalidServerResponse("unused")))
-    }
-
-    func setFogTrustRoots(_ trustRoots: SecSSLCertificates?) -> Result<(), InvalidInputError> {
-        .failure(InvalidInputError("This requester keeps no fog trust roots"))
-    }
-
-    func setConsensusTrustRoots(_ trustRoots: SecSSLCertificates?)
-        -> Result<(), InvalidInputError>
-    {
-        .failure(InvalidInputError("This requester keeps no consensus trust roots"))
-    }
-}
-
-// URLAuthenticationChallenge demands a sender. Nothing under test calls back
-// into it.
-private final class NullChallengeSender: NSObject, URLAuthenticationChallengeSender {
-    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
-    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
-    func cancel(_ challenge: URLAuthenticationChallenge) {}
 }


### PR DESCRIPTION

Pins each named host against the trust roots pushed for that host. A chain that matches the fog roots will fail a challenge from a consensus host.

- `CertificatePinningDelegate` keeps the hosts each set of roots covers. `pinnedKeys(for:)` answers with the keys of every set that names the challenged host and carries keys.
- A host that no such set names is judged against every root the delegate holds. That is the answer every host got before.
- The fog report host comes from the recipient's public address at `FogResolverManager.swift:34`. Refusing an unnamed host would break the report path for an unlisted wallet.
- A set that carries no keys takes no part in a lookup. Its hosts stay on that fallback and keep the pinning they had.
- `HttpRequester.setFogTrustRoots` and `setConsensusTrustRoots` take a `hosts` array, which is source-breaking for a consumer that writes its own requester. `NetworkConfig` fills that array from `fogUrls` and `consensusUrls`. The `MobileCoinClient.Config` setters keep their signatures.
- A host lookup ignores case and any trailing dot, since a DNS name is case-insensitive and a trailing dot names the same host.
- `CertificateTests` gains a wrong-consensus-right-fog case and an unnamed-host case. A third names one host in both sets, where the delegate answers with both key sets.
- The two skipped `FogBlockConnectionIntTests` cases say what their bodies need from the network they run against.